### PR TITLE
Replace useCallback with useEffectEvent for callback handlers

### DIFF
--- a/src/SuggestionsOverlay.tsx
+++ b/src/SuggestionsOverlay.tsx
@@ -1,10 +1,11 @@
-import React, { Children, useCallback, useLayoutEffect, useMemo, useState } from 'react'
+import React, { Children, useLayoutEffect, useMemo, useState } from 'react'
 import type { CSSProperties } from 'react'
 import { cva } from 'class-variance-authority'
 import LoadingIndicator from './LoadingIndicator'
 import { DEFAULT_MENTION_PROPS } from './MentionDefaultProps'
 import Suggestion from './Suggestion'
 import { cn, flattenSuggestions, getSuggestionHtmlId } from './utils'
+import { useEffectEvent } from './utils/useEffectEvent'
 import type {
   MentionComponentProps,
   MentionRenderSuggestion,
@@ -120,19 +121,15 @@ function SuggestionsOverlay<Extra extends Record<string, unknown> = Record<strin
   const overlayClassName = cn(overlayStyles(), className)
   const listClassNameResolved = cn(listStyles, listClassName)
 
-  const selectSuggestion = useCallback(
+  const selectSuggestion = useEffectEvent(
     (suggestionItem: SuggestionDataItem<Extra>, queryInfo: QueryInfo) => {
       onSelect?.(suggestionItem, queryInfo)
-    },
-    [onSelect]
+    }
   )
 
-  const handleMouseEnter = useCallback(
-    (index: number) => {
-      onMouseEnter?.(index)
-    },
-    [onMouseEnter]
-  )
+  const handleMouseEnter = useEffectEvent((index: number) => {
+    onMouseEnter?.(index)
+  })
 
   const flattenedSuggestions = useMemo<FlattenedSuggestion<Extra>[]>(() => {
     return flattenSuggestions(children, suggestions)
@@ -156,13 +153,12 @@ function SuggestionsOverlay<Extra extends Record<string, unknown> = Record<strin
         index,
       }
     })
-  }, [childRenderSuggestions, focusIndex, flattenedSuggestions, handleMouseEnter, selectSuggestion])
+  }, [childRenderSuggestions, focusIndex, flattenedSuggestions])
 
-  const handleListMouseDown: React.MouseEventHandler<HTMLUListElement> = useCallback(
+  const handleListMouseDown = useEffectEvent<React.MouseEventHandler<HTMLUListElement>>(
     (event) => {
       onMouseDown?.(event)
-    },
-    [onMouseDown]
+    }
   )
 
   const renderSuggestions = (): React.ReactElement => {


### PR DESCRIPTION
## Summary
Refactored callback handlers in `SuggestionsOverlay.tsx` to use `useEffectEvent` instead of `useCallback`, eliminating unnecessary dependency array management and simplifying the code.

## Key Changes
- Replaced `useCallback` with `useEffectEvent` for three callback handlers:
  - `selectSuggestion`: Wraps `onSelect` callback
  - `handleMouseEnter`: Wraps `onMouseEnter` callback
  - `handleListMouseDown`: Wraps `onMouseDown` callback
- Removed dependency arrays from these callbacks since `useEffectEvent` handles stable function identity automatically
- Removed `useCallback` import and added `useEffectEvent` import from utils
- Simplified the `useMemo` dependency array for `renderSuggestions` by removing `handleMouseEnter` and `selectSuggestion` (now stable via `useEffectEvent`)

## Implementation Details
The `useEffectEvent` hook provides a cleaner pattern for event handlers that need to access current prop values without causing unnecessary re-renders or dependency array bloat. This change improves code maintainability by reducing boilerplate while maintaining the same runtime behavior.

https://claude.ai/code/session_01Nw4Lsueexkp452hWn82Ehv

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace `useCallback` with `useEffectEvent` for event handlers in `SuggestionsOverlay`
> Switches `selectSuggestion`, `handleMouseEnter`, and `handleListMouseDown` in [SuggestionsOverlay.tsx](https://github.com/hbmartin/react-mentions-ts/pull/160/files#diff-8d2b85b42eafe864e1f94902263195848ee9436d546b75c7baae1384f02e7f8a) from `useCallback` to `useEffectEvent`, giving them stable identities across renders. Because the handlers are now stable, `handleMouseEnter` and `selectSuggestion` are removed from the `useMemo` dependency array for `suggestionEntries`, preventing unnecessary recomputation on each render.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4adf9fd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code improvements with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->