### PR TITLE
Fix event signatures in MI props

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -7,7 +7,7 @@ import type {
   ReactNode,
   RefObject,
   FocusEvent as ReactFocusEvent,
-  MouseEvent as ReactMouseEvent,
+  SyntheticEvent,
 } from 'react'
 export type MentionTrigger = string | RegExp
 
@@ -108,7 +108,7 @@ export type InputComponent =
 export interface MentionsInputProps
   extends Omit<
     React.TextareaHTMLAttributes<HTMLTextAreaElement>,
-    'children' | 'onChange' | 'value' | 'defaultValue' | 'style' | 'valueLink'
+    'children' | 'onChange' | 'value' | 'defaultValue' | 'style' | 'valueLink' | 'onBlur'
   > {
   a11ySuggestionsListLabel?: string
   allowSpaceInQuery?: boolean
@@ -125,11 +125,7 @@ export interface MentionsInputProps
   onBlur?: (event: ReactFocusEvent<InputElement>, clickedSuggestion: boolean) => void
   onChange?: MentionsInputChangeHandler
   onKeyDown?: MentionsInputKeyDownHandler
-  onSelect?: (
-    event: ReactMouseEvent<HTMLInputElement | HTMLTextAreaElement>,
-    suggestion: SuggestionDataItem | string,
-    queryInfo: QueryInfo
-  ) => void
+  onSelect?: (event: SyntheticEvent<InputElement>) => void
   readOnly?: boolean
   selectLastSuggestionOnSpace?: boolean
   singleLine?: boolean


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fix event handler signatures in MentionsInputProps interface

- Replace ReactMouseEvent with SyntheticEvent for onSelect handler

- Add onBlur to omitted TextareaHTMLAttributes properties

- Update import to use SyntheticEvent instead of ReactMouseEvent


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["MentionsInputProps"] -->|"Remove ReactMouseEvent import"| B["Import SyntheticEvent"]
  A -->|"Simplify onSelect signature"| C["onSelect: SyntheticEvent"]
  A -->|"Add onBlur to omitted props"| D["Omit onBlur from TextareaHTMLAttributes"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>types.ts</strong><dd><code>Correct event handler type signatures</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/types.ts

<ul><li>Replaced <code>ReactMouseEvent</code> import with <code>SyntheticEvent</code> from React<br> <li> Added <code>onBlur</code> to the omitted properties in MentionsInputProps <br>TextareaHTMLAttributes<br> <li> Simplified <code>onSelect</code> event handler signature from <br><code>ReactMouseEvent<HTMLInputElement | HTMLTextAreaElement></code> with multiple <br>parameters to <code>SyntheticEvent<InputElement></code><br> <li> Removed complex parameter destructuring from onSelect handler <br>definition</ul>


</details>


  </td>
  <td><a href="https://github.com/hbmartin/react-mentions-ts/pull/28/files#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410a">+3/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Simplified the `onSelect` callback to receive a single event parameter instead of multiple parameters.
  * Removed support for the `onBlur` event handler.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->