### PR TITLE
add onMentionSelectionChange

### DIFF
--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -18,18 +18,15 @@ const App: React.FC = () => (
           system. Swap styling strategies, customise suggestion experiences, and ship polished UX in
           minutes.
         </p>
-        <p className="mt-6 text-sm text-slate-400">
-          Crafted by HM &amp; Signavio — open-sourced under BSD on{' '}
+        <h2 className="mt-6 text-2xl text-slate-400">
           <a
             className="font-semibold text-indigo-300 underline-offset-4 transition hover:text-indigo-200 hover:underline"
             href="https://github.com/hbmartin/react-mentions-ts"
-            target="_blank"
             rel="noreferrer"
           >
-            GitHub
+            Install and Setup
           </a>
-          .
-        </p>
+        </h2>
       </header>
 
       <Examples />

--- a/demo/src/examples/Examples.tsx
+++ b/demo/src/examples/Examples.tsx
@@ -11,6 +11,7 @@ import CustomSuggestionsContainer from './CustomSuggestionsContainer'
 import InlineAutocomplete from './InlineAutocomplete'
 import AllowSpaceInQuery from './AllowSpaceInQuery'
 import AlphabetRegexTrigger from './AlphabetRegexTrigger'
+import MentionSelection from './MentionSelection'
 
 const users = [
   {
@@ -82,6 +83,7 @@ export default function Examples() {
       <Scrollable data={users} />
       <Advanced data={users} />
       <CutCopyPaste data={users} disabledSource={false} />
+      <MentionSelection data={users} />
       <InlineAutocomplete data={users} />
       <AsyncGithubUserMentions />
       <Emojis data={users} onAdd={(addParams) => console.log('onAdd', addParams)} />

--- a/demo/src/examples/MentionSelection.tsx
+++ b/demo/src/examples/MentionSelection.tsx
@@ -1,0 +1,105 @@
+import React, { useMemo, useState } from 'react'
+import { clsx } from 'clsx'
+
+import { Mention, MentionsInput } from '../../../src'
+import type { MentionDataItem, MentionSelection } from '../../../src'
+import ExampleCard from './ExampleCard'
+import {
+  mergeClassNames,
+  multilineMentionsClassNames,
+} from './mentionsClassNames'
+import { useExampleValue } from './hooks'
+
+const initialValue =
+  'Sync with @[Walter White](walter) and @[Jesse Pinkman](jesse) before the hand-off.'
+
+const selectionAwareClassNames = mergeClassNames(multilineMentionsClassNames, {
+  highlighter: clsx(
+    multilineMentionsClassNames.highlighter,
+    'transition-shadow'
+  ),
+})
+
+const mentionChipClass = clsx(
+  'rounded-full px-2 py-0.5 text-sm font-semibold text-indigo-100',
+  'bg-indigo-500/30 shadow-inner shadow-indigo-900/20 transition-colors',
+  'data-[mention-selection=inside]:bg-emerald-500/35 data-[mention-selection=inside]:text-emerald-50',
+  'data-[mention-selection=boundary]:ring-2 data-[mention-selection=boundary]:ring-indigo-300 data-[mention-selection=boundary]:bg-indigo-500/40',
+  'data-[mention-selection=partial]:bg-amber-500/40 data-[mention-selection=partial]:text-amber-50',
+  'data-[mention-selection=full]:bg-indigo-500 data-[mention-selection=full]:text-white'
+)
+
+export default function MentionSelectionExample({
+  data,
+}: {
+  data: MentionDataItem[]
+}) {
+  const [value, onMentionsChange, onAdd] = useExampleValue(initialValue)
+  const [selection, setSelection] = useState<MentionSelection[]>([])
+
+  const listItems = useMemo(() => {
+    if (selection.length === 0) {
+      return (
+        <li className="text-sm text-slate-400">
+          Move the caret inside a mention to see its selection state.
+        </li>
+      )
+    }
+
+    return selection.map((item) => (
+      <li
+        key={`${item.serializerId}:${item.id}:${item.plainTextStart}:${item.selection}`}
+        className="flex flex-wrap items-center justify-between gap-2 rounded-2xl bg-slate-900/60 px-4 py-2 text-sm text-slate-200 ring-1 ring-white/5"
+      >
+        <span className="font-semibold text-slate-100">{item.display}</span>
+        <span className="rounded-full bg-slate-700/70 px-2 py-0.5 text-xs uppercase tracking-wide text-slate-200">
+          {item.selection}
+        </span>
+        <span className="text-xs text-slate-400">
+          {item.plainTextStart} – {item.plainTextEnd}
+        </span>
+      </li>
+    ))
+  }, [selection])
+
+  return (
+    <ExampleCard
+      title="Caret mention states"
+      description="Listen for caret changes overlapping mentions and style them with data attributes."
+    >
+      <div className="grid gap-5 lg:grid-cols-[1.4fr,1fr]">
+        <div className="space-y-3">
+          <MentionsInput
+            value={value}
+            onMentionsChange={onMentionsChange}
+            onMentionSelectionChange={setSelection}
+            className="mentions"
+            classNames={selectionAwareClassNames}
+            placeholder={"Mention teammates using '@'"}
+            a11ySuggestionsListLabel={'Suggested mentions'}
+          >
+            <Mention
+              trigger="@"
+              data={data}
+              onAdd={onAdd}
+              className={mentionChipClass}
+            />
+          </MentionsInput>
+          <p className="text-xs text-slate-400">
+            Mentions receive a `data-mention-selection` attribute in both the
+            input and highlighter layers, so you can style boundary, inside,
+            partial, or full selections independently.
+          </p>
+        </div>
+        <div className="space-y-3">
+          <h4 className="text-sm font-semibold text-slate-200">
+            Active mention selection
+          </h4>
+          <ul className="space-y-2 rounded-3xl bg-slate-900/40 p-4 shadow-inner shadow-slate-950/40 backdrop-blur">
+            {listItems}
+          </ul>
+        </div>
+      </div>
+    </ExampleCard>
+  )
+}

--- a/src/Mention.tsx
+++ b/src/Mention.tsx
@@ -18,10 +18,15 @@ export default function Mention<Extra extends Record<string, unknown> = Record<s
   display,
   className,
   style,
+  selectionState,
 }: MentionProps<Extra>) {
   return (
-    <strong className={cn(mentionBaseClass, className, mentionsRequiredClass)} style={style}>
+    <span
+      className={cn(mentionBaseClass, className, mentionsRequiredClass)}
+      style={style}
+      data-mention-selection={selectionState ?? undefined}
+    >
       {display}
-    </strong>
+    </span>
   )
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,8 @@ export type {
   MentionsInputChangeTriggerType,
   MentionSerializer,
   MentionSerializerMatch,
+  MentionSelection,
+  MentionSelectionState,
 } from './types'
 export { default as createMarkupSerializer } from './utils/createMarkupSerializer'
 export { makeTriggerRegex } from './utils/makeTriggerRegex'

--- a/src/types.ts
+++ b/src/types.ts
@@ -70,6 +70,8 @@ export type MentionRenderSuggestion<
 
 export type DisplayTransform = (id: MentionIdentifier, display?: string | null) => string
 
+export type MentionSelectionState = 'inside' | 'boundary' | 'partial' | 'full'
+
 export interface MentionComponentProps<
   Extra extends Record<string, unknown> = Record<string, unknown>,
 > {
@@ -88,6 +90,7 @@ export interface MentionComponentProps<
   onRemove?: (id: MentionIdentifier) => void
   isLoading?: boolean
   appendSpaceOnAdd?: boolean
+  selectionState?: MentionSelectionState
 }
 
 export type MentionsInputChangeTriggerType =
@@ -111,6 +114,15 @@ export interface MentionOccurrence<
   index: number
   plainTextIndex: number
   data?: MentionDataItem<Extra>
+}
+
+export interface MentionSelection<
+  Extra extends Record<string, unknown> = Record<string, unknown>,
+> extends MentionOccurrence<Extra> {
+  selection: MentionSelectionState
+  plainTextStart: number
+  plainTextEnd: number
+  serializerId: string
 }
 
 export interface MentionsInputChangeEvent<
@@ -179,6 +191,7 @@ export interface MentionsInputProps<Extra extends Record<string, unknown> = Reco
   onMentionBlur?: (event: ReactFocusEvent<InputElement>, clickedSuggestion: boolean) => void
   onChange?: (event: ChangeEvent<InputElement>) => void
   onMentionsChange?: MentionsInputChangeHandler<Extra>
+  onMentionSelectionChange?: (selection: MentionSelection<Extra>[]) => void
   onKeyDown?: MentionsInputKeyDownHandler
   onSelect?: (event: SyntheticEvent<InputElement>) => void
   readOnly?: boolean


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `onMentionSelectionChange` callback to track when mentions are selected, including selection state (inside, boundary, partial, full) and caret position details
  * Introduced `data-mention-selection` attribute for caret-driven styling of mentions based on selection state
  * New demo example showcasing live mention selection tracking and display

* **Documentation**
  * Expanded README with caret-driven styling hooks section, callback payload details, and usage examples

<!-- end of auto-generated comment: release notes by coderabbit.ai -->