### PR TITLE
Add Codecov coverage reporting to CI workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,7 @@
 name: CI
-on: push
+on:
+  push:
+  pull_request:
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -14,7 +16,15 @@ jobs:
       - run: yarn --frozen-lockfile
       - run: yarn audit
       - run: yarn run prettier --check "src/**/*.{ts,tsx,js,jsx,json,css,md}"
-      - run: yarn test
+      - run: yarn test --coverage
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: coverage/lcov.info
+          name: unit-tests
+          flags: unit-tests
+          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}
       - run: yarn lint
       - run: yarn build
       - run: npx publint --pack npm

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,13 @@
+comment:
+  layout: "reach, diff, files"
+  behavior: default
+coverage:
+  status:
+    project:
+      default:
+        target: 80%
+        threshold: 1%
+    patch:
+      default:
+        target: 80%
+        threshold: 1%


### PR DESCRIPTION
## Summary
- run CI workflow on push and pull request events
- collect coverage during tests and upload results to Codecov
- configure Codecov to provide PR comments and enforce coverage thresholds

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fe205f82dc832196d6c2ee275b2434

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Implemented automated code coverage measurement and reporting to track and monitor overall code quality
  * Added type checking validation to the testing pipeline for improved type safety

* **Chores**
  * Enhanced continuous integration to run comprehensive tests and validation on all pull requests
  * Configured coverage analysis standards with defined quality targets and reporting thresholds

<!-- end of auto-generated comment: release notes by coderabbit.ai -->