### PR TITLE
Include ID in callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,8 +102,8 @@ The `MentionsInput` component supports the following props:
 | Prop name                  | Type                                                                   | Default value  | Description                                                                                                                           |
 | -------------------------- | ---------------------------------------------------------------------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
 | value                      | string                                                                 | `''`           | The value containing markup for mentions                                                                                              |
-| onMentionsChange           | function ({ trigger, value, plainTextValue, mentions, previousValue }) | `undefined`    | Called when the mention markup changes; receives the updated markup value, plain text, active mentions, and the previous markup value |
-| onMentionSelectionChange   | function (selection)                                                   | `undefined`    | Called whenever the caret or selection overlaps one or more mentions; receives an ordered array of `MentionSelection` entries         |
+| onMentionsChange           | function ({ trigger, value, plainTextValue, mentionId, mentions, previousValue }) | `undefined`    | Called when the mention markup changes; receives the updated markup value, plain text, the affected mention id (when applicable), active mentions, and the previous markup value |
+| onMentionSelectionChange   | function (selection, context)                                          | `undefined`    | Called whenever the caret or selection overlaps one or more mentions; receives an ordered array of `MentionSelection` entries and a metadata context containing the current value, plain text, and mention identifiers |
 | onKeyDown                  | function (event)                                                       | empty function | A callback that is invoked when the user presses a key in the mentions input                                                          |
 | singleLine                 | boolean                                                                | `false`        | Renders a single line text input instead of a textarea, if set to `true`                                                              |
 | onMentionBlur              | function (event, clickedSuggestion)                                    | `undefined`    | Receives an extra `clickedSuggestion` flag when focus left via the suggestions list                                                   |
@@ -123,6 +123,7 @@ The `MentionsInput` component supports the following props:
 
 - `value`: the latest markup string containing mentions
 - `plainTextValue`: the same content without mention markup
+- `mentionId`: the identifier of the mention that triggered the change when the `trigger.type` is mention-specific (e.g. `'mention-add'`); otherwise `undefined`
 - `mentions`: the mention occurrences extracted from the new value
 - `previousValue`: the markup string before the change
 - `trigger`: metadata about what caused the change. `trigger.type` is one of `'input'`, `'paste'`, `'cut'`, `'mention-add'`, or `'mention-remove'`, and, when available, `trigger.nativeEvent` references the originating DOM event (optional; do not rely on its exact shape). Regular text edits (typing, Backspace/Delete) use `trigger.type: 'input'`.
@@ -141,6 +142,13 @@ The `MentionsInput` component supports the following props:
   - `'full'` – the selection fully covers the mention
 
 The callback fires on every selection change, so you can keep live state in sync with caret movement.
+
+The optional `context` argument includes:
+
+- `value` / `plainTextValue`: the latest markup and plain-text representations
+- `mentions`: the mentions found in the current value
+- `mentionIds`: the identifiers for the mentions covered by the current selection (ordered)
+- `mentionId`: the identifier when the selection maps to a single mention; otherwise `undefined`
 
 ### Mention Props
 

--- a/src/MentionsInput.spec.tsx
+++ b/src/MentionsInput.spec.tsx
@@ -245,6 +245,7 @@ describe('MentionsInput', () => {
       expect(onMentionsChange).toHaveBeenCalled()
       const payload = getLastMentionsChange(onMentionsChange)
       expect(payload.value).toContain(data[0].id)
+      expect(payload.mentionId).toBe(data[0].id)
       expect(payload.trigger.type).toBe('mention-add')
     })
   })
@@ -274,6 +275,7 @@ describe('MentionsInput', () => {
       expect(onMentionsChange).toHaveBeenCalled()
       const payload = getLastMentionsChange(onMentionsChange)
       expect(payload.trigger.type).toBe('mention-add')
+      expect(payload.mentionId).toBe(data[0].id)
       expect(payload.value.endsWith(' ')).toBe(true)
       expect(payload.plainTextValue.endsWith(' ')).toBe(true)
     })
@@ -1025,18 +1027,27 @@ describe('MentionsInput', () => {
       const onMentionSelectionChange = jest.fn()
       const { textarea } = renderMentionsInput({ onMentionSelectionChange })
 
+      const expectedPlainTextValue = `${mentionDisplay} remainder`
+
       onMentionSelectionChange.mockClear()
       textarea.setSelectionRange(2, 2)
       fireEvent.select(textarea)
 
       await waitFor(() => expect(onMentionSelectionChange).toHaveBeenCalledTimes(1))
       let selections = onMentionSelectionChange.mock.calls[0][0] as Array<Record<string, unknown>>
+      const firstContext = onMentionSelectionChange.mock.calls[0][1] as Record<string, unknown>
       expect(selections).toHaveLength(1)
       expect(selections[0]).toMatchObject({
         id: 'first',
         selection: 'inside',
         plainTextStart: 0,
         plainTextEnd: mentionDisplay.length,
+      })
+      expect(firstContext).toMatchObject({
+        mentionId: 'first',
+        mentionIds: ['first'],
+        value: defaultValue,
+        plainTextValue: expectedPlainTextValue,
       })
 
       onMentionSelectionChange.mockClear()
@@ -1045,9 +1056,16 @@ describe('MentionsInput', () => {
 
       await waitFor(() => expect(onMentionSelectionChange).toHaveBeenCalledTimes(1))
       selections = onMentionSelectionChange.mock.calls[0][0] as Array<Record<string, unknown>>
+      const secondContext = onMentionSelectionChange.mock.calls[0][1] as Record<string, unknown>
       expect(selections).toHaveLength(1)
       expect(selections[0]).toMatchObject({
         selection: 'boundary',
+      })
+      expect(secondContext).toMatchObject({
+        mentionId: 'first',
+        mentionIds: ['first'],
+        value: defaultValue,
+        plainTextValue: expectedPlainTextValue,
       })
 
       onMentionSelectionChange.mockClear()
@@ -1057,10 +1075,17 @@ describe('MentionsInput', () => {
 
       await waitFor(() => expect(onMentionSelectionChange).toHaveBeenCalledTimes(1))
       selections = onMentionSelectionChange.mock.calls[0][0] as Array<Record<string, unknown>>
+      const thirdContext = onMentionSelectionChange.mock.calls[0][1] as Record<string, unknown>
       expect(selections).toHaveLength(1)
       expect(selections[0]).toMatchObject({
         selection: 'boundary',
         plainTextEnd: mentionEnd,
+      })
+      expect(thirdContext).toMatchObject({
+        mentionId: 'first',
+        mentionIds: ['first'],
+        value: defaultValue,
+        plainTextValue: expectedPlainTextValue,
       })
     })
 
@@ -1074,9 +1099,14 @@ describe('MentionsInput', () => {
 
       await waitFor(() => expect(onMentionSelectionChange).toHaveBeenCalledTimes(1))
       let selections = onMentionSelectionChange.mock.calls[0][0] as Array<Record<string, unknown>>
+      const partialContext = onMentionSelectionChange.mock.calls[0][1] as Record<string, unknown>
       expect(selections).toHaveLength(1)
       expect(selections[0]).toMatchObject({
         selection: 'partial',
+      })
+      expect(partialContext).toMatchObject({
+        mentionId: 'first',
+        mentionIds: ['first'],
       })
 
       onMentionSelectionChange.mockClear()
@@ -1085,9 +1115,14 @@ describe('MentionsInput', () => {
 
       await waitFor(() => expect(onMentionSelectionChange).toHaveBeenCalledTimes(1))
       selections = onMentionSelectionChange.mock.calls[0][0] as Array<Record<string, unknown>>
+      const fullContext = onMentionSelectionChange.mock.calls[0][1] as Record<string, unknown>
       expect(selections).toHaveLength(1)
       expect(selections[0]).toMatchObject({
         selection: 'full',
+      })
+      expect(fullContext).toMatchObject({
+        mentionId: 'first',
+        mentionIds: ['first'],
       })
     })
 
@@ -1238,9 +1273,14 @@ describe('MentionsInput', () => {
 
       await waitFor(() => expect(onMentionSelectionChange).toHaveBeenCalledTimes(1))
       const selections = onMentionSelectionChange.mock.calls[0][0] as Array<Record<string, unknown>>
+      const context = onMentionSelectionChange.mock.calls[0][1] as Record<string, unknown>
       expect(selections).toHaveLength(2)
       expect(selections[0]).toMatchObject({ id: 'first' })
       expect(selections[1]).toMatchObject({ id: 'second' })
+      expect(context).toMatchObject({
+        mentionId: undefined,
+        mentionIds: ['first', 'second'],
+      })
     })
   })
 
@@ -1346,6 +1386,7 @@ describe('MentionsInput', () => {
       expect(payload.plainTextValue).toBe('Alice')
       expect(payload.mentions).toHaveLength(1)
       expect(payload.mentions[0]).toMatchObject({ id: 'alice' })
+      expect(payload.mentionId).toBe('alice')
       expect(payload.trigger.type).toBe('mention-add')
     })
   })

--- a/src/MentionsInput.tsx
+++ b/src/MentionsInput.tsx
@@ -442,7 +442,16 @@ class MentionsInput<
       }
 
       if (shouldEmit && this.props.onMentionSelectionChange) {
-        this.props.onMentionSelectionChange(currentSelection.selections)
+        const selectionMentionIds = currentSelection.selections.map((selection) => selection.id)
+        const selectionContext = {
+          value: currentValue,
+          plainTextValue: getPlainText(currentValue, this.state.config),
+          mentions: mentionsForSelection,
+          mentionIds: selectionMentionIds,
+          mentionId: selectionMentionIds.length === 1 ? selectionMentionIds[0] : undefined,
+        }
+
+        this.props.onMentionSelectionChange(currentSelection.selections, selectionContext)
       }
     }
   }
@@ -1022,7 +1031,8 @@ class MentionsInput<
     newValue: string,
     newPlainTextValue: string,
     mentions: MentionOccurrence[],
-    previousValue: string
+    previousValue: string,
+    mentionId?: MentionIdentifier
   ): void => {
     if (this.props.onMentionsChange) {
       this.props.onMentionsChange({
@@ -1031,6 +1041,7 @@ class MentionsInput<
         plainTextValue: newPlainTextValue,
         mentions: mentions as MentionOccurrence<Extra>[],
         previousValue,
+        mentionId,
       })
     }
   }
@@ -1838,7 +1849,14 @@ class MentionsInput<
       displayValue
     )
 
-    this.executeOnChange({ type: 'mention-add' }, newValue, newPlainTextValue, mentions, value)
+    this.executeOnChange(
+      { type: 'mention-add' },
+      newValue,
+      newPlainTextValue,
+      mentions,
+      value,
+      id
+    )
 
     if (onAdd !== undefined) {
       onAdd({

--- a/src/types.ts
+++ b/src/types.ts
@@ -124,12 +124,23 @@ export interface MentionSelection<Extra extends Record<string, unknown> = Record
   serializerId: string
 }
 
+export interface MentionSelectionChangeEvent<
+  Extra extends Record<string, unknown> = Record<string, unknown>,
+> {
+  value: string
+  plainTextValue: string
+  mentions: MentionOccurrence<Extra>[]
+  mentionIds: MentionIdentifier[]
+  mentionId?: MentionIdentifier
+}
+
 export interface MentionsInputChangeEvent<
   Extra extends Record<string, unknown> = Record<string, unknown>,
 > {
   trigger: MentionsInputChangeTrigger
   value: string
   plainTextValue: string
+  mentionId?: MentionIdentifier
   mentions: MentionOccurrence<Extra>[]
   previousValue: string
 }
@@ -141,6 +152,13 @@ export type MentionsInputEventData<
 export type MentionsInputChangeHandler<
   Extra extends Record<string, unknown> = Record<string, unknown>,
 > = (change: MentionsInputChangeEvent<Extra>) => void
+
+export type MentionSelectionChangeHandler<
+  Extra extends Record<string, unknown> = Record<string, unknown>,
+> = (
+  selection: MentionSelection<Extra>[],
+  context?: MentionSelectionChangeEvent<Extra>
+) => void
 
 export type MentionsInputKeyDownHandler = (
   event: KeyboardEvent<HTMLInputElement | HTMLTextAreaElement>
@@ -190,7 +208,7 @@ export interface MentionsInputProps<Extra extends Record<string, unknown> = Reco
   onMentionBlur?: (event: ReactFocusEvent<InputElement>, clickedSuggestion: boolean) => void
   onChange?: (event: ChangeEvent<InputElement>) => void
   onMentionsChange?: MentionsInputChangeHandler<Extra>
-  onMentionSelectionChange?: (selection: MentionSelection<Extra>[]) => void
+  onMentionSelectionChange?: MentionSelectionChangeHandler<Extra>
   onKeyDown?: MentionsInputKeyDownHandler
   onSelect?: (event: SyntheticEvent<InputElement>) => void
   readOnly?: boolean


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced `onMentionsChange` callback with `mentionId` to identify affected mentions
  * Extended `onMentionSelectionChange` callback with contextual data including value, plainTextValue, mentions, and mention identifiers

* **Documentation**
  * Updated API documentation with expanded event payload details and context parameter specifications

<!-- end of auto-generated comment: release notes by coderabbit.ai -->