### PR TITLE
Automatic markup generation

### DIFF
--- a/demo/src/examples/Emojis.tsx
+++ b/demo/src/examples/Emojis.tsx
@@ -25,11 +25,18 @@ const emojiClassNames = mergeClassNames(multilineMentionsClassNames, {
   suggestionHighlight: 'font-semibold text-emerald-800',
 })
 
-export default function Emojis({ data }: { data: MentionDataItem[] }) {
+export default function Emojis({
+  data,
+  onAdd = () => {},
+}: {
+  data: MentionDataItem[]
+  onAdd?: (...args: any[]) => void
+}) {
   const [emojis] = useState<EmojiEntry[]>(emojisData.emojis as EmojiEntry[])
   const [value, setValue] = useState('')
 
   const queryEmojis = (query: string) => {
+    console.log('queryEmojis', query, emojis.length)
     if (!query) return Promise.resolve([])
 
     const lower = query.toLowerCase()
@@ -54,17 +61,19 @@ export default function Emojis({ data }: { data: MentionDataItem[] }) {
         placeholder={"Press ':' for emojis, mention people using '@'"}
       >
         <Mention
+          onAdd={onAdd}
           trigger="@"
           displayTransform={(username) => `@${username}`}
-          markup="@__id__"
           data={data}
           className={mentionPillClass}
           appendSpaceOnAdd
         />
         <Mention
+          onAdd={onAdd}
           trigger=":"
-          markup="__id__"
           data={queryEmojis}
+          className="bg-transparent"
+          displayTransform={(id) => String(id)}
           renderSuggestion={(suggestion, _search, highlightedDisplay, _index, focused) => {
             return (
               <div

--- a/demo/src/examples/Examples.tsx
+++ b/demo/src/examples/Examples.tsx
@@ -82,7 +82,7 @@ export default function Examples() {
       <CutCopyPaste data={users} disabledSource={false} />
       <InlineAutocomplete data={users} />
       <AsyncGithubUserMentions />
-      <Emojis data={users} />
+      <Emojis data={users} onAdd={(addParams) => console.log('onAdd', addParams)} />
       <SuggestionPortal data={users} />
       <CustomSuggestionsContainer data={users} />
     </div>

--- a/src/utils/makeTriggerRegex.spec.ts
+++ b/src/utils/makeTriggerRegex.spec.ts
@@ -216,4 +216,228 @@ describe('makeTriggerRegex', () => {
       })
     })
   })
+
+  describe('unusual trigger characters', () => {
+    describe('colon trigger (:)', () => {
+      it('should create a valid regex for colon trigger', () => {
+        const regex = makeTriggerRegex(':')
+        expect(regex).toBeInstanceOf(RegExp)
+        expect(regex.source).not.toBe('')
+        // Verify the regex properly escapes colon
+        expect(regex.source).toContain(':')
+      })
+
+      it('should match text starting with colon at beginning', () => {
+        const regex = makeTriggerRegex(':')
+        const match = ':emoji'.match(regex)
+        expect(match).not.toBeNull()
+        expect(match?.[1]).toBe(':emoji')
+        expect(match?.[2]).toBe('emoji')
+      })
+
+      it('should match text starting with colon after whitespace', () => {
+        const regex = makeTriggerRegex(':')
+        const match = 'Hello :emoji'.match(regex)
+        expect(match).not.toBeNull()
+        expect(match?.[1]).toBe(':emoji')
+        expect(match?.[2]).toBe('emoji')
+      })
+
+      it('should not match colon in the middle of text without space', () => {
+        const regex = makeTriggerRegex(':')
+        const match = 'http://example.com'.match(regex)
+        expect(match).toBeNull()
+      })
+
+      it('should match partial emoji notation', () => {
+        const regex = makeTriggerRegex(':')
+        const testCases = [
+          { input: ':smile', expected: 'smile' },
+          { input: ':heart', expected: 'heart' },
+          { input: ':thumbs', expected: 'thumbs' },
+          { input: ':fire', expected: 'fire' },
+        ]
+
+        for (const { input, expected } of testCases) {
+          const match = input.match(regex)
+          expect(match).not.toBeNull()
+          expect(match?.[2]).toBe(expected)
+        }
+      })
+
+      it('should not match when there are multiple colons without space', () => {
+        const regex = makeTriggerRegex(':')
+        const match = 'time::now'.match(regex)
+        expect(match).toBeNull()
+      })
+
+      it('should work with allowSpaceInQuery option', () => {
+        const regex = makeTriggerRegex(':', { allowSpaceInQuery: true })
+        const match = ':multi word emoji'.match(regex)
+        expect(match).not.toBeNull()
+        expect(match?.[2]).toBe('multi word emoji')
+      })
+    })
+
+    describe('forward slash trigger (/)', () => {
+      it('should create a valid regex for forward slash trigger', () => {
+        const regex = makeTriggerRegex('/')
+        expect(regex).toBeInstanceOf(RegExp)
+        expect(regex.source).not.toBe('')
+        // Verify the regex properly escapes forward slash
+        expect(regex.source).toContain('/')
+      })
+
+      it('should match text starting with slash at beginning', () => {
+        const regex = makeTriggerRegex('/')
+        const match = '/command'.match(regex)
+        expect(match).not.toBeNull()
+        expect(match?.[1]).toBe('/command')
+        expect(match?.[2]).toBe('command')
+      })
+
+      it('should match text starting with slash after whitespace', () => {
+        const regex = makeTriggerRegex('/')
+        const match = 'Execute /command'.match(regex)
+        expect(match).not.toBeNull()
+        expect(match?.[1]).toBe('/command')
+        expect(match?.[2]).toBe('command')
+      })
+
+      it('should not match slash in file paths without space', () => {
+        const regex = makeTriggerRegex('/')
+        const match = 'path/to/file'.match(regex)
+        expect(match).toBeNull()
+      })
+
+      it('should match various command names', () => {
+        const regex = makeTriggerRegex('/')
+        const testCases = [
+          { input: '/help', expected: 'help' },
+          { input: '/status', expected: 'status' },
+          { input: '/search', expected: 'search' },
+          { input: '/join', expected: 'join' },
+        ]
+
+        for (const { input, expected } of testCases) {
+          const match = input.match(regex)
+          expect(match).not.toBeNull()
+          expect(match?.[2]).toBe(expected)
+        }
+      })
+
+      it('should handle consecutive slashes properly', () => {
+        const regex = makeTriggerRegex('/')
+        // URL with // should not match
+        const match = 'https://example.com'.match(regex)
+        expect(match).toBeNull()
+      })
+
+      it('should work with allowSpaceInQuery option', () => {
+        const regex = makeTriggerRegex('/', { allowSpaceInQuery: true })
+        const match = '/search for something'.match(regex)
+        expect(match).not.toBeNull()
+        expect(match?.[2]).toBe('search for something')
+      })
+
+      it('should match empty slash query', () => {
+        const regex = makeTriggerRegex('/')
+        const match = '/'.match(regex)
+        expect(match).not.toBeNull()
+        expect(match?.[2]).toBe('')
+      })
+    })
+
+    describe('backslash trigger (\\)', () => {
+      it('should create a valid regex for backslash trigger', () => {
+        const regex = makeTriggerRegex('\\')
+        expect(regex).toBeInstanceOf(RegExp)
+        expect(regex.source).not.toBe('')
+        // Verify the regex properly escapes backslash
+        expect(regex.source).toContain('\\\\')
+      })
+
+      it('should match text starting with backslash at beginning', () => {
+        const regex = makeTriggerRegex('\\')
+        const match = '\\command'.match(regex)
+        expect(match).not.toBeNull()
+        expect(match?.[1]).toBe('\\command')
+        expect(match?.[2]).toBe('command')
+      })
+
+      it('should match text starting with backslash after whitespace', () => {
+        const regex = makeTriggerRegex('\\')
+        const match = 'LaTeX \\command'.match(regex)
+        expect(match).not.toBeNull()
+        expect(match?.[1]).toBe('\\command')
+        expect(match?.[2]).toBe('command')
+      })
+
+      it('should not match backslash in Windows paths without space', () => {
+        const regex = makeTriggerRegex('\\')
+        const match = 'C:\\Users\\file'.match(regex)
+        expect(match).toBeNull()
+      })
+
+      it('should match various LaTeX-style commands', () => {
+        const regex = makeTriggerRegex('\\')
+        const testCases = [
+          { input: '\\alpha', expected: 'alpha' },
+          { input: '\\beta', expected: 'beta' },
+          { input: '\\sum', expected: 'sum' },
+          { input: '\\int', expected: 'int' },
+        ]
+
+        for (const { input, expected } of testCases) {
+          const match = input.match(regex)
+          expect(match).not.toBeNull()
+          expect(match?.[2]).toBe(expected)
+        }
+      })
+
+      it('should handle consecutive backslashes properly', () => {
+        const regex = makeTriggerRegex('\\')
+        // Double backslash should not match
+        const match = '\\\\newline'.match(regex)
+        expect(match).toBeNull()
+      })
+
+      it('should work with allowSpaceInQuery option', () => {
+        const regex = makeTriggerRegex('\\', { allowSpaceInQuery: true })
+        const match = '\\text with spaces'.match(regex)
+        expect(match).not.toBeNull()
+        expect(match?.[2]).toBe('text with spaces')
+      })
+
+      it('should match empty backslash query', () => {
+        const regex = makeTriggerRegex('\\')
+        const match = '\\'.match(regex)
+        expect(match).not.toBeNull()
+        expect(match?.[2]).toBe('')
+      })
+    })
+
+    describe('unusual triggers with ignoreAccents option', () => {
+      it('should work with colon trigger and accented characters', () => {
+        const regex = makeTriggerRegex(':', { ignoreAccents: true })
+        const match = ':café'.match(regex)
+        expect(match).not.toBeNull()
+        expect(match?.[2]).toBe('café')
+      })
+
+      it('should work with slash trigger and accented characters', () => {
+        const regex = makeTriggerRegex('/', { ignoreAccents: true })
+        const match = '/José'.match(regex)
+        expect(match).not.toBeNull()
+        expect(match?.[2]).toBe('José')
+      })
+
+      it('should work with backslash trigger and accented characters', () => {
+        const regex = makeTriggerRegex('\\', { ignoreAccents: true })
+        const match = '\\Müller'.match(regex)
+        expect(match).not.toBeNull()
+        expect(match?.[2]).toBe('Müller')
+      })
+    })
+  })
 })

--- a/src/utils/readConfigFromChildren.spec.tsx
+++ b/src/utils/readConfigFromChildren.spec.tsx
@@ -1,88 +1,139 @@
 import React from 'react'
 import Mention from '../Mention'
-import createMarkupSerializer from '../serializers/createMarkupSerializer'
 import readConfigFromChildren from './readConfigFromChildren'
-
-const makeMention = (props: Partial<React.ComponentProps<typeof Mention>> = {}) => (
-  <Mention data={[]} {...props} />
-)
+import getPlainText from './getPlainText'
 
 describe('readConfigFromChildren', () => {
-  it('returns default config when markup is omitted', () => {
-    const config = readConfigFromChildren(makeMention())
+  describe('trigger-specific markup generation', () => {
+    it('should generate unique markup for different triggers when no markup is specified', () => {
+      const children = [
+        <Mention key="1" trigger="@" data={[]} />,
+        <Mention key="2" trigger=":" data={[]} />,
+      ]
 
-    expect(config).toHaveLength(1)
-    expect(config[0]?.markup).toBe('@[__display__](__id__)')
-    expect(config[0]?.serializer.insert({ id: '123', display: 'Ada' })).toBe('@[Ada](123)')
+      const config = readConfigFromChildren(children)
+
+      expect(config).toHaveLength(2)
+      expect(config[0].serializer.id).toBe('@[__display__](__id__)')
+      expect(config[1].serializer.id).toBe(':[__display__](__id__)')
+    })
+
+    it('should use custom markup when explicitly provided', () => {
+      const children = [
+        <Mention key="1" trigger="@" markup="@[__display__](user:__id__)" data={[]} />,
+        <Mention key="2" trigger=":" markup=":[__display__](emoji:__id__)" data={[]} />,
+      ]
+
+      const config = readConfigFromChildren(children)
+
+      expect(config).toHaveLength(2)
+      expect(config[0].serializer.id).toBe('@[__display__](user:__id__)')
+      expect(config[1].serializer.id).toBe(':[__display__](emoji:__id__)')
+    })
+
+    it('should prevent serializer collisions between different triggers', () => {
+      const children = [
+        <Mention
+          key="1"
+          trigger="@"
+          displayTransform={(id) => `@${id}`}
+          data={[]}
+        />,
+        <Mention
+          key="2"
+          trigger=":"
+          displayTransform={(id) => String(id)}
+          data={[]}
+        />,
+      ]
+
+      const config = readConfigFromChildren(children)
+
+      // Simulate adding an emoji mention (trigger: ':')
+      const emojiMarkup = config[1].serializer.insert({ id: '😀', display: '😀' })
+      expect(emojiMarkup).toBe(':[😀](😀)')
+
+      // Simulate adding a user mention (trigger: '@')
+      const userMarkup = config[0].serializer.insert({ id: 'john', display: 'John' })
+      expect(userMarkup).toBe('@[John](john)')
+
+      // Test that getPlainText correctly uses each mention's displayTransform
+      const value = `Hello ${userMarkup} ${emojiMarkup}`
+      const plainText = getPlainText(value, config)
+
+      // The emoji should NOT have '@' prefix (bug fix verification)
+      expect(plainText).toBe('Hello @john 😀')
+    })
+
+    it('should handle RegExp triggers with default markup', () => {
+      const children = [
+        <Mention key="1" trigger={/@/} data={[]} />,
+      ]
+
+      const config = readConfigFromChildren(children)
+
+      expect(config).toHaveLength(1)
+      expect(config[0].serializer.id).toBe('@[__display__](__id__)')
+    })
+
+    it('should correctly apply displayTransform for each mention type', () => {
+      const children = [
+        <Mention
+          key="1"
+          trigger="@"
+          displayTransform={(id, display) => `@${display || id}`}
+          data={[]}
+        />,
+        <Mention
+          key="2"
+          trigger=":"
+          displayTransform={(id) => String(id)}
+          data={[]}
+        />,
+        <Mention
+          key="3"
+          trigger="#"
+          displayTransform={(id) => `#${id}`}
+          data={[]}
+        />,
+      ]
+
+      const config = readConfigFromChildren(children)
+
+      const atMention = config[0].serializer.insert({ id: 'user1', display: 'User One' })
+      const colonMention = config[1].serializer.insert({ id: '🎉', display: '🎉' })
+      const hashMention = config[2].serializer.insert({ id: 'tag1', display: 'tag1' })
+
+      const value = `Message ${atMention} ${colonMention} ${hashMention}`
+      const plainText = getPlainText(value, config)
+
+      expect(plainText).toBe('Message @User One 🎉 #tag1')
+    })
   })
 
-  it('creates a serializer from a markup string', () => {
-    const config = readConfigFromChildren(makeMention({ markup: '[__id__]' }))
+  describe('backward compatibility', () => {
+    it('should use the shared DEFAULT_SERIALIZER when trigger is @ and no markup is provided', () => {
+      const children = [
+        <Mention key="1" trigger="@" data={[]} />,
+        <Mention key="2" trigger="@" data={[]} />,
+      ]
 
-    const matches = config[0]?.serializer.findAll('Hello [42]')
-    expect(matches?.[0]?.id).toBe('42')
-  })
+      const config = readConfigFromChildren(children)
 
-  it('accepts a MentionSerializer via the markup prop', () => {
-    const serializer = createMarkupSerializer(':__id__')
-    const config = readConfigFromChildren(makeMention({ markup: serializer }))
+      // Both should use the same serializer instance for efficiency
+      expect(config[0].serializer).toBe(config[1].serializer)
+      expect(config[0].serializer.id).toBe('@[__display__](__id__)')
+    })
 
-    expect(config[0]?.serializer.insert({ id: 'abc', display: 'User' })).toBe(':abc')
-  })
+    it('should maintain existing behavior when custom markup is provided', () => {
+      const customMarkup = '@[__display__](custom:__id__)'
+      const children = [
+        <Mention key="1" trigger="@" markup={customMarkup} data={[]} />,
+      ]
 
-  it('preserves per-child overrides such as displayTransform', () => {
-    const config = readConfigFromChildren(
-      <>
-        {makeMention({ displayTransform: () => 'first' })}
-        {makeMention({ displayTransform: () => 'second' })}
-      </>
-    )
+      const config = readConfigFromChildren(children)
 
-    expect(config[0]?.displayTransform('1', 'one')).toBe('first')
-    expect(config[1]?.displayTransform('2', 'two')).toBe('second')
-  })
-
-  it('ignores non-mention nodes', () => {
-    const config = readConfigFromChildren(
-      <>
-        <span>text node</span>
-        {null}
-        {makeMention({ markup: '@[__display__](__id__)', trigger: '@' })}
-        {makeMention({ markup: '#__id__', trigger: '#' })}
-      </>
-    )
-
-    expect(config).toHaveLength(2)
-    expect(config[0]?.trigger).toBe('@')
-    expect(config[1]?.trigger).toBe('#')
-  })
-
-  it('ignores non-mention nodes with data prop', () => {
-    const config = readConfigFromChildren(
-      <>
-        {/* @ts-expect-error - Testing with invalid prop to ensure non-Mention nodes are filtered */}
-        <span data="text-node">text node</span>
-        {null}
-        {makeMention({ markup: '@[__display__](__id__)', trigger: '@' })}
-        {makeMention({ markup: '#__id__', trigger: '#' })}
-      </>
-    )
-
-    expect(config).toHaveLength(2)
-    expect(config[0]?.trigger).toBe('@')
-    expect(config[1]?.trigger).toBe('#')
-  })
-
-  it('handles nested fragments and arrays of mentions', () => {
-    const config = readConfigFromChildren(
-      <>
-        {[makeMention({ markup: '(__id__)' })]}
-        <React.Fragment>{makeMention({ markup: '[__id__]' })}</React.Fragment>
-      </>
-    )
-
-    expect(config).toHaveLength(2)
-    expect(config[0]?.serializer.findAll('x(foo)')[0]?.id).toBe('foo')
-    expect(config[1]?.serializer.findAll('y[bar]')[0]?.id).toBe('bar')
+      expect(config[0].serializer.id).toBe(customMarkup)
+    })
   })
 })


### PR DESCRIPTION
When no custom markup is specified, the system now generates unique markup based on the trigger

  character:
    - @ trigger → `@[__display__](__id__)`
    - : trigger → `:[__display__](__id__)`
    - # trigger → `#[__display__](__id__)`
  2. Backward compatibility: The fix handles edge cases:
    - RegExp triggers use default markup
    - If trigger contains placeholder patterns (legacy incorrect usage), falls back to default markup
    - Explicit custom markup is always respected
  3. Added comprehensive tests in src/utils/readConfigFromChildren.spec.tsx verifying:
    - Different triggers generate unique markup
    - No serializer collisions occur
    - Each mention correctly applies its own displayTransform

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional callback support for item additions, enabling external consumers to react to mention suggestions.

* **Tests**
  * Significantly expanded test coverage for trigger character handling, including edge cases and special character scenarios.
  * Improved test coverage for configuration reading and markup generation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->