### PR TITLE
Fixes single line highlighting when text overflows input width

### DIFF
--- a/src/Highlighter.tsx
+++ b/src/Highlighter.tsx
@@ -37,7 +37,7 @@ interface HighlighterProps {
 
 // Note: singleLine intentionally overrides whitespace/break behavior
 const highlighterStyles = cva(
-  'box-border w-full overflow-hidden text-start text-transparent pointer-events-none',
+  'box-border w-full overflow-hidden text-start text-transparent pointer-events-none [font-family:inherit] [font-size:inherit] [line-height:inherit]',
   {
     variants: {
       singleLine: {
@@ -48,7 +48,7 @@ const highlighterStyles = cva(
   }
 )
 
-const substringStyles = 'text-transparent'
+const substringStyles = 'text-transparent inline [white-space:inherit]'
 const caretStyles = 'relative inline-block h-0 w-0 align-baseline'
 
 // eslint-disable-next-line code-complete/low-function-cohesion
@@ -207,6 +207,21 @@ function Highlighter({
   if (components !== resultComponents) {
     resultComponents.push(renderCaretMarker(), ...components)
   }
+  const content = singleLine ? (
+    <div
+      style={{
+        display: 'inline-block',
+        whiteSpace: 'inherit',
+        width: 'max-content',
+        minWidth: '100%',
+      }}
+    >
+      {resultComponents}
+    </div>
+  ) : (
+    resultComponents
+  )
+
   return (
     <div
       className={rootClassName}
@@ -216,7 +231,7 @@ function Highlighter({
       style={HIGHLIGHTER_OVERLAY_STYLE}
       ref={containerRef}
     >
-      {resultComponents}
+      {content}
     </div>
   )
 }

--- a/src/MentionsInput.spec.tsx
+++ b/src/MentionsInput.spec.tsx
@@ -518,6 +518,23 @@ describe('MentionsInput', () => {
     expect(highlighter!.scrollTop).toBe(23)
   })
 
+  it('mirrors horizontal scroll offsets in single-line mode', () => {
+    const { container } = render(
+      <MentionsInput singleLine value={'@'.repeat(200)}>
+        <Mention trigger="@" data={data} />
+      </MentionsInput>
+    )
+
+    const input = screen.getByRole('combobox')
+    const highlighter = container.querySelector('[data-slot="highlighter"]') as HTMLElement
+    expect(highlighter).not.toBeNull()
+
+    input.scrollLeft = 45
+    fireEvent.scroll(input, { target: { scrollLeft: 45 } })
+
+    expect(highlighter.scrollLeft).toBe(45)
+  })
+
   it('should place suggestions in suggestionsPortalHost', async () => {
     // Create a portal container
     const portalContainer = document.createElement('div')
@@ -1004,7 +1021,6 @@ describe('MentionsInput', () => {
       })
 
       expect(textarea.style.height).toBe('42px')
-
       ;(globalThis as any).getComputedStyle = originalGetComputedStyle
       unmount()
     })
@@ -1030,7 +1046,6 @@ describe('MentionsInput', () => {
       })
 
       expect(textarea.style.height).not.toBe('')
-
       ;(globalThis as any).window = originalWindow
       unmount()
     })
@@ -2402,9 +2417,7 @@ describe('MentionsInput', () => {
       instance._scrollSyncFrame = 7
 
       const cancel = jest.spyOn(globalThis, 'cancelAnimationFrame').mockImplementation(() => {})
-      const raf = jest
-        .spyOn(globalThis, 'requestAnimationFrame')
-        .mockImplementation(() => 9)
+      const raf = jest.spyOn(globalThis, 'requestAnimationFrame').mockImplementation(() => 9)
 
       act(() => {
         instance.requestHighlighterScrollSync()

--- a/src/MentionsInput.tsx
+++ b/src/MentionsInput.tsx
@@ -1436,6 +1436,8 @@ class MentionsInput<
     )
 
     this.props.onChange?.(ev)
+
+    this.requestHighlighterScrollSync()
   }
 
   // Handle input element's select event


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fix single-line highlighting when text overflows input width

- Add font/line-height inheritance and white-space handling to highlighter

- Wrap single-line content in inline-block container with max-content width

- Sync horizontal scroll offset between input and highlighter in single-line mode

- Add test coverage for horizontal scroll mirroring


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Single-line input overflow"] -->|"Add CSS inheritance"| B["Highlighter styles updated"]
  B -->|"Wrap content in container"| C["Inline-block with max-content"]
  A -->|"Sync scroll events"| D["Horizontal scroll mirroring"]
  D -->|"Test coverage"| E["Scroll offset verification"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Highlighter.tsx</strong><dd><code>Add CSS inheritance and overflow handling for single-line mode</code></dd></summary>
<hr>

src/Highlighter.tsx

<ul><li>Updated <code>highlighterStyles</code> to inherit font-family, font-size, and <br>line-height from parent<br> <li> Modified <code>substringStyles</code> to include <code>inline</code> display and <br><code>[white-space:inherit]</code><br> <li> Wrapped single-line content in inline-block div with <code>max-content</code> width <br>and <code>minWidth: '100%'</code> to handle text overflow<br> <li> Changed render output to use new <code>content</code> variable instead of directly <br>rendering <code>resultComponents</code></ul>


</details>


  </td>
  <td><a href="https://github.com/hbmartin/react-mentions-ts/pull/102/files#diff-2d8fdc86aaeb8d7adcdd60631f48110e3e6cce38d17b7e31828f5c0088eadcc2">+18/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>MentionsInput.tsx</strong><dd><code>Trigger scroll sync on input value changes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/MentionsInput.tsx

<ul><li>Added <code>this.requestHighlighterScrollSync()</code> call in <code>handleChange</code> method <br>to sync scroll position after value changes<br> <li> Ensures highlighter scroll offset is updated when input content <br>changes</ul>


</details>


  </td>
  <td><a href="https://github.com/hbmartin/react-mentions-ts/pull/102/files#diff-5324a6e48c1ed3e0637605dab500fd0e512b7917d46884c35cba8e68698b5473">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>MentionsInput.spec.tsx</strong><dd><code>Add horizontal scroll mirroring test and cleanup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/MentionsInput.spec.tsx

<ul><li>Added new test <code>mirrors horizontal scroll offsets in single-line mode</code> <br>to verify scroll synchronization<br> <li> Test sets <code>scrollLeft</code> on input and verifies highlighter receives <br>matching scroll offset<br> <li> Removed trailing blank lines in existing tests for code cleanup<br> <li> Reformatted multi-line jest spy statement to single line</ul>


</details>


  </td>
  <td><a href="https://github.com/hbmartin/react-mentions-ts/pull/102/files#diff-b685f69aea6de57d68f84daa62a580acd4b95f6de2c7c04d3f723142ddb2245f">+18/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scroll synchronization in single-line mode to keep the input and highlighter properly aligned during scrolling

* **Style**
  * Enhanced font inheritance and layout consistency in the highlighter component for more uniform visual rendering

<!-- end of auto-generated comment: release notes by coderabbit.ai -->