### PR TITLE
Async query cleanup now only removes a matching AbortController, so s…

### DIFF
--- a/demo/src/examples/AsyncGithubUserMentions.tsx
+++ b/demo/src/examples/AsyncGithubUserMentions.tsx
@@ -2,11 +2,7 @@ import React, { useState } from 'react'
 import { clsx } from 'clsx'
 
 import { MentionsInput, Mention } from '../../../src'
-import type {
-  MentionDataItem,
-  MentionSearchContext,
-  MentionsInputChangeEvent,
-} from '../../../src'
+import type { MentionDataItem, MentionSearchContext, MentionsInputChangeEvent } from '../../../src'
 import ExampleCard from './ExampleCard'
 import {
   mentionPillClass,
@@ -23,8 +19,12 @@ async function fetchUsers(
   }
 
   const response = await fetch(`https://api.github.com/search/users?q=${query}`, { signal })
-  const data = await response.json()
-  return data.items.map((user: { login: string }) => ({ display: user.login, id: user.login }))
+  if (!response.ok) {
+    throw new Error(`GitHub user search failed (${response.status.toString()})`)
+  }
+
+  const data = (await response.json()) as { items?: Array<{ login: string }> }
+  return (data.items ?? []).map((user) => ({ display: user.login, id: user.login }))
 }
 
 const githubSuggestions = mergeClassNames(multilineMentionsClassNames, {

--- a/scripts/dev-with-wdyr.mjs
+++ b/scripts/dev-with-wdyr.mjs
@@ -2,8 +2,9 @@
 
 import { spawn } from 'node:child_process'
 
-const child = spawn('pnpm', ['vite', '--config', 'demo/vite.config.ts'], {
-  shell: true,
+const pnpmCommand = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm'
+
+const child = spawn(pnpmCommand, ['vite', '--config', 'demo/vite.config.ts'], {
   stdio: 'inherit',
   env: {
     ...process.env,

--- a/src/MentionsInput.spec.tsx
+++ b/src/MentionsInput.spec.tsx
@@ -490,7 +490,10 @@ describe('MentionsInput', () => {
     fireEvent.select(textarea)
 
     await waitFor(() => {
-      expect(asyncData).toHaveBeenCalledWith('a', expect.objectContaining({ signal: expect.any(Object) }))
+      expect(asyncData).toHaveBeenCalledWith(
+        'a',
+        expect.objectContaining({ signal: expect.any(Object) })
+      )
     })
 
     await waitFor(() => {
@@ -524,7 +527,10 @@ describe('MentionsInput', () => {
     fireEvent.select(textarea)
 
     await waitFor(() => {
-      expect(asyncData).toHaveBeenCalledWith('a', expect.objectContaining({ signal: expect.any(Object) }))
+      expect(asyncData).toHaveBeenCalledWith(
+        'a',
+        expect.objectContaining({ signal: expect.any(Object) })
+      )
     })
 
     rerender(
@@ -537,7 +543,10 @@ describe('MentionsInput', () => {
     fireEvent.select(textarea)
 
     await waitFor(() => {
-      expect(asyncData).toHaveBeenCalledWith('ab', expect.objectContaining({ signal: expect.any(Object) }))
+      expect(asyncData).toHaveBeenCalledWith(
+        'ab',
+        expect.objectContaining({ signal: expect.any(Object) })
+      )
     })
 
     requests.get('ab')?.resolve([{ id: 'fresh', display: 'Fresh Result' }])
@@ -577,6 +586,171 @@ describe('MentionsInput', () => {
     })
   })
 
+  it('allows renderEmpty to suppress the built-in empty state.', async () => {
+    type DeferredResult = {
+      resolve: (value: Array<{ id: string; display: string }>) => void
+    }
+
+    const requests = new Map<string, DeferredResult>()
+    const asyncData = jest.fn(
+      (query: string) =>
+        new Promise<Array<{ id: string; display: string }>>((resolve) => {
+          requests.set(query, { resolve })
+        })
+    )
+
+    const { container } = render(
+      <MentionsInput value="@a">
+        <Mention trigger="@" data={asyncData} renderEmpty={() => null} />
+      </MentionsInput>
+    )
+
+    const textarea = screen.getByRole('combobox')
+    fireEvent.focus(textarea)
+    textarea.setSelectionRange(2, 2)
+    fireEvent.select(textarea)
+
+    await waitFor(() => {
+      expect(asyncData).toHaveBeenCalledWith(
+        'a',
+        expect.objectContaining({ signal: expect.any(Object) })
+      )
+    })
+
+    requests.get('a')?.resolve([])
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-slot="suggestions"]')).toBeNull()
+    })
+
+    expect(screen.queryByText('No suggestions found')).not.toBeInTheDocument()
+  })
+
+  it('allows renderError to suppress the built-in error state.', async () => {
+    type DeferredResult = {
+      reject: (reason?: unknown) => void
+    }
+
+    const requests = new Map<string, DeferredResult>()
+    const asyncData = jest.fn(
+      (query: string) =>
+        new Promise<Array<{ id: string; display: string }>>((_, reject) => {
+          requests.set(query, { reject })
+        })
+    )
+
+    const { container } = render(
+      <MentionsInput value="@a">
+        <Mention trigger="@" data={asyncData} renderError={() => false} />
+      </MentionsInput>
+    )
+
+    const textarea = screen.getByRole('combobox')
+    fireEvent.focus(textarea)
+    textarea.setSelectionRange(2, 2)
+    fireEvent.select(textarea)
+
+    await waitFor(() => {
+      expect(asyncData).toHaveBeenCalledWith(
+        'a',
+        expect.objectContaining({ signal: expect.any(Object) })
+      )
+    })
+
+    requests.get('a')?.reject(new Error('boom'))
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-slot="suggestions"]')).toBeNull()
+    })
+
+    expect(screen.queryByText('Unable to load suggestions')).not.toBeInTheDocument()
+  })
+
+  it('keeps the active request abortable after an older request rejects.', async () => {
+    type DeferredResult = {
+      resolve: (value: Array<{ id: string; display: string }>) => void
+      reject: (reason?: unknown) => void
+      signal: AbortSignal
+    }
+
+    const requests = new Map<string, DeferredResult>()
+    const asyncData = jest.fn(
+      (query: string, { signal }: { signal: AbortSignal }) =>
+        new Promise<Array<{ id: string; display: string }>>((resolve, reject) => {
+          requests.set(query, { resolve, reject, signal })
+        })
+    )
+
+    const { rerender } = render(
+      <MentionsInput value="@a">
+        <Mention trigger="@" data={asyncData} />
+      </MentionsInput>
+    )
+
+    const textarea = screen.getByRole('combobox')
+    fireEvent.focus(textarea)
+    textarea.setSelectionRange(2, 2)
+    fireEvent.select(textarea)
+
+    await waitFor(() => {
+      expect(asyncData).toHaveBeenCalledWith(
+        'a',
+        expect.objectContaining({ signal: expect.any(Object) })
+      )
+    })
+
+    rerender(
+      <MentionsInput value="@ab">
+        <Mention trigger="@" data={asyncData} />
+      </MentionsInput>
+    )
+
+    textarea.setSelectionRange(3, 3)
+    fireEvent.select(textarea)
+
+    await waitFor(() => {
+      expect(asyncData).toHaveBeenCalledWith(
+        'ab',
+        expect.objectContaining({ signal: expect.any(Object) })
+      )
+    })
+
+    const firstRequest = requests.get('a')
+    const secondRequest = requests.get('ab')
+    expect(firstRequest?.signal.aborted).toBe(true)
+    expect(secondRequest?.signal.aborted).toBe(false)
+
+    firstRequest?.reject(new Error('stale request aborted'))
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    rerender(
+      <MentionsInput value="@abc">
+        <Mention trigger="@" data={asyncData} />
+      </MentionsInput>
+    )
+
+    textarea.setSelectionRange(4, 4)
+    fireEvent.select(textarea)
+
+    await waitFor(() => {
+      expect(asyncData).toHaveBeenCalledWith(
+        'abc',
+        expect.objectContaining({ signal: expect.any(Object) })
+      )
+    })
+
+    expect(secondRequest?.signal.aborted).toBe(true)
+
+    requests.get('abc')?.resolve([])
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+  })
+
   it('supports debounced async providers and maxSuggestions.', async () => {
     jest.useFakeTimers()
 
@@ -606,7 +780,10 @@ describe('MentionsInput', () => {
       })
 
       await waitFor(() => {
-        expect(asyncData).toHaveBeenCalledWith('a', expect.objectContaining({ signal: expect.any(Object) }))
+        expect(asyncData).toHaveBeenCalledWith(
+          'a',
+          expect.objectContaining({ signal: expect.any(Object) })
+        )
       })
 
       await waitFor(() => {

--- a/src/MentionsInput.tsx
+++ b/src/MentionsInput.tsx
@@ -121,19 +121,18 @@ const createGeneratedId = (): string => {
 }
 
 const isAbortError = (error: unknown): boolean =>
-  (typeof DOMException !== 'undefined' && error instanceof DOMException)
+  typeof DOMException !== 'undefined' && error instanceof DOMException
     ? error.name === 'AbortError'
     : typeof error === 'object' &&
-        error !== null &&
-        'name' in error &&
-        (error as { name?: string }).name === 'AbortError'
+      error !== null &&
+      'name' in error &&
+      (error as { name?: string }).name === 'AbortError'
 
 const DEFAULT_EMPTY_SUGGESTIONS_MESSAGE = 'No suggestions found'
 const DEFAULT_ERROR_SUGGESTIONS_MESSAGE = 'Unable to load suggestions'
 
-const getMentionChildren = <Extra extends Record<string, unknown>>(
-  children: React.ReactNode
-) => collectMentionElements<Extra>(children)
+const getMentionChildren = <Extra extends Record<string, unknown>>(children: React.ReactNode) =>
+  collectMentionElements<Extra>(children)
 
 const getMentionChild = <Extra extends Record<string, unknown>>(
   children: React.ReactNode,
@@ -375,7 +374,10 @@ class MentionsInput<
 
   private validateChildTree(children: React.ReactNode, seenChildren: Set<string>): void {
     React.Children.forEach(children, (child) => {
-      if (React.isValidElement<{ children?: React.ReactNode }>(child) && child.type === React.Fragment) {
+      if (
+        React.isValidElement<{ children?: React.ReactNode }>(child) &&
+        child.type === React.Fragment
+      ) {
         this.validateChildTree(child.props.children, seenChildren)
         return
       }
@@ -748,7 +750,9 @@ class MentionsInput<
       'aria-haspopup': isInlineAutocomplete ? undefined : 'listbox',
       'aria-controls': isOverlayOpen && overlayId ? overlayId : undefined,
       'aria-activedescendant':
-        isOverlayOpen && overlayId ? getSuggestionHtmlId(overlayId, this.state.focusIndex) : undefined,
+        isOverlayOpen && overlayId
+          ? getSuggestionHtmlId(overlayId, this.state.focusIndex)
+          : undefined,
     })
 
     if (isInlineAutocomplete && inlineSuggestion) {
@@ -1094,10 +1098,7 @@ class MentionsInput<
     }
     const previousPosition = this.state.inlineSuggestionPosition
 
-    if (
-      previousPosition?.left === nextPosition.left &&
-      previousPosition.top === nextPosition.top
-    ) {
+    if (previousPosition?.left === nextPosition.left && previousPosition.top === nextPosition.top) {
       return
     }
 
@@ -1283,17 +1284,42 @@ class MentionsInput<
     if (preferredQueryState.status === 'error') {
       const renderError =
         mentionChild.props.renderError ?? DEFAULT_MENTION_PROPS.renderError ?? null
+      if (!renderError) {
+        return {
+          statusContent: DEFAULT_ERROR_SUGGESTIONS_MESSAGE,
+          statusType: 'error',
+        }
+      }
+
+      const statusContent = renderError(
+        preferredQueryState.queryInfo.query,
+        preferredQueryState.error
+      )
+      if (statusContent === null || statusContent === false) {
+        return { statusContent: null, statusType: null }
+      }
+
       return {
-        statusContent:
-          renderError?.(preferredQueryState.queryInfo.query, preferredQueryState.error) ??
-          DEFAULT_ERROR_SUGGESTIONS_MESSAGE,
+        statusContent,
         statusType: 'error',
       }
     }
 
     const renderEmpty = mentionChild.props.renderEmpty ?? DEFAULT_MENTION_PROPS.renderEmpty ?? null
+    if (!renderEmpty) {
+      return {
+        statusContent: DEFAULT_EMPTY_SUGGESTIONS_MESSAGE,
+        statusType: 'empty',
+      }
+    }
+
+    const statusContent = renderEmpty(preferredQueryState.queryInfo.query)
+    if (statusContent === null || statusContent === false) {
+      return { statusContent: null, statusType: null }
+    }
+
     return {
-      statusContent: renderEmpty?.(preferredQueryState.queryInfo.query) ?? DEFAULT_EMPTY_SUGGESTIONS_MESSAGE,
+      statusContent,
       statusType: 'empty',
     }
   }
@@ -2068,10 +2094,7 @@ class MentionsInput<
     }
   }
 
-  private setQueryState(
-    childIndex: number,
-    queryState: SuggestionQueryState<Extra> | null
-  ): void {
+  private setQueryState(childIndex: number, queryState: SuggestionQueryState<Extra> | null): void {
     this.setState((prevState) => {
       const nextQueryStates: SuggestionQueryStateMap<Extra> = { ...prevState.queryStates }
 
@@ -2095,8 +2118,7 @@ class MentionsInput<
     ignoreAccents: boolean
   ): void {
     const debounceMs = mentionChild.props.debounceMs ?? DEFAULT_MENTION_PROPS.debounceMs
-    const maxSuggestions =
-      mentionChild.props.maxSuggestions ?? DEFAULT_MENTION_PROPS.maxSuggestions
+    const maxSuggestions = mentionChild.props.maxSuggestions ?? DEFAULT_MENTION_PROPS.maxSuggestions
 
     const pendingTimer = this._queryDebounceTimers.get(childIndex)
     if (pendingTimer !== undefined) {
@@ -2124,7 +2146,13 @@ class MentionsInput<
         signal: controller.signal,
       })
 
-      void this.updateSuggestions(queryId, childIndex, queryInfo, provideData(queryInfo.query), controller)
+      void this.updateSuggestions(
+        queryId,
+        childIndex,
+        queryInfo,
+        provideData(queryInfo.query),
+        controller
+      )
     }
 
     if (debounceMs > 0) {
@@ -2216,7 +2244,9 @@ class MentionsInput<
         return
       }
 
-      this._queryAbortControllers.delete(childIndex)
+      if (this._queryAbortControllers.get(childIndex) === controller) {
+        this._queryAbortControllers.delete(childIndex)
+      }
 
       this.suggestions = {
         ...this.suggestions,
@@ -2247,7 +2277,9 @@ class MentionsInput<
         },
       }))
     } catch (error) {
-      this._queryAbortControllers.delete(childIndex)
+      if (this._queryAbortControllers.get(childIndex) === controller) {
+        this._queryAbortControllers.delete(childIndex)
+      }
 
       if (queryId !== this._queryId || controller.signal.aborted || isAbortError(error)) {
         return

--- a/src/utils/useEventCallback.ts
+++ b/src/utils/useEventCallback.ts
@@ -4,8 +4,5 @@ export function useEventCallback<T extends (...args: never[]) => unknown>(handle
   const handlerRef = useRef(handler)
   handlerRef.current = handler
 
-  return useCallback(
-    ((...args: Parameters<T>) => handlerRef.current(...args)) as T,
-    []
-  )
+  return useCallback(((...args: Parameters<T>) => handlerRef.current(...args)) as T, [])
 }


### PR DESCRIPTION
…tale rejections cannot unregister the live request. renderEmpty and renderError still fall back to the built-in status messages when no renderer is provided, but now honor renderer returns of null or false as an explicit “render nothing” opt-out

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `updateSuggestions` abort controller cleanup to not clear newer in-flight requests
> - The abort controller for a query is now only deleted if it matches the controller stored for that query at cleanup time, preventing an older resolved/rejected request from clearing the controller of a newer request.
> - `getSuggestionsStatusContent` now suppresses the status UI entirely when a custom `renderError` or `renderEmpty` callback returns `null` or `false`, rather than falling back to the default message.
> - Behavioral Change: custom `renderError`/`renderEmpty` callbacks that return `null` or `false` will no longer show the default message — they will hide the status UI entirely.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized efb3124.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for async data requests with HTTP response validation
  * Enhanced null/undefined protection when processing API responses to prevent runtime errors
  * Fixed request cancellation logic to prevent older queries from interfering with newer ones

* **Tests**
  * Added coverage for async suggestion handling, error states, and empty responses

<!-- end of auto-generated comment: release notes by coderabbit.ai -->