### PR TITLE
adds setSelectionAfterHandleCut

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ The `MentionsInput` component supports the following props:
 - `plainTextValue`: the same content without mention markup
 - `mentions`: the mention occurrences extracted from the new value
 - `previousValue`: the markup string before the change
-- `trigger`: metadata about what caused the change. `trigger.type` is one of `'input'`, `'paste'`, `'cut'`, `'mention-add'`, or `'mention-remove'`, and when available `trigger.nativeEvent` references the originating DOM event.
+- `trigger`: metadata about what caused the change. `trigger.type` is one of `'input'`, `'paste'`, `'cut'`, `'mention-add'`, or `'mention-remove'`, and, when available, `trigger.nativeEvent` references the originating DOM event (optional; do not rely on its exact shape). Regular text edits (typing, Backspace/Delete) use `trigger.type: 'input'`.
 
 ### Mention Props
 

--- a/src/MentionsInput.spec.tsx
+++ b/src/MentionsInput.spec.tsx
@@ -522,6 +522,43 @@ describe('MentionsInput', () => {
       expect(newPlainTextValue).toMatchSnapshot()
     })
 
+    it('should restore the caret to the start of the cut selection.', async () => {
+      const onChange = jest.fn()
+
+      render(
+        <MentionsInput value={value} onChange={onChange}>
+          <Mention trigger="@[__display__](__id__)" data={data} />
+        </MentionsInput>
+      )
+
+      const textarea = screen.getByRole('textbox')
+
+      const selectionStart = plainTextValue.indexOf('First') + 2
+      const selectionEnd = plainTextValue.indexOf('First') + 'First'.length + 5
+
+      textarea.setSelectionRange(selectionStart, selectionEnd)
+      expect(textarea.selectionStart).toBe(selectionStart)
+      expect(textarea.selectionEnd).toBe(selectionEnd)
+
+      fireEvent.select(textarea, {
+        target: { selectionStart, selectionEnd },
+      })
+
+      const event = new Event('cut', { bubbles: true })
+      event.clipboardData = { setData: jest.fn() }
+
+      fireEvent(textarea, event)
+
+      await waitFor(() => {
+        expect(onChange).toHaveBeenCalledTimes(1)
+      })
+
+      await waitFor(() => {
+        expect(textarea.selectionStart).toBe(selectionStart)
+        expect(textarea.selectionEnd).toBe(selectionStart)
+      })
+    })
+
     it('should read mentions markup from a paste event.', () => {
       const onChange = jest.fn()
 

--- a/src/MentionsInput.tsx
+++ b/src/MentionsInput.tsx
@@ -191,6 +191,7 @@ class MentionsInput extends React.Component<MentionsInputProps, MentionsInputSta
       caretPosition: null,
       suggestionsPosition: {},
       setSelectionAfterHandlePaste: false,
+      setSelectionAfterHandleCut: false,
     }
   }
 
@@ -212,12 +213,16 @@ class MentionsInput extends React.Component<MentionsInputProps, MentionsInputSta
 
     // maintain selection in case a mention is added/removed causing
     // the cursor to jump to the end
-    if (this.state.setSelectionAfterMentionChange) {
+    if (this.state.setSelectionAfterMentionChange === true) {
       this.setState({ setSelectionAfterMentionChange: false })
       this.setSelection(this.state.selectionStart, this.state.selectionEnd)
     }
     if (this.state.setSelectionAfterHandlePaste) {
       this.setState({ setSelectionAfterHandlePaste: false })
+      this.setSelection(this.state.selectionStart, this.state.selectionEnd)
+    }
+    if (this.state.setSelectionAfterHandleCut === true) {
+      this.setState({ setSelectionAfterHandleCut: false })
       this.setSelection(this.state.selectionStart, this.state.selectionEnd)
     }
   }
@@ -840,6 +845,12 @@ class MentionsInput extends React.Component<MentionsInputProps, MentionsInputSta
 
     const mentions = getMentions(newValue, config)
 
+    this.setState({
+      selectionStart: safeSelectionStart,
+      selectionEnd: safeSelectionStart,
+      setSelectionAfterHandleCut: true,
+    })
+
     this.executeOnChange(
       { type: 'cut', nativeEvent: event },
       newValue,
@@ -1447,13 +1458,7 @@ class MentionsInput extends React.Component<MentionsInputProps, MentionsInputSta
       displayValue
     )
 
-    this.executeOnChange(
-      { type: 'mention-add' },
-      newValue,
-      newPlainTextValue,
-      mentions,
-      value
-    )
+    this.executeOnChange({ type: 'mention-add' }, newValue, newPlainTextValue, mentions, value)
 
     if (onAdd) {
       onAdd(id, mentionDisplay, start, end)

--- a/src/types.ts
+++ b/src/types.ts
@@ -159,6 +159,7 @@ export interface MentionsInputState {
   suggestionsPosition: SuggestionsPosition
   scrollFocusedIntoView?: boolean
   setSelectionAfterMentionChange?: boolean
+  setSelectionAfterHandleCut?: boolean
   setSelectionAfterHandlePaste: boolean
 }
 


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add selection restoration after cut operations

- Implement `setSelectionAfterHandleCut` state flag

- Restore caret to cut selection start position

- Update documentation for trigger metadata clarity


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Cut Event Triggered"] --> B["Store Selection Start"]
  B --> C["Set setSelectionAfterHandleCut Flag"]
  C --> D["Execute onChange"]
  D --> E["componentDidUpdate Detects Flag"]
  E --> F["Restore Selection to Start"]
  F --> G["Clear Flag"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>types.ts</strong><dd><code>Add setSelectionAfterHandleCut state property</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/types.ts

<ul><li>Add <code>setSelectionAfterHandleCut</code> optional boolean property to <br><code>MentionsInputState</code> interface<br> <li> Enables tracking when selection should be restored after cut <br>operations</ul>


</details>


  </td>
  <td><a href="https://github.com/hbmartin/react-mentions-ts/pull/34/files#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410a">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>MentionsInput.tsx</strong><dd><code>Implement cut selection restoration logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/MentionsInput.tsx

<ul><li>Initialize <code>setSelectionAfterHandleCut</code> to false in component state<br> <li> Add logic in <code>componentDidUpdate</code> to restore selection after cut <br>operations<br> <li> Update <code>handleCut</code> method to set selection state before executing <br>onChange<br> <li> Improve condition check for <code>setSelectionAfterMentionChange</code> with <br>explicit true comparison<br> <li> Reformat <code>executeOnChange</code> call in <code>addMention</code> for consistency</ul>


</details>


  </td>
  <td><a href="https://github.com/hbmartin/react-mentions-ts/pull/34/files#diff-5324a6e48c1ed3e0637605dab500fd0e512b7917d46884c35cba8e68698b5473">+13/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Improve trigger metadata documentation clarity</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Clarify trigger metadata documentation with improved punctuation<br> <li> Add note that <code>trigger.nativeEvent</code> is optional and shape should not be <br>relied upon<br> <li> Document that regular text edits use <code>trigger.type: 'input'</code></ul>


</details>


  </td>
  <td><a href="https://github.com/hbmartin/react-mentions-ts/pull/34/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>MentionsInput.spec.tsx</strong><dd><code>Add test for cut selection restoration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/MentionsInput.spec.tsx

<ul><li>Add comprehensive test case for cut operation selection restoration<br> <li> Verify caret is positioned at cut selection start after cut event<br> <li> Test selection range setup and restoration workflow</ul>


</details>


  </td>
  <td><a href="https://github.com/hbmartin/react-mentions-ts/pull/34/files#diff-b685f69aea6de57d68f84daa62a580acd4b95f6de2c7c04d3f723142ddb2245f">+37/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified onChange payload behavior documentation regarding nativeEvent optionality and input event type handling.

* **Bug Fixes**
  * Improved caret restoration after cut operations to properly reset position to the start of the previous selection.
  * Enhanced paste handling to consistently restore caret position after paste operations.

* **Tests**
  * Added test coverage for caret restoration behavior following cut operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->