### PR TITLE
recompute text styles

### DIFF
--- a/src/MentionsInput.spec.tsx
+++ b/src/MentionsInput.spec.tsx
@@ -2098,12 +2098,16 @@ describe('MentionsInput', () => {
 
       const instance = ref.current as unknown as any
 
+      const initialVersion = instance.state.highlighterRecomputeVersion
+
       act(() => {
         instance.scheduleHighlighterRecompute()
         instance.scheduleHighlighterRecompute()
       })
 
-      await waitFor(() => expect(instance.state.highlighterRecomputeVersion).toBe(2))
+      await waitFor(() =>
+        expect(instance.state.highlighterRecomputeVersion).toBe(initialVersion + 2)
+      )
 
       unmount()
     })
@@ -2360,9 +2364,12 @@ describe('MentionsInput', () => {
       expect(updatePosition.mock.calls.length).toBeGreaterThan(positionCalls + 2)
 
       unmountBridge()
-      for (const observer of observers) {
-        expect(observer.disconnect).toHaveBeenCalled()
-      }
+      unmount()
+      await waitFor(() => {
+        for (const observer of observers) {
+          expect(observer.disconnect).toHaveBeenCalled()
+        }
+      })
       expect(handlers.resize).toBeDefined()
       expect(handlers.orientationchange).toBeDefined()
       expect(addListener).toHaveBeenCalledWith('resize', handlers.resize)
@@ -2372,7 +2379,6 @@ describe('MentionsInput', () => {
       addListener.mockRestore()
       removeListener.mockRestore()
       ;(globalThis as any).ResizeObserver = originalResizeObserver
-      unmount()
     })
 
     it('runs updateHighlighterScroll twice when animation frames resolve', () => {

--- a/src/MentionsInput.tsx
+++ b/src/MentionsInput.tsx
@@ -1749,7 +1749,14 @@ class MentionsInput<
       }
     }
 
-    if (prevScrollLeft !== nextScrollLeft || prevScrollTop !== nextScrollTop || heightChanged) {
+    const typographyUpdated = mirrorInputTypographicStyles(input, highlighter)
+
+    if (
+      prevScrollLeft !== nextScrollLeft ||
+      prevScrollTop !== nextScrollTop ||
+      heightChanged ||
+      typographyUpdated
+    ) {
       this.scheduleHighlighterRecompute()
     }
   }
@@ -2174,7 +2181,7 @@ const mirrorInputTypographicStyles = (
       typeof computed.getPropertyValue === 'function'
         ? computed.getPropertyValue(property)
         : // Older JSDOM mocks may not include getPropertyValue; best-effort fallback
-          ((computed as Record<string, string | undefined>)[property] ?? '')
+          ((computed as unknown as Record<string, string | undefined>)[property] ?? '')
     if (nextValue && highlighter.style.getPropertyValue(property) !== nextValue) {
       highlighter.style.setProperty(property, nextValue)
       didUpdate = true


### PR DESCRIPTION
### **PR Type**
Bug fix, Tests


___

### **Description**
- Fix text style recomputation by detecting typography changes

- Add `typographyUpdated` flag to trigger highlighter recompute when styles change

- Improve test reliability with proper async/await for observer cleanup

- Fix type casting issue in `mirrorInputTypographicStyles` function

- Update test assertions to use relative version increments instead of absolute values


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["updateHighlighterScroll"] -->|"calls"| B["mirrorInputTypographicStyles"]
  B -->|"returns typographyUpdated"| C["scheduleHighlighterRecompute"]
  D["Test: highlighter recompute"] -->|"uses initialVersion"| E["relative increment check"]
  F["Test: observer cleanup"] -->|"wrapped in waitFor"| G["async assertion"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>MentionsInput.tsx</strong><dd><code>Add typography change detection to highlighter recompute</code>&nbsp; </dd></summary>
<hr>

src/MentionsInput.tsx

<ul><li>Add <code>typographyUpdated</code> variable from <code>mirrorInputTypographicStyles</code> call<br> <li> Include <code>typographyUpdated</code> in condition to trigger <br><code>scheduleHighlighterRecompute</code><br> <li> Fix type casting in <code>mirrorInputTypographicStyles</code> by adding <code>unknown</code> <br>intermediate cast<br> <li> Ensure highlighter recomputes when input typography styles change</ul>


</details>


  </td>
  <td><a href="https://github.com/hbmartin/react-mentions-ts/pull/104/files#diff-5324a6e48c1ed3e0637605dab500fd0e512b7917d46884c35cba8e68698b5473">+9/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>MentionsInput.spec.tsx</strong><dd><code>Improve test reliability with async assertions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/MentionsInput.spec.tsx

<ul><li>Store initial <code>highlighterRecomputeVersion</code> before scheduling recomputes<br> <li> Change assertion to use relative increment (<code>initialVersion + 2</code>) <br>instead of absolute value<br> <li> Wrap observer disconnect assertions in <code>waitFor</code> for async reliability<br> <li> Move <code>unmount()</code> call inside <code>waitFor</code> block to ensure proper cleanup <br>timing<br> <li> Remove duplicate <code>unmount()</code> call at end of test</ul>


</details>


  </td>
  <td><a href="https://github.com/hbmartin/react-mentions-ts/pull/104/files#diff-b685f69aea6de57d68f84daa62a580acd4b95f6de2c7c04d3f723142ddb2245f">+11/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced synchronization between the input field and highlighter to maintain consistent typography and scroll positioning during typing and interactions.

* **Tests**
  * Improved cleanup verification for internal observers to ensure proper resource management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->