### PR TITLE
Reliability and ssr and performance followup 2

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -41,7 +41,7 @@ jobs:
         run: pnpm build
 
       - name: Build demo
-        run: pnpm build:demo -- --base=/react-mentions-ts/
+        run: pnpm build:demo --base=/react-mentions-ts/
 
       - name: Archive build artifacts
         uses: actions/upload-artifact@v4

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "react-mentions-ts",
 	"private": false,
-	"version": "5.4.7",
+	"version": "5.4.8",
 	"description": "A React component that enables Facebook/Twitter-style @mentions and tagging in textarea inputs with full TypeScript support.",
 	"type": "module",
 	"packageManager": "pnpm@10.33.0",
@@ -145,7 +145,7 @@
 	"peerDependencies": {
 		"class-variance-authority": ">=0.6.0",
 		"clsx": ">=2.0.0",
-		"react": ">=19.0.0",
+		"react": ">=19.0.3 <19.1.0 || >=19.1.4 <19.2.0 || >=19.2.3",
 		"react-dom": ">=19.0.0",
 		"tailwind-merge": ">=3.0.0"
 	},

--- a/scripts/dev-with-wdyr.mjs
+++ b/scripts/dev-with-wdyr.mjs
@@ -12,6 +12,11 @@ const child = spawn(pnpmCommand, ['vite', '--config', 'demo/vite.config.ts'], {
   },
 })
 
+child.on('error', (error) => {
+  console.error('Failed to start dev server:', error)
+  process.exit(1)
+})
+
 child.on('close', (code, signal) => {
   if (signal) {
     process.kill(process.pid, signal)

--- a/src/MentionsInput.spec.tsx
+++ b/src/MentionsInput.spec.tsx
@@ -626,6 +626,44 @@ describe('MentionsInput', () => {
     expect(screen.queryByText('No suggestions found')).not.toBeInTheDocument()
   })
 
+  it('falls back to the built-in empty state when renderEmpty returns undefined.', async () => {
+    type DeferredResult = {
+      resolve: (value: Array<{ id: string; display: string }>) => void
+    }
+
+    const requests = new Map<string, DeferredResult>()
+    const asyncData = jest.fn(
+      (query: string) =>
+        new Promise<Array<{ id: string; display: string }>>((resolve) => {
+          requests.set(query, { resolve })
+        })
+    )
+
+    render(
+      <MentionsInput value="@a">
+        <Mention trigger="@" data={asyncData} renderEmpty={() => undefined} />
+      </MentionsInput>
+    )
+
+    const textarea = screen.getByRole('combobox')
+    fireEvent.focus(textarea)
+    textarea.setSelectionRange(2, 2)
+    fireEvent.select(textarea)
+
+    await waitFor(() => {
+      expect(asyncData).toHaveBeenCalledWith(
+        'a',
+        expect.objectContaining({ signal: expect.any(Object) })
+      )
+    })
+
+    requests.get('a')?.resolve([])
+
+    await waitFor(() => {
+      expect(screen.getByText('No suggestions found')).toBeInTheDocument()
+    })
+  })
+
   it('allows renderError to suppress the built-in error state.', async () => {
     type DeferredResult = {
       reject: (reason?: unknown) => void
@@ -664,6 +702,44 @@ describe('MentionsInput', () => {
     })
 
     expect(screen.queryByText('Unable to load suggestions')).not.toBeInTheDocument()
+  })
+
+  it('falls back to the built-in error state when renderError returns undefined.', async () => {
+    type DeferredResult = {
+      reject: (reason?: unknown) => void
+    }
+
+    const requests = new Map<string, DeferredResult>()
+    const asyncData = jest.fn(
+      (query: string) =>
+        new Promise<Array<{ id: string; display: string }>>((_, reject) => {
+          requests.set(query, { reject })
+        })
+    )
+
+    render(
+      <MentionsInput value="@a">
+        <Mention trigger="@" data={asyncData} renderError={() => undefined} />
+      </MentionsInput>
+    )
+
+    const textarea = screen.getByRole('combobox')
+    fireEvent.focus(textarea)
+    textarea.setSelectionRange(2, 2)
+    fireEvent.select(textarea)
+
+    await waitFor(() => {
+      expect(asyncData).toHaveBeenCalledWith(
+        'a',
+        expect.objectContaining({ signal: expect.any(Object) })
+      )
+    })
+
+    requests.get('a')?.reject(new Error('boom'))
+
+    await waitFor(() => {
+      expect(screen.getByText('Unable to load suggestions')).toBeInTheDocument()
+    })
   })
 
   it('keeps the active request abortable after an older request rejects.', async () => {

--- a/src/MentionsInput.tsx
+++ b/src/MentionsInput.tsx
@@ -1300,7 +1300,8 @@ class MentionsInput<
       }
 
       return {
-        statusContent,
+        statusContent:
+          statusContent === undefined ? DEFAULT_ERROR_SUGGESTIONS_MESSAGE : statusContent,
         statusType: 'error',
       }
     }
@@ -1319,7 +1320,8 @@ class MentionsInput<
     }
 
     return {
-      statusContent,
+      statusContent:
+        statusContent === undefined ? DEFAULT_EMPTY_SUGGESTIONS_MESSAGE : statusContent,
       statusType: 'empty',
     }
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error and empty state handling: default fallback messages now properly display when custom render callbacks return undefined, ensuring better user interface consistency across edge cases.

* **Chores**
  * Package version updated to 5.4.8.
  * Refined React peer dependency version constraints for improved compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix fallback behavior in `MentionsInput` when `renderEmpty`/`renderError` return undefined
> - `getSuggestionsStatusContent` now shows default status messages ('No suggestions found' / 'Unable to load suggestions') when `renderEmpty` or `renderError` return `undefined`, while `null`/`false` still suppresses the status content.
> - Fixes the demo deploy workflow by passing `--base` directly to the pnpm script instead of after a `--` separator in [deploy-demo.yml](.github/workflows/deploy-demo.yml).
> - Narrows the React peer dependency range to exclude known problematic versions (e.g. `>=19.0.3 <19.1.0 || >=19.1.4 <19.2.0 || >=19.2.3`).
> - Behavioral Change: any existing custom `renderEmpty`/`renderError` implementations that rely on returning `undefined` to suppress output will now show the default message instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9349114.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->