### PR TITLE
Implemented the hybrid refactor around a single queued view-sync path…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ npm-debug.log*
 /attw*
 .npm-cache
 /reviews_triage
+triage_decisions.db

--- a/src/MeasurementBridge.spec.tsx
+++ b/src/MeasurementBridge.spec.tsx
@@ -1,0 +1,122 @@
+import React from 'react'
+import { act, render, waitFor } from '@testing-library/react'
+import MeasurementBridge from './MeasurementBridge'
+
+describe('MeasurementBridge', () => {
+  it('requests view sync from mount, observers, scroll, and viewport listeners, then cleans up', async () => {
+    const requestViewSync = jest.fn()
+    const container = document.createElement('div')
+    const highlighter = document.createElement('div')
+    const input = document.createElement('textarea')
+    const suggestions = document.createElement('div')
+
+    const originalResizeObserver = (globalThis as typeof globalThis & { ResizeObserver?: unknown })
+      .ResizeObserver
+    const observers: Array<{
+      callback: () => void
+      observe: jest.Mock
+      disconnect: jest.Mock
+    }> = []
+
+    class MockResizeObserver {
+      readonly callback: () => void
+      readonly observe: jest.Mock
+      readonly disconnect: jest.Mock
+
+      constructor(callback: () => void) {
+        this.callback = callback
+        this.observe = jest.fn()
+        this.disconnect = jest.fn()
+        observers.push(this)
+      }
+    }
+
+    ;(globalThis as typeof globalThis & { ResizeObserver?: unknown }).ResizeObserver =
+      MockResizeObserver
+
+    const originalAdd = globalThis.addEventListener
+    const originalRemove = globalThis.removeEventListener
+    const handlers: Partial<Record<string, EventListener>> = {}
+
+    const addListener = jest
+      .spyOn(globalThis, 'addEventListener')
+      .mockImplementation(
+        (
+          type: string,
+          listener: EventListenerOrEventListenerObject,
+          options?: boolean | AddEventListenerOptions
+        ) => {
+          handlers[type] = listener as EventListener
+          return originalAdd.call(globalThis, type, listener, options)
+        }
+      )
+
+    const removeListener = jest
+      .spyOn(globalThis, 'removeEventListener')
+      .mockImplementation(
+        (
+          type: string,
+          listener: EventListenerOrEventListenerObject,
+          options?: boolean | EventListenerOptions
+        ) => originalRemove.call(globalThis, type, listener, options)
+      )
+
+    try {
+      const { unmount } = render(
+        <MeasurementBridge
+          container={container}
+          highlighter={highlighter}
+          input={input}
+          suggestions={suggestions}
+          requestViewSync={requestViewSync}
+        />
+      )
+
+      expect(requestViewSync).toHaveBeenCalledWith({
+        syncScroll: true,
+        measureSuggestions: true,
+        measureInline: true,
+      })
+
+      act(() => {
+        observers.forEach((observer) => {
+          observer.callback()
+        })
+      })
+
+      act(() => {
+        input.dispatchEvent(new Event('scroll'))
+      })
+
+      act(() => {
+        globalThis.dispatchEvent(new Event('resize'))
+        globalThis.dispatchEvent(new Event('orientationchange'))
+      })
+
+      expect(requestViewSync).toHaveBeenCalledWith({
+        measureSuggestions: true,
+      })
+      expect(requestViewSync.mock.calls.length).toBeGreaterThan(4)
+
+      unmount()
+
+      await waitFor(() => {
+        for (const observer of observers) {
+          expect(observer.disconnect).toHaveBeenCalled()
+        }
+      })
+
+      expect(handlers.resize).toBeDefined()
+      expect(handlers.orientationchange).toBeDefined()
+      expect(addListener).toHaveBeenCalledWith('resize', handlers.resize)
+      expect(addListener).toHaveBeenCalledWith('orientationchange', handlers.orientationchange)
+      expect(removeListener).toHaveBeenCalledWith('resize', handlers.resize)
+      expect(removeListener).toHaveBeenCalledWith('orientationchange', handlers.orientationchange)
+    } finally {
+      addListener.mockRestore()
+      removeListener.mockRestore()
+      ;(globalThis as typeof globalThis & { ResizeObserver?: unknown }).ResizeObserver =
+        originalResizeObserver
+    }
+  })
+})

--- a/src/MeasurementBridge.tsx
+++ b/src/MeasurementBridge.tsx
@@ -1,0 +1,107 @@
+import { useLayoutEffect } from 'react'
+import type { InputElement } from './types'
+import type { PendingViewSync } from './MentionsInputLayout'
+import { useEventCallback } from './utils/useEventCallback'
+
+export interface MeasurementBridgeProps {
+  readonly container: HTMLDivElement | null
+  readonly highlighter: HTMLDivElement | null
+  readonly input: InputElement | null
+  readonly suggestions: HTMLDivElement | null
+  readonly requestViewSync: (flags: Partial<PendingViewSync>) => void
+}
+
+const ALL_MEASUREMENT_FLAGS: Partial<PendingViewSync> = {
+  syncScroll: true,
+  measureSuggestions: true,
+  measureInline: true,
+}
+
+const SUGGESTIONS_ONLY_FLAGS: Partial<PendingViewSync> = {
+  measureSuggestions: true,
+}
+
+const MeasurementBridge = ({
+  container,
+  highlighter,
+  input,
+  suggestions,
+  requestViewSync,
+}: MeasurementBridgeProps) => {
+  const requestAllMeasurements = useEventCallback(() => {
+    requestViewSync(ALL_MEASUREMENT_FLAGS)
+  })
+
+  const requestSuggestionsMeasurement = useEventCallback(() => {
+    requestViewSync(SUGGESTIONS_ONLY_FLAGS)
+  })
+
+  const observe = useEventCallback((element: Element | null, callback: () => void) => {
+    if (!element || typeof ResizeObserver === 'undefined') {
+      return undefined
+    }
+
+    const observer = new ResizeObserver(() => {
+      callback()
+    })
+
+    observer.observe(element)
+
+    return () => {
+      observer.disconnect()
+    }
+  })
+
+  useLayoutEffect(() => {
+    requestAllMeasurements()
+  }, [requestAllMeasurements])
+
+  useLayoutEffect(() => observe(container, requestAllMeasurements), [container, observe, requestAllMeasurements])
+  useLayoutEffect(
+    () => observe(highlighter, requestAllMeasurements),
+    [highlighter, observe, requestAllMeasurements]
+  )
+  useLayoutEffect(() => observe(input, requestAllMeasurements), [input, observe, requestAllMeasurements])
+  useLayoutEffect(
+    () => observe(suggestions, requestSuggestionsMeasurement),
+    [suggestions, observe, requestSuggestionsMeasurement]
+  )
+
+  useLayoutEffect(() => {
+    if (globalThis.window === undefined) {
+      return undefined
+    }
+
+    const handleViewportChange = () => {
+      requestAllMeasurements()
+    }
+
+    globalThis.addEventListener('resize', handleViewportChange)
+    globalThis.addEventListener('orientationchange', handleViewportChange)
+
+    return () => {
+      globalThis.removeEventListener('resize', handleViewportChange)
+      globalThis.removeEventListener('orientationchange', handleViewportChange)
+    }
+  }, [requestAllMeasurements])
+
+  useLayoutEffect(() => {
+    if (!input) {
+      return undefined
+    }
+
+    const handleScroll = () => {
+      requestAllMeasurements()
+    }
+
+    input.addEventListener('scroll', handleScroll, { passive: true })
+
+    return () => {
+      input.removeEventListener('scroll', handleScroll)
+    }
+  }, [input, requestAllMeasurements])
+
+  return null
+}
+
+export default MeasurementBridge

--- a/src/MentionsInput.spec.tsx
+++ b/src/MentionsInput.spec.tsx
@@ -2667,126 +2667,7 @@ describe('MentionsInput', () => {
       unmount()
     })
 
-    it('syncs measurement bridge observers and cleans up.', async () => {
-      const ref = React.createRef<MentionsInput>()
-      const { unmount } = render(
-        <MentionsInput ref={ref} value="">
-          <Mention trigger="@" data={data} />
-        </MentionsInput>
-      )
-
-      await waitFor(() => {
-        expect(ref.current).not.toBeNull()
-      })
-
-      const instance = ref.current as unknown as any
-      const container = document.createElement('div')
-      const highlighter = document.createElement('div')
-      const input = document.createElement('textarea')
-      const suggestions = document.createElement('div')
-      instance.containerElement = container
-      instance.highlighterElement = highlighter
-      instance.inputElement = input
-      instance.suggestionsElement = suggestions
-
-      const syncScroll = jest.fn()
-      const updatePosition = jest.fn()
-      instance.updateHighlighterScroll = syncScroll
-      instance.updateSuggestionsPosition = updatePosition
-
-      const originalResizeObserver = (globalThis as any).ResizeObserver
-      const observers: Array<{ observe: jest.Mock; disconnect: jest.Mock }> = []
-      class MockResizeObserver {
-        private readonly callback: () => void
-        observe: jest.Mock
-        disconnect: jest.Mock
-        constructor(cb: () => void) {
-          this.callback = cb
-          this.observe = jest.fn(() => {
-            this.callback()
-          })
-          this.disconnect = jest.fn()
-          observers.push(this)
-        }
-      }
-      ;(globalThis as any).ResizeObserver = MockResizeObserver
-
-      const originalAdd = window.addEventListener
-      const originalRemove = window.removeEventListener
-      const handlers: Partial<Record<string, EventListener>> = {}
-      const addListener = jest
-        .spyOn(globalThis, 'addEventListener')
-        .mockImplementation(
-          (
-            type: string,
-            listener: EventListenerOrEventListenerObject,
-            options?: boolean | AddEventListenerOptions
-          ) => {
-            handlers[type] = listener as EventListener
-            return originalAdd.call(globalThis, type, listener, options)
-          }
-        )
-      const removeListener = jest
-        .spyOn(globalThis, 'removeEventListener')
-        .mockImplementation(
-          (
-            type: string,
-            listener: EventListenerOrEventListenerObject,
-            options?: boolean | EventListenerOptions
-          ) => {
-            return originalRemove.call(globalThis, type, listener, options)
-          }
-        )
-
-      const bridgeElement = instance.renderMeasurementBridge() as React.ReactElement
-      const { unmount: unmountBridge } = render(bridgeElement)
-
-      expect(syncScroll).toHaveBeenCalled()
-      expect(updatePosition).toHaveBeenCalled()
-
-      const syncCalls = syncScroll.mock.calls.length
-      const positionCalls = updatePosition.mock.calls.length
-
-      act(() => {
-        input.dispatchEvent(new Event('scroll'))
-      })
-
-      expect(syncScroll.mock.calls.length).toBe(syncCalls + 1)
-      expect(updatePosition.mock.calls.length).toBe(positionCalls + 1)
-
-      act(() => {
-        globalThis.dispatchEvent(new Event('resize'))
-      })
-
-      expect(syncScroll.mock.calls.length).toBeGreaterThan(syncCalls + 1)
-      expect(updatePosition.mock.calls.length).toBeGreaterThan(positionCalls + 1)
-
-      act(() => {
-        globalThis.dispatchEvent(new Event('orientationchange'))
-      })
-
-      expect(syncScroll.mock.calls.length).toBeGreaterThan(syncCalls + 2)
-      expect(updatePosition.mock.calls.length).toBeGreaterThan(positionCalls + 2)
-
-      unmountBridge()
-      unmount()
-      await waitFor(() => {
-        for (const observer of observers) {
-          expect(observer.disconnect).toHaveBeenCalled()
-        }
-      })
-      expect(handlers.resize).toBeDefined()
-      expect(handlers.orientationchange).toBeDefined()
-      expect(addListener).toHaveBeenCalledWith('resize', handlers.resize)
-      expect(addListener).toHaveBeenCalledWith('orientationchange', handlers.orientationchange)
-      expect(removeListener).toHaveBeenCalledWith('resize', handlers.resize)
-      expect(removeListener).toHaveBeenCalledWith('orientationchange', handlers.orientationchange)
-      addListener.mockRestore()
-      removeListener.mockRestore()
-      ;(globalThis as any).ResizeObserver = originalResizeObserver
-    })
-
-    it('runs updateHighlighterScroll twice when animation frames resolve', () => {
+    it('flushes a queued scroll sync when the animation frame resolves', () => {
       const ref = React.createRef<MentionsInput>()
       const { unmount } = render(
         <MentionsInput ref={ref} value="">
@@ -2796,27 +2677,28 @@ describe('MentionsInput', () => {
 
       const instance = ref.current as unknown as any
       const updateSpy = jest.spyOn(instance, 'updateHighlighterScroll').mockImplementation(() => {})
+      const flushSpy = jest.spyOn(instance, 'flushPendingViewSync')
       const raf = jest
         .spyOn(globalThis, 'requestAnimationFrame')
         .mockImplementation((cb: FrameRequestCallback) => {
           cb(0)
           return 1
         })
-      const cancel = jest.spyOn(globalThis, 'cancelAnimationFrame').mockImplementation(() => {})
 
       act(() => {
         instance.requestHighlighterScrollSync()
       })
 
-      expect(updateSpy).toHaveBeenCalledTimes(2)
+      expect(updateSpy).toHaveBeenCalledTimes(1)
+      expect(flushSpy).toHaveBeenCalledTimes(1)
 
+      flushSpy.mockRestore()
       updateSpy.mockRestore()
       raf.mockRestore()
-      cancel.mockRestore()
       unmount()
     })
 
-    it('cancels a pending scroll sync frame before scheduling a new one', () => {
+    it('coalesces repeated queued view sync requests into one frame', () => {
       const ref = React.createRef<MentionsInput>()
       const { unmount } = render(
         <MentionsInput ref={ref} value="">
@@ -2825,19 +2707,21 @@ describe('MentionsInput', () => {
       )
 
       const instance = ref.current as unknown as any
-      instance._scrollSyncFrame = 7
-
-      const cancel = jest.spyOn(globalThis, 'cancelAnimationFrame').mockImplementation(() => {})
       const raf = jest.spyOn(globalThis, 'requestAnimationFrame').mockImplementation(() => 9)
 
       act(() => {
         instance.requestHighlighterScrollSync()
+        instance.requestViewSync({ measureSuggestions: true })
       })
 
-      expect(cancel).toHaveBeenCalledWith(7)
       expect(instance._scrollSyncFrame).toBe(9)
+      expect(raf).toHaveBeenCalledTimes(1)
+      expect(instance._pendingViewSync).toMatchObject({
+        syncScroll: true,
+        measureSuggestions: true,
+        measureInline: true,
+      })
 
-      cancel.mockRestore()
       raf.mockRestore()
       unmount()
     })

--- a/src/MentionsInput.tsx
+++ b/src/MentionsInput.tsx
@@ -7,11 +7,41 @@ import type {
   MouseEvent as ReactMouseEvent,
   SyntheticEvent,
 } from 'react'
-import React, { useLayoutEffect } from 'react'
+import React from 'react'
 import { cva } from 'class-variance-authority'
 import { createPortal } from 'react-dom'
 import Highlighter from './Highlighter'
+import MeasurementBridge from './MeasurementBridge'
 import { DEFAULT_MENTION_PROPS } from './MentionDefaultProps'
+import {
+  applyHighlighterViewPatch,
+  applyTextareaResizePatch,
+  areInlineSuggestionPositionsEqual,
+  areSuggestionsPositionsEqual,
+  calculateInlineSuggestionPosition,
+  calculateSuggestionsPosition,
+  createPendingViewSync,
+  createViewSyncPatch,
+  getHighlighterViewPatch,
+  getInputInlineStyle,
+  getTextareaResizePatch,
+  hasPendingViewSync,
+  mergePendingViewSync,
+} from './MentionsInputLayout'
+import type { PendingViewSync, ViewSyncPatch } from './MentionsInputLayout'
+import {
+  getDataProvider,
+  getFocusedSuggestionEntry,
+  getInlineSuggestionAnnouncement,
+  getInlineSuggestionDetails,
+  getMentionChild,
+  getMentionChildren,
+  getSuggestionData,
+  getSuggestionQueryStateEntries,
+  getSuggestionsStatusContent,
+} from './MentionsInputSelectors'
+import type { InlineSuggestionDetails } from './MentionsInputSelectors'
+import MentionsInputView from './MentionsInputView'
 import SuggestionsOverlay from './SuggestionsOverlay'
 import {
   applyChangeToValue,
@@ -23,7 +53,6 @@ import {
   getSubstringIndex,
   getSuggestionHtmlId,
   isNumber,
-  flattenSuggestions,
   mapPlainTextIndex,
   omit,
   spliceString,
@@ -32,23 +61,18 @@ import {
 import { areMentionSelectionsEqual } from './utils/areMentionSelectionsEqual'
 import { isMentionElement } from './utils/isMentionElement'
 import { makeTriggerRegex } from './utils/makeTriggerRegex'
-import readConfigFromChildren, { collectMentionElements } from './utils/readConfigFromChildren'
-import { useEventCallback } from './utils/useEventCallback'
+import readConfigFromChildren from './utils/readConfigFromChildren'
 import type {
   CaretCoordinates,
-  DataSource,
-  InlineSuggestionPosition,
   InputComponentProps,
   MentionComponentProps,
   MentionDataItem,
   MentionIdentifier,
   MentionOccurrence,
-  MentionSearchContext,
   MentionSelection,
   MentionSelectionState,
   MentionChildConfig,
   MentionsInputProps,
-  MentionsInputAnchorMode,
   MentionsInputState,
   MentionsInputClassNames,
   MentionsInputChangeTrigger,
@@ -57,57 +81,8 @@ import type {
   SuggestionQueryState,
   SuggestionQueryStateMap,
   SuggestionsMap,
-  SuggestionsPosition,
   InputElement,
 } from './types'
-import type { FlattenedSuggestion } from './utils/flattenSuggestions'
-
-const getDataProvider = <Extra extends Record<string, unknown>>(
-  data: DataSource<Extra>,
-  options: {
-    ignoreAccents: boolean
-    maxSuggestions?: number
-    signal: AbortSignal
-  }
-): ((query: string) => Promise<MentionDataItem<Extra>[]>) => {
-  const { ignoreAccents, maxSuggestions, signal } = options
-  const applyMaxSuggestions = (
-    items: ReadonlyArray<MentionDataItem<Extra>>
-  ): MentionDataItem<Extra>[] =>
-    maxSuggestions === undefined ? [...items] : [...items.slice(0, maxSuggestions)]
-
-  if (Array.isArray(data)) {
-    const items = data as ReadonlyArray<MentionDataItem<Extra>>
-    // eslint-disable-next-line @typescript-eslint/require-await
-    return async (query: string) =>
-      applyMaxSuggestions(
-        items.flatMap((item) => {
-          if (signal.aborted) {
-            return []
-          }
-
-          const index = getSubstringIndex(item.display || String(item.id), query, ignoreAccents)
-          return index >= 0
-            ? [
-                {
-                  ...item,
-                  highlights: [{ start: index, end: index + query.length }],
-                },
-              ]
-            : []
-        })
-      )
-  }
-
-  return async (query: string) => {
-    const provider = data as (
-      query: string,
-      context: MentionSearchContext
-    ) => Promise<ReadonlyArray<MentionDataItem<Extra>>> | ReadonlyArray<MentionDataItem<Extra>>
-    const result = await Promise.resolve(provider(query, { signal }))
-    return applyMaxSuggestions(result)
-  }
-}
 
 let generatedIdCounter = 0
 
@@ -127,26 +102,6 @@ const isAbortError = (error: unknown): boolean =>
       error !== null &&
       'name' in error &&
       (error as { name?: string }).name === 'AbortError'
-
-const DEFAULT_EMPTY_SUGGESTIONS_MESSAGE = 'No suggestions found'
-const DEFAULT_ERROR_SUGGESTIONS_MESSAGE = 'Unable to load suggestions'
-
-const getMentionChildren = <Extra extends Record<string, unknown>>(children: React.ReactNode) =>
-  collectMentionElements<Extra>(children)
-
-const getMentionChild = <Extra extends Record<string, unknown>>(
-  children: React.ReactNode,
-  childIndex: number
-): React.ReactElement<MentionComponentProps<Extra>> | undefined =>
-  getMentionChildren<Extra>(children)[childIndex]
-
-const getSuggestionQueryStateEntries = <Extra extends Record<string, unknown>>(
-  queryStates: SuggestionQueryStateMap<Extra>
-): ReadonlyArray<readonly [number, SuggestionQueryState<Extra>]> =>
-  Object.entries(queryStates)
-    .map(([key, value]) => [Number(key), value] as const)
-    .filter(([key]) => Number.isInteger(key))
-    .toSorted(([left], [right]) => left - right)
 
 const KEY = {
   TAB: 'Tab',
@@ -225,16 +180,6 @@ interface MentionSelectionComputation<Extra extends Record<string, unknown>> {
   selectionMap: Record<string, MentionSelectionState>
 }
 
-interface InlineSuggestionDetails<Extra extends Record<string, unknown> = Record<string, unknown>> {
-  hiddenPrefix: string
-  visibleText: string
-  queryInfo: QueryInfo
-  suggestion: SuggestionDataItem<Extra>
-  announcement: string
-}
-
-const INLINE_AUTOCOMPLETE_FALLBACK_ANNOUNCEMENT = 'No inline suggestions available'
-
 const visuallyHiddenStyles: CSSProperties = {
   position: 'absolute',
   width: 1,
@@ -305,6 +250,8 @@ class MentionsInput<
   private _scrollSyncFrame: number | null = null
   private _autoResizeFrame: number | null = null
   private _cachedMarkupValue = ''
+  private _pendingViewSync: PendingViewSync = createPendingViewSync()
+  private _isFlushingViewSync = false
   private readonly _queryDebounceTimers = new Map<number, ReturnType<typeof setTimeout>>()
   private readonly _queryAbortControllers = new Map<number, AbortController>()
 
@@ -330,6 +277,38 @@ class MentionsInput<
       controller.abort()
     }
     this._queryAbortControllers.clear()
+  }
+
+  requestViewSync = (
+    flags: Partial<PendingViewSync>,
+    options: {
+      flushNow?: boolean
+    } = {}
+  ): void => {
+    this._pendingViewSync = mergePendingViewSync(this._pendingViewSync, flags)
+
+    if (!hasPendingViewSync(this._pendingViewSync)) {
+      return
+    }
+
+    if (options.flushNow) {
+      this.flushPendingViewSync()
+      return
+    }
+
+    if (globalThis.window === undefined || typeof globalThis.requestAnimationFrame !== 'function') {
+      this.flushPendingViewSync()
+      return
+    }
+
+    if (this._scrollSyncFrame !== null) {
+      return
+    }
+
+    this._scrollSyncFrame = globalThis.requestAnimationFrame(() => {
+      this._scrollSyncFrame = null
+      this.flushPendingViewSync()
+    })
   }
 
   private ensureGeneratedId(): void {
@@ -429,6 +408,52 @@ class MentionsInput<
     return this.defaultSuggestionsPortalHost
   }
 
+  flushPendingViewSync = (): ViewSyncPatch => {
+    if (this._didUnmount || this._isFlushingViewSync || !hasPendingViewSync(this._pendingViewSync)) {
+      return createViewSyncPatch()
+    }
+
+    if (this._scrollSyncFrame !== null) {
+      this.cancelScheduledFrame('_scrollSyncFrame')
+    }
+
+    this._isFlushingViewSync = true
+    const pendingViewSync = this._pendingViewSync
+    this._pendingViewSync = createPendingViewSync()
+    const patch = createViewSyncPatch()
+
+    if (pendingViewSync.restoreSelection && this.state.pendingSelectionUpdate) {
+      this.setState({ pendingSelectionUpdate: false })
+      this.setSelection(this.state.selectionStart, this.state.selectionEnd)
+      patch.restoredSelection = true
+    }
+
+    let layoutDidChange = false
+
+    if (pendingViewSync.syncScroll) {
+      patch.syncedScroll = true
+      layoutDidChange = this.updateHighlighterScroll() || layoutDidChange
+      layoutDidChange = this.resetTextareaHeight() || layoutDidChange
+    }
+
+    if (pendingViewSync.measureSuggestions) {
+      patch.measuredSuggestions = this.updateSuggestionsPosition()
+    }
+
+    if (pendingViewSync.measureInline) {
+      patch.measuredInline = this.updateInlineSuggestionPosition()
+    }
+
+    if (pendingViewSync.recomputeHighlighter || layoutDidChange) {
+      this.scheduleHighlighterRecompute()
+      patch.recomputedHighlighter = true
+    }
+
+    this._isFlushingViewSync = false
+
+    return patch
+  }
+
   constructor(props: MentionsInputProps<Extra>) {
     super(props)
     this.defaultSuggestionsPortalHost = typeof document === 'undefined' ? null : document.body
@@ -522,14 +547,14 @@ class MentionsInput<
     document.addEventListener('scroll', this.handleDocumentScroll, true)
     document.addEventListener('selectionchange', this.handleDocumentSelectionChange)
 
-    this.updateSuggestionsPosition()
-    this.updateInlineSuggestionPosition()
-
-    this.resetTextareaHeight()
-
-    if (this.inputElement && this.highlighterElement) {
-      mirrorInputTypographicStyles(this.inputElement, this.highlighterElement)
-    }
+    this.requestViewSync(
+      {
+        syncScroll: true,
+        measureSuggestions: true,
+        measureInline: true,
+      },
+      { flushNow: true }
+    )
   }
 
   // eslint-disable-next-line code-complete/low-function-cohesion
@@ -537,32 +562,8 @@ class MentionsInput<
     prevProps: MentionsInputProps<Extra>,
     prevState: MentionsInputState<Extra>
   ): void {
-    // Validate children if they've changed
     if (prevProps.children !== this.props.children) {
       this.validateChildren()
-    }
-
-    // Update position of suggestions unless this componentDidUpdate was
-    // triggered by an update to suggestionsPosition.
-    if (prevState.suggestionsPosition === this.state.suggestionsPosition) {
-      this.updateSuggestionsPosition()
-    }
-
-    if (
-      prevState.inlineSuggestionPosition === this.state.inlineSuggestionPosition &&
-      (this.isInlineAutocomplete() ||
-        prevState.caretPosition !== this.state.caretPosition ||
-        prevProps.value !== this.props.value ||
-        prevState.generatedId !== this.state.generatedId)
-    ) {
-      this.updateInlineSuggestionPosition()
-    }
-
-    // maintain selection in case a mention is added/removed causing
-    // the cursor to jump to the end
-    if (this.state.pendingSelectionUpdate) {
-      this.setState({ pendingSelectionUpdate: false })
-      this.setSelection(this.state.selectionStart, this.state.selectionEnd)
     }
 
     const selectionPositionsChanged =
@@ -574,14 +575,8 @@ class MentionsInput<
     const configChanged = this.state.config !== prevState.config
     const valueChanged = currentValue !== previousValue || configChanged
 
-    if (this.getExplicitId() === null && prevState.generatedId !== this.state.generatedId) {
-      this.updateSuggestionsPosition()
-    } else if (this.getExplicitId() === null && this.state.generatedId === null) {
+    if (this.getExplicitId() === null && this.state.generatedId === null) {
       this.ensureGeneratedId()
-    }
-
-    if (valueChanged || prevProps.autoResize !== this.props.autoResize) {
-      this.resetTextareaHeight()
     }
 
     const recalculatedMentions = valueChanged
@@ -614,6 +609,37 @@ class MentionsInput<
     if (valueChanged) {
       this._cachedMarkupValue = currentValue
     }
+
+    if (this.state.pendingSelectionUpdate) {
+      this.requestViewSync({ restoreSelection: true })
+    }
+
+    if (valueChanged || prevProps.autoResize !== this.props.autoResize) {
+      this.requestViewSync({
+        syncScroll: true,
+        measureSuggestions: true,
+        measureInline: true,
+      })
+    }
+
+    if (selectionPositionsChanged) {
+      this.requestViewSync({
+        measureSuggestions: true,
+        measureInline: true,
+      })
+    }
+
+    if (
+      prevState.generatedId !== this.state.generatedId ||
+      prevState.caretPosition !== this.state.caretPosition
+    ) {
+      this.requestViewSync({
+        measureSuggestions: true,
+        measureInline: true,
+      })
+    }
+
+    this.flushPendingViewSync()
 
     if (selectionPositionsChanged || valueChanged) {
       const currentSelection = this.computeMentionSelectionDetails(
@@ -670,20 +696,21 @@ class MentionsInput<
   render(): React.ReactNode {
     const { className, style, singleLine } = this.props
     const rootClassName = cn(rootStyles(), className)
+
     return (
-      <div
-        ref={this.setContainerElement}
-        className={rootClassName}
+      <MentionsInputView
+        rootRef={this.setContainerElement}
+        rootClassName={rootClassName}
         style={style}
-        data-single-line={
-          (singleLine ?? MentionsInput.defaultProps.singleLine) ? 'true' : undefined
-        }
-        data-multi-line={(singleLine ?? MentionsInput.defaultProps.singleLine) ? undefined : 'true'}
-      >
-        {this.renderControl()}
-        {this.renderSuggestionsOverlay()}
-        {this.renderMeasurementBridge()}
-      </div>
+        singleLine={singleLine ?? MentionsInput.defaultProps.singleLine}
+        controlClassName={this.getSlotClassName('control', controlStyles())}
+        highlighter={this.renderHighlighter()}
+        input={this.renderInputControl()}
+        inlineSuggestion={this.renderInlineSuggestion()}
+        inlineSuggestionLiveRegion={this.renderInlineSuggestionLiveRegion()}
+        suggestionsOverlay={this.renderSuggestionsOverlay()}
+        measurementBridge={this.renderMeasurementBridge()}
+      />
     )
   }
 
@@ -708,20 +735,13 @@ class MentionsInput<
       ...restPassthrough,
       className: baseClassName,
       value: getPlainText(this.props.value ?? '', this.state.config),
-      onScroll: this.updateHighlighterScroll,
+      onScroll: this.handleInputScroll,
       'data-slot': 'input',
       'data-single-line': singleLine ? 'true' : undefined,
       'data-multi-line': singleLine ? undefined : 'true',
     }
 
-    const inlineStyle: CSSProperties = {
-      background: 'transparent',
-    }
-
-    if (!singleLine && isMobileSafari()) {
-      inlineStyle.marginTop = 1
-      inlineStyle.marginLeft = -3
-    }
+    const inlineStyle = getInputInlineStyle(singleLine)
 
     if (Object.keys(inlineStyle).length > 0) {
       props.style = inlineStyle
@@ -768,26 +788,16 @@ class MentionsInput<
     return props as InputComponentProps
   }
 
-  renderControl = (): React.ReactElement => {
+  renderInputControl = (): React.ReactElement => {
     const { singleLine, inputComponent: CustomInput } = this.props
     const inputProps = this.getInputProps()
-    const controlClassName = this.getSlotClassName('control', controlStyles())
 
-    const control = CustomInput ? (
+    return CustomInput ? (
       <CustomInput ref={this.setInputRef} {...inputProps} />
     ) : singleLine ? (
       this.renderInput(inputProps)
     ) : (
       this.renderTextarea(inputProps)
-    )
-
-    return (
-      <div className={controlClassName} data-slot="control">
-        {this.renderHighlighter()}
-        {control}
-        {this.renderInlineSuggestion()}
-        {this.renderInlineSuggestionLiveRegion()}
-      </div>
     )
   }
 
@@ -810,57 +820,32 @@ class MentionsInput<
   }
 
   // eslint-disable-next-line code-complete/low-function-cohesion
-  private readonly resetTextareaHeight = (): void => {
+  private readonly resetTextareaHeight = (): boolean => {
     const hasTextarea =
       typeof HTMLTextAreaElement !== 'undefined' && this.inputElement instanceof HTMLTextAreaElement
 
-    // When disabled or in single-line mode, clear any previously applied inline sizing.
-    if (this.props.singleLine === true || this.props.autoResize !== true) {
-      if (hasTextarea) {
-        this.inputElement!.style.height = ''
-        this.inputElement!.style.overflowY = ''
-      }
+    if (!hasTextarea) {
+      return false
+    }
+
+    const resizePatch = getTextareaResizePatch(this.inputElement, {
+      singleLine: this.props.singleLine,
+      autoResize: this.props.autoResize,
+    })
+    const didUpdate = applyTextareaResizePatch(this.inputElement, resizePatch)
+
+    if (
+      this.props.singleLine === true ||
+      this.props.autoResize !== true ||
+      globalThis.window === undefined ||
+      typeof globalThis.requestAnimationFrame !== 'function'
+    ) {
       if (this._autoResizeFrame !== null && typeof globalThis.cancelAnimationFrame === 'function') {
         globalThis.cancelAnimationFrame(this._autoResizeFrame)
         this._autoResizeFrame = null
       }
-      return
-    }
 
-    // eslint-disable-next-line code-complete/low-function-cohesion
-    const measure = () => {
-      const element = this.inputElement
-      if (
-        !element ||
-        typeof HTMLTextAreaElement === 'undefined' ||
-        !(element instanceof HTMLTextAreaElement)
-      ) {
-        return
-      }
-
-      element.style.height = 'auto'
-      element.style.overflowY = 'hidden'
-
-      let borderAdjustment = 0
-      if (globalThis.window !== undefined && typeof globalThis.getComputedStyle === 'function') {
-        const computed = globalThis.getComputedStyle(element)
-        const parse = (value: string | null | undefined) =>
-          value ? Number.parseFloat(value) || 0 : 0
-        borderAdjustment = parse(computed.borderTopWidth) + parse(computed.borderBottomWidth)
-      }
-
-      const nextHeight = element.scrollHeight + borderAdjustment
-      element.style.height = `${nextHeight}px`
-    }
-
-    measure()
-
-    if (
-      !hasTextarea ||
-      globalThis.window === undefined ||
-      typeof globalThis.requestAnimationFrame !== 'function'
-    ) {
-      return
+      return didUpdate
     }
 
     if (this._autoResizeFrame !== null && typeof globalThis.cancelAnimationFrame === 'function') {
@@ -869,8 +854,16 @@ class MentionsInput<
 
     this._autoResizeFrame = globalThis.requestAnimationFrame(() => {
       this._autoResizeFrame = null
-      measure()
+      applyTextareaResizePatch(
+        this.inputElement,
+        getTextareaResizePatch(this.inputElement, {
+          singleLine: this.props.singleLine,
+          autoResize: this.props.autoResize,
+        })
+      )
     })
+
+    return didUpdate
   }
 
   setSuggestionsElement = (el: HTMLDivElement | null) => {
@@ -990,7 +983,10 @@ class MentionsInput<
     }
 
     const inlineSuggestion = this.getInlineSuggestionDetails()
-    const announcement = this.getInlineSuggestionAnnouncement(inlineSuggestion)
+    const announcement = getInlineSuggestionAnnouncement(
+      inlineSuggestion,
+      this.getSuggestionsStatusContent()
+    )
     const liveRegionId = this.getInlineAutocompleteLiveRegionId()
 
     return (
@@ -1007,21 +1003,6 @@ class MentionsInput<
     )
   }
 
-  private readonly getInlineSuggestionAnnouncement = (
-    inlineSuggestion: InlineSuggestionDetails<Extra> | null
-  ): string => {
-    if (!inlineSuggestion) {
-      const { statusContent, statusType } = this.getSuggestionsStatusContent()
-      if (statusType !== null && typeof statusContent === 'string') {
-        return statusContent
-      }
-
-      return INLINE_AUTOCOMPLETE_FALLBACK_ANNOUNCEMENT
-    }
-
-    return inlineSuggestion.announcement
-  }
-
   renderMeasurementBridge = (): React.ReactNode => {
     return (
       <MeasurementBridge
@@ -1029,9 +1010,7 @@ class MentionsInput<
         highlighter={this.highlighterElement}
         input={this.inputElement}
         suggestions={this.suggestionsElement}
-        onSyncScroll={this.updateHighlighterScroll}
-        onUpdateInlineSuggestionPosition={this.updateInlineSuggestionPosition}
-        onUpdateSuggestionsPosition={this.updateSuggestionsPosition}
+        requestViewSync={this.requestViewSync}
       />
     )
   }
@@ -1063,56 +1042,34 @@ class MentionsInput<
     this.highlighterElement = el
   }
 
-  updateInlineSuggestionPosition = (): void => {
+  updateInlineSuggestionPosition = (): boolean => {
     if (!this.isInlineAutocomplete()) {
-      if (this.state.inlineSuggestionPosition !== null) {
-        this.setState({ inlineSuggestionPosition: null })
+      if (this.state.inlineSuggestionPosition === null) {
+        return false
       }
-      return
+
+      this.setState({ inlineSuggestionPosition: null })
+      return true
     }
 
-    const inlineSuggestion = this.getInlineSuggestionDetails()
-    const highlighter = this.highlighterElement
-    if (!inlineSuggestion || !highlighter) {
-      if (this.state.inlineSuggestionPosition !== null) {
-        this.setState({ inlineSuggestionPosition: null })
-      }
-      return
-    }
+    const nextPosition = this.getInlineSuggestionDetails()
+      ? calculateInlineSuggestionPosition({ highlighter: this.highlighterElement })
+      : null
 
-    const caretElement = highlighter.querySelector<HTMLSpanElement>('[data-mentions-caret]')
-    const controlElement = highlighter.parentElement
-    const controlRect = controlElement?.getBoundingClientRect()
-    const caretRect = caretElement?.getBoundingClientRect()
-
-    if (!caretRect || !controlRect) {
-      if (this.state.inlineSuggestionPosition !== null) {
-        this.setState({ inlineSuggestionPosition: null })
-      }
-      return
-    }
-
-    const nextPosition: InlineSuggestionPosition = {
-      left: caretRect.left - controlRect.left,
-      top: caretRect.top - controlRect.top,
-    }
-    const previousPosition = this.state.inlineSuggestionPosition
-
-    if (previousPosition?.left === nextPosition.left && previousPosition.top === nextPosition.top) {
-      return
+    if (areInlineSuggestionPositionsEqual(this.state.inlineSuggestionPosition, nextPosition)) {
+      return false
     }
 
     this.setState({ inlineSuggestionPosition: nextPosition })
+    return true
   }
 
   handleCaretPositionChange = (position: CaretCoordinates | null) => {
-    this.setState({ caretPosition: position }, () => {
-      if (position) {
-        this.updateSuggestionsPosition()
-      }
-      this.updateInlineSuggestionPosition()
+    this.setState({ caretPosition: position })
+    this.requestViewSync({
+      measureSuggestions: true,
+      measureInline: true,
     })
-    this.scheduleHighlighterRecompute()
   }
 
   scheduleHighlighterRecompute = (): void => {
@@ -1142,101 +1099,20 @@ class MentionsInput<
 
   isInlineAutocomplete = (): boolean => this.props.suggestionsDisplay === 'inline'
 
-  getFlattenedSuggestions = (): FlattenedSuggestion<Extra>[] => {
-    return flattenSuggestions<Extra>(this.getMentionChildren(), this.state.suggestions)
-  }
+  getFocusedSuggestionEntry = () =>
+    getFocusedSuggestionEntry<Extra>(this.props.children, this.state.suggestions, this.state.focusIndex)
 
-  getFocusedSuggestionEntry = (): {
-    result: SuggestionDataItem<Extra>
-    queryInfo: QueryInfo
-  } | null => {
-    const flattened = this.getFlattenedSuggestions()
-    if (flattened.length === 0) {
-      return null
-    }
-    return flattened[this.state.focusIndex] ?? flattened[0]
-  }
+  getSuggestionData = (suggestion: SuggestionDataItem<Extra>) => getSuggestionData(suggestion)
 
-  getSuggestionData = (
-    suggestion: SuggestionDataItem<Extra>
-  ): {
-    id: MentionIdentifier
-    display: string
-  } => {
-    if (typeof suggestion === 'string') {
-      return { id: suggestion, display: suggestion }
-    }
-    return {
-      id: suggestion.id,
-      display: suggestion.display ?? String(suggestion.id),
-    }
-  }
+  getInlineSuggestionDetails = (): InlineSuggestionDetails<Extra> | null =>
+    this.isInlineAutocomplete()
+      ? getInlineSuggestionDetails<Extra>(
+          this.props.children,
+          this.state.suggestions,
+          this.state.focusIndex
+        )
+      : null
 
-  // eslint-disable-next-line code-complete/low-function-cohesion
-  getInlineSuggestionDetails = (): InlineSuggestionDetails<Extra> | null => {
-    if (!this.isInlineAutocomplete()) {
-      return null
-    }
-
-    const entry = this.getFocusedSuggestionEntry()
-    if (!entry) {
-      return null
-    }
-
-    const { queryInfo, result } = entry
-    const mentionChild = getMentionChild<Extra>(this.props.children, queryInfo.childIndex)
-
-    if (!mentionChild) {
-      return null
-    }
-
-    const {
-      displayTransform = DEFAULT_MENTION_PROPS.displayTransform,
-      appendSpaceOnAdd = DEFAULT_MENTION_PROPS.appendSpaceOnAdd,
-    } = mentionChild.props
-
-    const { id, display } = this.getSuggestionData(result)
-    let displayValue = displayTransform(id, display)
-    if (appendSpaceOnAdd) {
-      displayValue += ' '
-    }
-
-    const visibleText = this.getInlineSuggestionRemainder(displayValue, queryInfo)
-
-    if (!visibleText) {
-      return null
-    }
-
-    const hiddenPrefixLength = displayValue.length - visibleText.length
-    const hiddenPrefix = hiddenPrefixLength > 0 ? displayValue.slice(0, hiddenPrefixLength) : ''
-    const announcement = displayValue.trimEnd()
-
-    return {
-      hiddenPrefix,
-      visibleText,
-      queryInfo,
-      suggestion: result,
-      announcement: announcement.length > 0 ? announcement : displayValue,
-    }
-  }
-
-  getInlineSuggestionRemainder = (displayValue: string, queryInfo: QueryInfo): string => {
-    const query = queryInfo.query ?? ''
-    if (query.length === 0) {
-      return displayValue
-    }
-
-    const normalizedDisplay = displayValue.toLocaleLowerCase()
-    const normalizedQuery = query.toLocaleLowerCase()
-
-    if (normalizedDisplay.startsWith(normalizedQuery)) {
-      return displayValue.slice(query.length)
-    }
-
-    return displayValue
-  }
-
-  // eslint-disable-next-line code-complete/low-function-cohesion
   canApplyInlineSuggestion = (): boolean => {
     if (!this.isInlineAutocomplete()) {
       return false
@@ -1260,71 +1136,12 @@ class MentionsInput<
     return entries[0]?.[1] ?? null
   }
 
-  getSuggestionsStatusContent(): {
-    statusContent: React.ReactNode
-    statusType: 'empty' | 'error' | null
-  } {
-    if (countSuggestions(this.state.suggestions) > 0) {
-      return { statusContent: null, statusType: null }
-    }
-
-    const preferredQueryState = this.getPreferredQueryState()
-    if (!preferredQueryState || preferredQueryState.status === 'loading') {
-      return { statusContent: null, statusType: null }
-    }
-
-    const mentionChild = getMentionChild<Extra>(
+  getSuggestionsStatusContent = () =>
+    getSuggestionsStatusContent<Extra>(
       this.props.children,
-      preferredQueryState.queryInfo.childIndex
+      this.state.suggestions,
+      this.state.queryStates
     )
-    if (!mentionChild) {
-      return { statusContent: null, statusType: null }
-    }
-
-    if (preferredQueryState.status === 'error') {
-      const renderError =
-        mentionChild.props.renderError ?? DEFAULT_MENTION_PROPS.renderError ?? null
-      if (!renderError) {
-        return {
-          statusContent: DEFAULT_ERROR_SUGGESTIONS_MESSAGE,
-          statusType: 'error',
-        }
-      }
-
-      const statusContent = renderError(
-        preferredQueryState.queryInfo.query,
-        preferredQueryState.error
-      )
-      if (statusContent === null || statusContent === false) {
-        return { statusContent: null, statusType: null }
-      }
-
-      return {
-        statusContent:
-          statusContent === undefined ? DEFAULT_ERROR_SUGGESTIONS_MESSAGE : statusContent,
-        statusType: 'error',
-      }
-    }
-
-    const renderEmpty = mentionChild.props.renderEmpty ?? DEFAULT_MENTION_PROPS.renderEmpty ?? null
-    if (!renderEmpty) {
-      return {
-        statusContent: DEFAULT_EMPTY_SUGGESTIONS_MESSAGE,
-        statusType: 'empty',
-      }
-    }
-
-    const statusContent = renderEmpty(preferredQueryState.queryInfo.query)
-    if (statusContent === null || statusContent === false) {
-      return { statusContent: null, statusType: null }
-    }
-
-    return {
-      statusContent:
-        statusContent === undefined ? DEFAULT_EMPTY_SUGGESTIONS_MESSAGE : statusContent,
-      statusType: 'empty',
-    }
-  }
 
   // eslint-disable-next-line code-complete/low-function-cohesion
   private readonly computeMentionSelectionDetails = (
@@ -1697,6 +1514,17 @@ class MentionsInput<
     this.props.onSelect?.(ev)
   }
 
+  handleInputScroll = (): void => {
+    this.requestViewSync(
+      {
+        syncScroll: true,
+        measureSuggestions: true,
+        measureInline: true,
+      },
+      { flushNow: true }
+    )
+  }
+
   // eslint-disable-next-line code-complete/low-function-cohesion
   private readonly syncSelectionFromInput = (
     reason: 'select' | 'selectionchange' = 'selectionchange'
@@ -1871,179 +1699,55 @@ class MentionsInput<
   }
 
   // eslint-disable-next-line code-complete/low-function-cohesion, sonarjs/cognitive-complexity
-  updateSuggestionsPosition = (): void => {
-    const { caretPosition } = this.state
-    const { suggestionsPlacement = 'below' } = this.props
-    const anchorMode: MentionsInputAnchorMode = this.props.anchorMode ?? 'caret'
-    const anchorToLeft = anchorMode === 'left'
-    const resolvedPortalHost = this.resolvePortalHost()
+  updateSuggestionsPosition = (): boolean => {
+    const position =
+      calculateSuggestionsPosition({
+        caretPosition: this.state.caretPosition,
+        suggestionsPlacement: this.props.suggestionsPlacement ?? 'below',
+        anchorMode: this.props.anchorMode ?? 'caret',
+        resolvedPortalHost: this.resolvePortalHost(),
+        suggestions: this.suggestionsElement,
+        highlighter: this.highlighterElement,
+        container: this.containerElement,
+      }) ?? {}
 
-    const suggestions = this.suggestionsElement
-    const highlighter = this.highlighterElement
-    const container = this.containerElement
-
-    if (!caretPosition || !suggestions || !highlighter || !container) {
-      return
+    if (areSuggestionsPositionsEqual(position, this.state.suggestionsPosition)) {
+      return false
     }
 
-    // first get viewport-relative position (highlighter is offsetParent of caret):
-    const caretOffsetParentRect = highlighter.getBoundingClientRect()
-    const caretHeight = getComputedStyleLengthProp(highlighter, 'font-size')
-    const viewportRelative = {
-      left: caretOffsetParentRect.left + (anchorToLeft ? 0 : caretPosition.left),
-      top: caretOffsetParentRect.top + caretPosition.top,
-    }
-    const viewportHeight = Math.max(document.documentElement.clientHeight, window.innerHeight || 0)
-    const desiredWidth = highlighter.offsetWidth
-
-    const position: SuggestionsPosition = {}
-
-    // if suggestions menu is in a portal, update position to be relative to its portal node
-    if (resolvedPortalHost) {
-      const viewportWidth = Math.max(document.documentElement.clientWidth, window.innerWidth || 0)
-      const width = Math.min(desiredWidth, viewportWidth)
-      position.width = width
-      position.position = 'fixed'
-      let { left, top } = viewportRelative
-      // absolute/fixed positioned elements are positioned according to their entire box including margins; so we remove margins here:
-      left -= getComputedStyleLengthProp(suggestions, 'margin-left')
-      top -= getComputedStyleLengthProp(suggestions, 'margin-top')
-      // take into account highlighter/textinput scrolling:
-      if (!anchorToLeft) {
-        left -= highlighter.scrollLeft
-      }
-      top -= highlighter.scrollTop
-      // guard for mentions suggestions list clipped by window edges
-      const maxLeft = Math.max(0, viewportWidth - width)
-      position.left = Math.min(maxLeft, Math.max(0, left))
-      const shouldShowAboveCaret =
-        suggestionsPlacement === 'above' ||
-        (suggestionsPlacement === 'auto' &&
-          top + suggestions.offsetHeight > viewportHeight &&
-          suggestions.offsetHeight < top - caretHeight)
-
-      // guard for mentions suggestions list clipped by the bottom edge of the window when using automatic placement.
-      position.top = shouldShowAboveCaret
-        ? Math.max(0, top - suggestions.offsetHeight - caretHeight)
-        : top
-    } else {
-      const containerWidth = container.offsetWidth
-      const width = Math.min(desiredWidth, containerWidth)
-      position.width = width
-      const left = anchorToLeft ? 0 : caretPosition.left - highlighter.scrollLeft
-      const top = caretPosition.top - highlighter.scrollTop
-      // guard for mentions suggestions list clipped by right edge of window
-      if (anchorToLeft) {
-        position.left = 0
-      } else if (left + width > containerWidth) {
-        position.right = 0
-      } else {
-        position.left = left
-      }
-      const shouldShowAboveCaret =
-        suggestionsPlacement === 'above' ||
-        (suggestionsPlacement === 'auto' &&
-          viewportRelative.top - highlighter.scrollTop + suggestions.offsetHeight >
-            viewportHeight &&
-          suggestions.offsetHeight <
-            caretOffsetParentRect.top - caretHeight - highlighter.scrollTop)
-
-      // guard for mentions suggestions list clipped by the bottom edge of the container when using automatic placement.
-      position.top = shouldShowAboveCaret ? top - suggestions.offsetHeight - caretHeight : top
-    }
-
-    if (
-      position.left === this.state.suggestionsPosition.left &&
-      position.top === this.state.suggestionsPosition.top &&
-      position.position === this.state.suggestionsPosition.position &&
-      position.width === this.state.suggestionsPosition.width &&
-      position.right === this.state.suggestionsPosition.right
-    ) {
-      return
-    }
     this.setState({
       suggestionsPosition: position,
     })
+
+    return true
   }
 
   // eslint-disable-next-line code-complete/low-function-cohesion
-  updateHighlighterScroll = (): void => {
-    const input = this.inputElement
-    const highlighter = this.highlighterElement
-    if (!input || !highlighter) {
-      // since the invocation of this function is deferred,
-      // the whole component may have been unmounted in the meanwhile
-      return
-    }
-
-    const nextScrollLeft = input.scrollLeft
-    const nextScrollTop = input.scrollTop
-    const prevScrollLeft = highlighter.scrollLeft
-    const prevScrollTop = highlighter.scrollTop
-
-    if (prevScrollLeft !== nextScrollLeft) {
-      highlighter.scrollLeft = nextScrollLeft
-    }
-    if (prevScrollTop !== nextScrollTop) {
-      highlighter.scrollTop = nextScrollTop
-    }
-    const inputHeight = input.clientHeight
-    let heightChanged = false
-    if (inputHeight) {
-      const nextHeight = `${inputHeight}px`
-      if (highlighter.style.height !== nextHeight) {
-        highlighter.style.height = nextHeight
-        heightChanged = true
-      }
-    }
-
-    const typographyUpdated = mirrorInputTypographicStyles(input, highlighter)
-
-    if (
-      prevScrollLeft !== nextScrollLeft ||
-      prevScrollTop !== nextScrollTop ||
-      heightChanged ||
-      typographyUpdated
-    ) {
-      this.updateInlineSuggestionPosition()
-      this.scheduleHighlighterRecompute()
-    }
-  }
+  updateHighlighterScroll = (): boolean =>
+    applyHighlighterViewPatch(
+      this.highlighterElement,
+      getHighlighterViewPatch(this.inputElement, this.highlighterElement)
+    )
 
   private readonly requestHighlighterScrollSync = (): void => {
-    // This first updateHighlighterScroll() call keeps the overlay in sync immediately,
-    // so any work done later in the same tick—like scheduleHighlighterRecompute() triggered by
-    // updateHighlighterScroll() or updateSuggestionsPosition() reads the up-to-date scroll and height.
-    this.updateHighlighterScroll()
-
-    if (globalThis.window === undefined) {
-      return
-    }
-
-    if (this._scrollSyncFrame !== null) {
-      globalThis.cancelAnimationFrame(this._scrollSyncFrame)
-      this._scrollSyncFrame = null
-    }
-
-    this._scrollSyncFrame = globalThis.requestAnimationFrame(() => {
-      this._scrollSyncFrame = null
-      // This second updateHighlighterScroll() call picks up any DOM adjustments that happen once
-      // the browser has painted (e.g., layout shifts from the just-updated input).
-      // Dropping either updateHighlighterScroll call introduces a one-frame visual lag (removing the first)
-      // or risks missing a final adjustment after the frame (removing the second)
-      this.updateHighlighterScroll()
+    this.requestViewSync({
+      syncScroll: true,
+      measureSuggestions: true,
+      measureInline: true,
     })
   }
 
   handleDocumentScroll = (): void => {
-    if (this._isScrolling || !this.suggestionsElement) {
+    if (this._isScrolling || (!this.suggestionsElement && !this.isInlineAutocomplete())) {
       return
     }
 
     this._isScrolling = true
     globalThis.requestAnimationFrame(() => {
-      this.updateSuggestionsPosition()
-      this.updateInlineSuggestionPosition()
+      this.requestViewSync({
+        measureSuggestions: true,
+        measureInline: true,
+      })
       this._isScrolling = false
     })
   }
@@ -2146,6 +1850,7 @@ class MentionsInput<
         ignoreAccents,
         maxSuggestions,
         signal: controller.signal,
+        getSubstringIndex,
       })
 
       void this.updateSuggestions(
@@ -2392,163 +2097,6 @@ class MentionsInput<
     (countSuggestions(this.state.suggestions) !== 0 ||
       this.isLoading() ||
       this.getSuggestionsStatusContent().statusType !== null)
-}
-
-/**
- * Returns the computed length property value for the provided element.
- * Note: According to spec and testing, can count on length values coming back in pixels. See https://developer.mozilla.org/en-US/docs/Web/CSS/used_value#Difference_from_computed_value
- */
-const getComputedStyleLengthProp = (forElement: Element, propertyName: string): number => {
-  const view = forElement.ownerDocument.defaultView ?? globalThis
-  const length = Number.parseFloat(
-    view.getComputedStyle(forElement, null).getPropertyValue(propertyName)
-  )
-  return Number.isFinite(length) ? length : 0
-}
-
-const isMobileSafari = (): boolean =>
-  typeof navigator !== 'undefined' && /iphone|ipad|ipod/i.test(navigator.userAgent)
-
-interface MeasurementBridgeProps {
-  readonly container: HTMLDivElement | null
-  readonly highlighter: HTMLDivElement | null
-  readonly input: InputElement | null
-  readonly suggestions: HTMLDivElement | null
-  readonly onSyncScroll: () => void
-  readonly onUpdateInlineSuggestionPosition: () => void
-  readonly onUpdateSuggestionsPosition: () => void
-}
-
-const MeasurementBridge = ({
-  container,
-  highlighter,
-  input,
-  suggestions,
-  onSyncScroll,
-  onUpdateInlineSuggestionPosition,
-  onUpdateSuggestionsPosition,
-}: MeasurementBridgeProps) => {
-  const updateSuggestions = useEventCallback(() => {
-    onUpdateSuggestionsPosition()
-  })
-
-  const updateInlineSuggestionPosition = useEventCallback(() => {
-    onUpdateInlineSuggestionPosition()
-  })
-
-  const syncScroll = useEventCallback(() => {
-    onSyncScroll()
-  })
-
-  const updateAll = useEventCallback(() => {
-    updateSuggestions()
-    updateInlineSuggestionPosition()
-    syncScroll()
-  })
-
-  const observe = useEventCallback((element: Element | null, callback: () => void) => {
-    if (!element || typeof ResizeObserver === 'undefined') {
-      return undefined
-    }
-
-    const observer = new ResizeObserver(() => {
-      callback()
-    })
-    observer.observe(element)
-    return () => {
-      observer.disconnect()
-    }
-  })
-
-  useLayoutEffect(() => {
-    updateAll()
-  }, [])
-
-  useLayoutEffect(() => observe(container, updateAll), [container])
-  useLayoutEffect(() => observe(highlighter, updateAll), [highlighter])
-  useLayoutEffect(() => observe(input, updateAll), [input])
-  useLayoutEffect(() => observe(suggestions, updateSuggestions), [suggestions])
-
-  useLayoutEffect(() => {
-    if (globalThis.window === undefined) {
-      return undefined
-    }
-
-    const handleViewportChange = () => {
-      updateAll()
-    }
-
-    window.addEventListener('resize', handleViewportChange)
-    globalThis.addEventListener('orientationchange', handleViewportChange)
-
-    return () => {
-      window.removeEventListener('resize', handleViewportChange)
-      globalThis.removeEventListener('orientationchange', handleViewportChange)
-    }
-  }, [])
-
-  useLayoutEffect(() => {
-    if (!input) {
-      return undefined
-    }
-
-    const handleScroll = () => {
-      syncScroll()
-      updateSuggestions()
-      updateInlineSuggestionPosition()
-    }
-
-    input.addEventListener('scroll', handleScroll, { passive: true })
-    return () => {
-      input.removeEventListener('scroll', handleScroll)
-    }
-  }, [input])
-
-  return null
-}
-
-const TYPOGRAPHIC_STYLE_PROPS = [
-  'font-family',
-  'font-size',
-  'font-style',
-  'font-variant',
-  'font-weight',
-  'font-stretch',
-  'font-feature-settings',
-  'font-variation-settings',
-  'letter-spacing',
-  'line-height',
-  'text-transform',
-  'text-indent',
-  'text-align',
-  'word-spacing',
-] as const
-
-// eslint-disable-next-line code-complete/low-function-cohesion
-const mirrorInputTypographicStyles = (
-  input: InputElement,
-  highlighter: HTMLDivElement
-): boolean => {
-  if (typeof globalThis.getComputedStyle !== 'function') {
-    return false
-  }
-
-  const computed = globalThis.getComputedStyle(input)
-  let didUpdate = false
-
-  for (const property of TYPOGRAPHIC_STYLE_PROPS) {
-    const nextValue =
-      typeof computed.getPropertyValue === 'function'
-        ? computed.getPropertyValue(property)
-        : // Older JSDOM mocks may not include getPropertyValue; best-effort fallback
-          ((computed as unknown as Record<string, string | undefined>)[property] ?? '')
-    if (nextValue && highlighter.style.getPropertyValue(property) !== nextValue) {
-      highlighter.style.setProperty(property, nextValue)
-      didUpdate = true
-    }
-  }
-
-  return didUpdate
 }
 
 export default MentionsInput

--- a/src/MentionsInputLayout.spec.ts
+++ b/src/MentionsInputLayout.spec.ts
@@ -1,0 +1,161 @@
+import {
+  areInlineSuggestionPositionsEqual,
+  areSuggestionsPositionsEqual,
+  calculateInlineSuggestionPosition,
+  calculateSuggestionsPosition,
+  createPendingViewSync,
+  mergePendingViewSync,
+} from './MentionsInputLayout'
+
+describe('MentionsInputLayout', () => {
+  it('calculates fixed suggestions positioning when rendered in a portal', () => {
+    const highlighter = document.createElement('div')
+    const suggestions = document.createElement('div')
+    const container = document.createElement('div')
+
+    highlighter.style.fontSize = '18px'
+    suggestions.style.marginLeft = '0px'
+    suggestions.style.marginTop = '7px'
+
+    Object.defineProperty(highlighter, 'getBoundingClientRect', {
+      value: () => ({
+        left: 4,
+        top: 6,
+        right: 0,
+        bottom: 0,
+        width: 0,
+        height: 0,
+      }),
+    })
+    Object.defineProperty(suggestions, 'offsetHeight', { value: 20, configurable: true })
+    Object.defineProperty(highlighter, 'offsetWidth', { value: 200, configurable: true })
+    Object.defineProperty(container, 'offsetWidth', { value: 320, configurable: true })
+
+    highlighter.scrollLeft = 5
+    highlighter.scrollTop = 3
+
+    const position = calculateSuggestionsPosition({
+      caretPosition: { left: 10, top: 12 },
+      suggestionsPlacement: 'below',
+      anchorMode: 'caret',
+      resolvedPortalHost: document.body,
+      suggestions,
+      highlighter,
+      container,
+    })
+
+    expect(position).toEqual({
+      position: 'fixed',
+      left: 9,
+      top: 8,
+      width: 200,
+    })
+  })
+
+  it('anchors non-portal suggestions to the control edge in left anchor mode', () => {
+    const highlighter = document.createElement('div')
+    const suggestions = document.createElement('div')
+    const container = document.createElement('div')
+
+    highlighter.style.fontSize = '16px'
+
+    Object.defineProperty(highlighter, 'getBoundingClientRect', {
+      value: () => ({
+        left: 2,
+        top: 8,
+        right: 0,
+        bottom: 0,
+        width: 0,
+        height: 0,
+      }),
+    })
+    Object.defineProperty(highlighter, 'offsetWidth', { value: 180, configurable: true })
+    Object.defineProperty(container, 'offsetWidth', { value: 220, configurable: true })
+    Object.defineProperty(suggestions, 'offsetHeight', { value: 40, configurable: true })
+
+    highlighter.scrollLeft = 14
+    highlighter.scrollTop = 5
+
+    const position = calculateSuggestionsPosition({
+      caretPosition: { left: 32, top: 18 },
+      suggestionsPlacement: 'below',
+      anchorMode: 'left',
+      resolvedPortalHost: null,
+      suggestions,
+      highlighter,
+      container,
+    })
+
+    expect(position).toEqual({
+      left: 0,
+      top: 13,
+      width: 180,
+    })
+  })
+
+  it('calculates inline suggestion offsets from the caret marker', () => {
+    const control = document.createElement('div')
+    const highlighter = document.createElement('div')
+    const caret = document.createElement('span')
+
+    caret.setAttribute('data-mentions-caret', 'true')
+    highlighter.append(caret)
+    control.append(highlighter)
+
+    Object.defineProperty(control, 'getBoundingClientRect', {
+      value: () => ({
+        left: 20,
+        top: 10,
+        right: 0,
+        bottom: 0,
+        width: 0,
+        height: 0,
+      }),
+    })
+    Object.defineProperty(caret, 'getBoundingClientRect', {
+      value: () => ({
+        left: 42,
+        top: 28,
+        right: 0,
+        bottom: 0,
+        width: 0,
+        height: 0,
+      }),
+    })
+
+    expect(calculateInlineSuggestionPosition({ highlighter })).toEqual({
+      left: 22,
+      top: 18,
+    })
+    expect(
+      areInlineSuggestionPositionsEqual(
+        { left: 22, top: 18 },
+        { left: 22, top: 18 }
+      )
+    ).toBe(true)
+  })
+
+  it('merges pending view-sync flags without dropping prior work', () => {
+    const pending = mergePendingViewSync(createPendingViewSync(), {
+      syncScroll: true,
+      measureSuggestions: true,
+    })
+    const merged = mergePendingViewSync(pending, {
+      measureInline: true,
+    })
+
+    expect(merged).toMatchObject({
+      syncScroll: true,
+      measureSuggestions: true,
+      measureInline: true,
+      restoreSelection: false,
+      recomputeHighlighter: false,
+    })
+    expect(
+      areSuggestionsPositionsEqual(
+        { left: 1, top: 2, width: 3 },
+        { left: 1, top: 2, width: 3 }
+      )
+    ).toBe(true)
+  })
+})

--- a/src/MentionsInputLayout.ts
+++ b/src/MentionsInputLayout.ts
@@ -1,0 +1,391 @@
+import type { CSSProperties } from 'react'
+import type {
+  CaretCoordinates,
+  InlineSuggestionPosition,
+  InputElement,
+  MentionsInputAnchorMode,
+  SuggestionsPosition,
+} from './types'
+
+export interface PendingViewSync {
+  restoreSelection: boolean
+  syncScroll: boolean
+  measureSuggestions: boolean
+  measureInline: boolean
+  recomputeHighlighter: boolean
+}
+
+export interface ViewSyncPatch {
+  restoredSelection: boolean
+  syncedScroll: boolean
+  measuredSuggestions: boolean
+  measuredInline: boolean
+  recomputedHighlighter: boolean
+}
+
+export interface MentionsDomRefs {
+  container: HTMLDivElement | null
+  highlighter: HTMLDivElement | null
+  input: InputElement | null
+  suggestions: HTMLDivElement | null
+}
+
+interface SuggestionsPositionArgs {
+  caretPosition: CaretCoordinates | null
+  suggestionsPlacement: 'auto' | 'above' | 'below'
+  anchorMode: MentionsInputAnchorMode
+  resolvedPortalHost: Element | null
+  suggestions: HTMLDivElement | null
+  highlighter: HTMLDivElement | null
+  container: HTMLDivElement | null
+}
+
+interface InlineSuggestionPositionArgs {
+  highlighter: HTMLDivElement | null
+}
+
+interface HighlighterViewPatch {
+  scrollLeft: number
+  scrollTop: number
+  height: string | null
+  typography: Array<{ property: string; value: string }>
+}
+
+interface TextareaResizePatch {
+  height: string
+  overflowY: string
+}
+
+const TYPOGRAPHIC_STYLE_PROPS = [
+  'font-family',
+  'font-size',
+  'font-style',
+  'font-variant',
+  'font-weight',
+  'font-stretch',
+  'font-feature-settings',
+  'font-variation-settings',
+  'letter-spacing',
+  'line-height',
+  'text-transform',
+  'text-indent',
+  'text-align',
+  'word-spacing',
+] as const
+
+const EMPTY_TEXTAREA_RESIZE_PATCH: TextareaResizePatch = {
+  height: '',
+  overflowY: '',
+}
+
+export const createPendingViewSync = (): PendingViewSync => ({
+  restoreSelection: false,
+  syncScroll: false,
+  measureSuggestions: false,
+  measureInline: false,
+  recomputeHighlighter: false,
+})
+
+export const hasPendingViewSync = (pendingViewSync: PendingViewSync): boolean =>
+  pendingViewSync.restoreSelection ||
+  pendingViewSync.syncScroll ||
+  pendingViewSync.measureSuggestions ||
+  pendingViewSync.measureInline ||
+  pendingViewSync.recomputeHighlighter
+
+export const mergePendingViewSync = (
+  current: PendingViewSync,
+  next: Partial<PendingViewSync>
+): PendingViewSync => ({
+  restoreSelection: current.restoreSelection || next.restoreSelection === true,
+  syncScroll: current.syncScroll || next.syncScroll === true,
+  measureSuggestions: current.measureSuggestions || next.measureSuggestions === true,
+  measureInline: current.measureInline || next.measureInline === true,
+  recomputeHighlighter: current.recomputeHighlighter || next.recomputeHighlighter === true,
+})
+
+export const createViewSyncPatch = (): ViewSyncPatch => ({
+  restoredSelection: false,
+  syncedScroll: false,
+  measuredSuggestions: false,
+  measuredInline: false,
+  recomputedHighlighter: false,
+})
+
+export const isMobileSafari = (): boolean =>
+  typeof navigator !== 'undefined' && /iphone|ipad|ipod/i.test(navigator.userAgent)
+
+export const getInputInlineStyle = (singleLine?: boolean): CSSProperties => {
+  const style: CSSProperties = {
+    background: 'transparent',
+  }
+
+  if (!singleLine && isMobileSafari()) {
+    style.marginTop = 1
+    style.marginLeft = -3
+  }
+
+  return style
+}
+
+/**
+ * Returns the computed length property value for the provided element.
+ * Note: According to spec and testing, can count on length values coming back in pixels.
+ */
+export const getComputedStyleLengthProp = (forElement: Element, propertyName: string): number => {
+  const view = forElement.ownerDocument.defaultView ?? globalThis
+  const length = Number.parseFloat(
+    view.getComputedStyle(forElement, null).getPropertyValue(propertyName)
+  )
+  return Number.isFinite(length) ? length : 0
+}
+
+export const calculateSuggestionsPosition = ({
+  caretPosition,
+  suggestionsPlacement,
+  anchorMode,
+  resolvedPortalHost,
+  suggestions,
+  highlighter,
+  container,
+}: SuggestionsPositionArgs): SuggestionsPosition | null => {
+  if (!caretPosition || !suggestions || !highlighter || !container) {
+    return null
+  }
+
+  const anchorToLeft = anchorMode === 'left'
+  const caretOffsetParentRect = highlighter.getBoundingClientRect()
+  const caretHeight = getComputedStyleLengthProp(highlighter, 'font-size')
+  const viewportRelative = {
+    left: caretOffsetParentRect.left + (anchorToLeft ? 0 : caretPosition.left),
+    top: caretOffsetParentRect.top + caretPosition.top,
+  }
+  const viewportHeight = Math.max(document.documentElement.clientHeight, window.innerHeight || 0)
+  const desiredWidth = highlighter.offsetWidth
+
+  const position: SuggestionsPosition = {}
+
+  if (resolvedPortalHost) {
+    const viewportWidth = Math.max(document.documentElement.clientWidth, window.innerWidth || 0)
+    const width = Math.min(desiredWidth, viewportWidth)
+    position.width = width
+    position.position = 'fixed'
+
+    let { left, top } = viewportRelative
+    left -= getComputedStyleLengthProp(suggestions, 'margin-left')
+    top -= getComputedStyleLengthProp(suggestions, 'margin-top')
+
+    if (!anchorToLeft) {
+      left -= highlighter.scrollLeft
+    }
+
+    top -= highlighter.scrollTop
+
+    const maxLeft = Math.max(0, viewportWidth - width)
+    position.left = Math.min(maxLeft, Math.max(0, left))
+
+    const shouldShowAboveCaret =
+      suggestionsPlacement === 'above' ||
+      (suggestionsPlacement === 'auto' &&
+        top + suggestions.offsetHeight > viewportHeight &&
+        suggestions.offsetHeight < top - caretHeight)
+
+    position.top = shouldShowAboveCaret
+      ? Math.max(0, top - suggestions.offsetHeight - caretHeight)
+      : top
+
+    return position
+  }
+
+  const containerWidth = container.offsetWidth
+  const width = Math.min(desiredWidth, containerWidth)
+  position.width = width
+
+  const left = anchorToLeft ? 0 : caretPosition.left - highlighter.scrollLeft
+  const top = caretPosition.top - highlighter.scrollTop
+
+  if (anchorToLeft) {
+    position.left = 0
+  } else if (left + width > containerWidth) {
+    position.right = 0
+  } else {
+    position.left = left
+  }
+
+  const shouldShowAboveCaret =
+    suggestionsPlacement === 'above' ||
+    (suggestionsPlacement === 'auto' &&
+      viewportRelative.top - highlighter.scrollTop + suggestions.offsetHeight > viewportHeight &&
+      suggestions.offsetHeight <
+        caretOffsetParentRect.top - caretHeight - highlighter.scrollTop)
+
+  position.top = shouldShowAboveCaret ? top - suggestions.offsetHeight - caretHeight : top
+
+  return position
+}
+
+export const calculateInlineSuggestionPosition = ({
+  highlighter,
+}: InlineSuggestionPositionArgs): InlineSuggestionPosition | null => {
+  if (!highlighter) {
+    return null
+  }
+
+  const caretElement = highlighter.querySelector<HTMLSpanElement>('[data-mentions-caret]')
+  const controlElement = highlighter.parentElement
+  const controlRect = controlElement?.getBoundingClientRect()
+  const caretRect = caretElement?.getBoundingClientRect()
+
+  if (!caretRect || !controlRect) {
+    return null
+  }
+
+  return {
+    left: caretRect.left - controlRect.left,
+    top: caretRect.top - controlRect.top,
+  }
+}
+
+export const areSuggestionsPositionsEqual = (
+  left: SuggestionsPosition,
+  right: SuggestionsPosition
+): boolean =>
+  left.left === right.left &&
+  left.right === right.right &&
+  left.top === right.top &&
+  left.width === right.width &&
+  left.position === right.position
+
+export const areInlineSuggestionPositionsEqual = (
+  left: InlineSuggestionPosition | null,
+  right: InlineSuggestionPosition | null
+): boolean => left?.left === right?.left && left?.top === right?.top
+
+export const getHighlighterViewPatch = (
+  input: InputElement | null,
+  highlighter: HTMLDivElement | null
+): HighlighterViewPatch | null => {
+  if (!input || !highlighter) {
+    return null
+  }
+
+  const height = input.clientHeight ? `${input.clientHeight}px` : null
+  const typography =
+    typeof globalThis.getComputedStyle !== 'function'
+      ? []
+      : TYPOGRAPHIC_STYLE_PROPS.flatMap((property) => {
+          const computed = globalThis.getComputedStyle(input)
+          const value =
+            typeof computed.getPropertyValue === 'function'
+              ? computed.getPropertyValue(property)
+              : ((computed as unknown as Record<string, string | undefined>)[property] ?? '')
+
+          return value ? [{ property, value }] : []
+        })
+
+  return {
+    scrollLeft: input.scrollLeft,
+    scrollTop: input.scrollTop,
+    height,
+    typography,
+  }
+}
+
+export const applyHighlighterViewPatch = (
+  highlighter: HTMLDivElement | null,
+  patch: HighlighterViewPatch | null
+): boolean => {
+  if (!highlighter || !patch) {
+    return false
+  }
+
+  let didUpdate = false
+
+  if (highlighter.scrollLeft !== patch.scrollLeft) {
+    highlighter.scrollLeft = patch.scrollLeft
+    didUpdate = true
+  }
+
+  if (highlighter.scrollTop !== patch.scrollTop) {
+    highlighter.scrollTop = patch.scrollTop
+    didUpdate = true
+  }
+
+  if (patch.height !== null && highlighter.style.height !== patch.height) {
+    highlighter.style.height = patch.height
+    didUpdate = true
+  }
+
+  for (const { property, value } of patch.typography) {
+    if (highlighter.style.getPropertyValue(property) !== value) {
+      highlighter.style.setProperty(property, value)
+      didUpdate = true
+    }
+  }
+
+  return didUpdate
+}
+
+export const getTextareaResizePatch = (
+  input: InputElement | null,
+  options: {
+    singleLine?: boolean
+    autoResize?: boolean
+  }
+): TextareaResizePatch | null => {
+  const hasTextarea =
+    typeof HTMLTextAreaElement !== 'undefined' && input instanceof HTMLTextAreaElement
+
+  if (options.singleLine === true || options.autoResize !== true) {
+    return hasTextarea ? EMPTY_TEXTAREA_RESIZE_PATCH : null
+  }
+
+  if (!hasTextarea) {
+    return null
+  }
+
+  const element = input as HTMLTextAreaElement
+  const previousHeight = element.style.height
+  const previousOverflowY = element.style.overflowY
+  element.style.height = 'auto'
+  element.style.overflowY = 'hidden'
+  let borderAdjustment = 0
+
+  if (globalThis.window !== undefined && typeof globalThis.getComputedStyle === 'function') {
+    const computed = globalThis.getComputedStyle(element)
+    const parse = (value: string | null | undefined) => (value ? Number.parseFloat(value) || 0 : 0)
+    borderAdjustment = parse(computed.borderTopWidth) + parse(computed.borderBottomWidth)
+  }
+
+  const nextHeight = element.scrollHeight + borderAdjustment
+  element.style.height = previousHeight
+  element.style.overflowY = previousOverflowY
+
+  return {
+    height: `${nextHeight}px`,
+    overflowY: 'hidden',
+  }
+}
+
+export const applyTextareaResizePatch = (
+  input: InputElement | null,
+  patch: TextareaResizePatch | null
+): boolean => {
+  if (!patch || typeof HTMLTextAreaElement === 'undefined' || !(input instanceof HTMLTextAreaElement)) {
+    return false
+  }
+
+  let didUpdate = false
+
+  if (input.style.height !== patch.height) {
+    input.style.height = patch.height
+    didUpdate = true
+  }
+
+  if (input.style.overflowY !== patch.overflowY) {
+    input.style.overflowY = patch.overflowY
+    didUpdate = true
+  }
+
+  return didUpdate
+}

--- a/src/MentionsInputSelectors.ts
+++ b/src/MentionsInputSelectors.ts
@@ -1,0 +1,294 @@
+import type React from 'react'
+import { DEFAULT_MENTION_PROPS } from './MentionDefaultProps'
+import type {
+  MentionComponentProps,
+  MentionDataItem,
+  MentionIdentifier,
+  MentionSearchContext,
+  QueryInfo,
+  SuggestionDataItem,
+  SuggestionQueryState,
+  SuggestionQueryStateMap,
+  SuggestionsMap,
+} from './types'
+import type { FlattenedSuggestion } from './utils/flattenSuggestions'
+import { flattenSuggestions } from './utils'
+import { collectMentionElements } from './utils/readConfigFromChildren'
+
+export interface InlineSuggestionDetails<
+  Extra extends Record<string, unknown> = Record<string, unknown>,
+> {
+  hiddenPrefix: string
+  visibleText: string
+  queryInfo: QueryInfo
+  suggestion: SuggestionDataItem<Extra>
+  announcement: string
+}
+
+export interface SuggestionsStatusContent {
+  statusContent: React.ReactNode
+  statusType: 'empty' | 'error' | null
+}
+
+export const DEFAULT_EMPTY_SUGGESTIONS_MESSAGE = 'No suggestions found'
+export const DEFAULT_ERROR_SUGGESTIONS_MESSAGE = 'Unable to load suggestions'
+export const INLINE_AUTOCOMPLETE_FALLBACK_ANNOUNCEMENT = 'No inline suggestions available'
+
+export const getMentionChildren = <Extra extends Record<string, unknown>>(
+  children: React.ReactNode
+) => collectMentionElements<Extra>(children)
+
+export const getMentionChild = <Extra extends Record<string, unknown>>(
+  children: React.ReactNode,
+  childIndex: number
+): React.ReactElement<MentionComponentProps<Extra>> | undefined =>
+  getMentionChildren<Extra>(children)[childIndex]
+
+export const getSuggestionQueryStateEntries = <Extra extends Record<string, unknown>>(
+  queryStates: SuggestionQueryStateMap<Extra>
+): ReadonlyArray<readonly [number, SuggestionQueryState<Extra>]> =>
+  Object.entries(queryStates)
+    .map(([key, value]) => [Number(key), value] as const)
+    .filter(([key]) => Number.isInteger(key))
+    .toSorted(([left], [right]) => left - right)
+
+export const getSuggestionData = <Extra extends Record<string, unknown>>(
+  suggestion: SuggestionDataItem<Extra>
+): {
+  id: MentionIdentifier
+  display: string
+} => {
+  if (typeof suggestion === 'string') {
+    return { id: suggestion, display: suggestion }
+  }
+
+  return {
+    id: suggestion.id,
+    display: suggestion.display ?? String(suggestion.id),
+  }
+}
+
+export const getFlattenedSuggestions = <Extra extends Record<string, unknown>>(
+  children: React.ReactNode,
+  suggestions: SuggestionsMap<Extra>
+): FlattenedSuggestion<Extra>[] => flattenSuggestions<Extra>(getMentionChildren(children), suggestions)
+
+export const getFocusedSuggestionEntry = <Extra extends Record<string, unknown>>(
+  children: React.ReactNode,
+  suggestions: SuggestionsMap<Extra>,
+  focusIndex: number
+): {
+  result: SuggestionDataItem<Extra>
+  queryInfo: QueryInfo
+} | null => {
+  const flattened = getFlattenedSuggestions(children, suggestions)
+  if (flattened.length === 0) {
+    return null
+  }
+
+  return flattened[focusIndex] ?? flattened[0]
+}
+
+export const getInlineSuggestionRemainder = (displayValue: string, queryInfo: QueryInfo): string => {
+  const query = queryInfo.query ?? ''
+  if (query.length === 0) {
+    return displayValue
+  }
+
+  const normalizedDisplay = displayValue.toLocaleLowerCase()
+  const normalizedQuery = query.toLocaleLowerCase()
+
+  if (normalizedDisplay.startsWith(normalizedQuery)) {
+    return displayValue.slice(query.length)
+  }
+
+  return displayValue
+}
+
+export const getInlineSuggestionDetails = <Extra extends Record<string, unknown>>(
+  children: React.ReactNode,
+  suggestions: SuggestionsMap<Extra>,
+  focusIndex: number
+): InlineSuggestionDetails<Extra> | null => {
+  const entry = getFocusedSuggestionEntry(children, suggestions, focusIndex)
+  if (!entry) {
+    return null
+  }
+
+  const { queryInfo, result } = entry
+  const mentionChild = getMentionChild<Extra>(children, queryInfo.childIndex)
+  if (!mentionChild) {
+    return null
+  }
+
+  const {
+    displayTransform = DEFAULT_MENTION_PROPS.displayTransform,
+    appendSpaceOnAdd = DEFAULT_MENTION_PROPS.appendSpaceOnAdd,
+  } = mentionChild.props
+
+  const { id, display } = getSuggestionData(result)
+  let displayValue = displayTransform(id, display)
+
+  if (appendSpaceOnAdd) {
+    displayValue += ' '
+  }
+
+  const visibleText = getInlineSuggestionRemainder(displayValue, queryInfo)
+  if (!visibleText) {
+    return null
+  }
+
+  const hiddenPrefixLength = displayValue.length - visibleText.length
+  const hiddenPrefix = hiddenPrefixLength > 0 ? displayValue.slice(0, hiddenPrefixLength) : ''
+  const announcement = displayValue.trimEnd()
+
+  return {
+    hiddenPrefix,
+    visibleText,
+    queryInfo,
+    suggestion: result,
+    announcement: announcement.length > 0 ? announcement : displayValue,
+  }
+}
+
+export const getPreferredQueryState = <Extra extends Record<string, unknown>>(
+  queryStates: SuggestionQueryStateMap<Extra>
+): SuggestionQueryState<Extra> | null => getSuggestionQueryStateEntries(queryStates)[0]?.[1] ?? null
+
+export const getSuggestionsStatusContent = <Extra extends Record<string, unknown>>(
+  children: React.ReactNode,
+  suggestions: SuggestionsMap<Extra>,
+  queryStates: SuggestionQueryStateMap<Extra>
+): SuggestionsStatusContent => {
+  if (Object.values(suggestions).some(({ results }) => results.length > 0)) {
+    return { statusContent: null, statusType: null }
+  }
+
+  const preferredQueryState = getPreferredQueryState(queryStates)
+  if (!preferredQueryState || preferredQueryState.status === 'loading') {
+    return { statusContent: null, statusType: null }
+  }
+
+  const mentionChild = getMentionChild<Extra>(children, preferredQueryState.queryInfo.childIndex)
+  if (!mentionChild) {
+    return { statusContent: null, statusType: null }
+  }
+
+  if (preferredQueryState.status === 'error') {
+    const renderError =
+      mentionChild.props.renderError ?? DEFAULT_MENTION_PROPS.renderError ?? null
+
+    if (!renderError) {
+      return {
+        statusContent: DEFAULT_ERROR_SUGGESTIONS_MESSAGE,
+        statusType: 'error',
+      }
+    }
+
+    const statusContent = renderError(
+      preferredQueryState.queryInfo.query,
+      preferredQueryState.error
+    )
+
+    if (statusContent === null || statusContent === false) {
+      return { statusContent: null, statusType: null }
+    }
+
+    return {
+      statusContent:
+        statusContent === undefined ? DEFAULT_ERROR_SUGGESTIONS_MESSAGE : statusContent,
+      statusType: 'error',
+    }
+  }
+
+  const renderEmpty = mentionChild.props.renderEmpty ?? DEFAULT_MENTION_PROPS.renderEmpty ?? null
+
+  if (!renderEmpty) {
+    return {
+      statusContent: DEFAULT_EMPTY_SUGGESTIONS_MESSAGE,
+      statusType: 'empty',
+    }
+  }
+
+  const statusContent = renderEmpty(preferredQueryState.queryInfo.query)
+
+  if (statusContent === null || statusContent === false) {
+    return { statusContent: null, statusType: null }
+  }
+
+  return {
+    statusContent: statusContent === undefined ? DEFAULT_EMPTY_SUGGESTIONS_MESSAGE : statusContent,
+    statusType: 'empty',
+  }
+}
+
+export const getInlineSuggestionAnnouncement = <Extra extends Record<string, unknown>>(
+  inlineSuggestion: InlineSuggestionDetails<Extra> | null,
+  statusContent: SuggestionsStatusContent
+): string => {
+  if (inlineSuggestion) {
+    return inlineSuggestion.announcement
+  }
+
+  if (statusContent.statusType !== null && typeof statusContent.statusContent === 'string') {
+    return statusContent.statusContent
+  }
+
+  return INLINE_AUTOCOMPLETE_FALLBACK_ANNOUNCEMENT
+}
+
+export const getDataProvider = <Extra extends Record<string, unknown>>(
+  data: ReadonlyArray<MentionDataItem<Extra>> | ((
+    query: string,
+    context: MentionSearchContext
+  ) => Promise<ReadonlyArray<MentionDataItem<Extra>>> | ReadonlyArray<MentionDataItem<Extra>>),
+  options: {
+    ignoreAccents: boolean
+    maxSuggestions?: number
+    signal: AbortSignal
+    getSubstringIndex: (
+      string: string,
+      substring: string,
+      ignoreAccents: boolean
+    ) => number
+  }
+): ((query: string) => Promise<MentionDataItem<Extra>[]>) => {
+  const { ignoreAccents, maxSuggestions, signal, getSubstringIndex } = options
+  const applyMaxSuggestions = (
+    items: ReadonlyArray<MentionDataItem<Extra>>
+  ): MentionDataItem<Extra>[] =>
+    maxSuggestions === undefined ? [...items] : [...items.slice(0, maxSuggestions)]
+
+  if (Array.isArray(data)) {
+    const items = data as ReadonlyArray<MentionDataItem<Extra>>
+
+    return async (query: string) =>
+      applyMaxSuggestions(
+        items.flatMap((item) => {
+          if (signal.aborted) {
+            return []
+          }
+
+          const index = getSubstringIndex(item.display || String(item.id), query, ignoreAccents)
+
+          return index >= 0
+            ? [
+                {
+                  ...item,
+                  highlights: [{ start: index, end: index + query.length }],
+                },
+              ]
+            : []
+        })
+      )
+  }
+
+  return async (query: string) => {
+    const provider = data as (
+      query: string,
+      context: MentionSearchContext
+    ) => Promise<ReadonlyArray<MentionDataItem<Extra>>> | ReadonlyArray<MentionDataItem<Extra>>
+    const result = await Promise.resolve(provider(query, { signal }))
+    return applyMaxSuggestions(result)
+  }
+}

--- a/src/MentionsInputView.tsx
+++ b/src/MentionsInputView.tsx
@@ -1,0 +1,49 @@
+import type React from 'react'
+import type { CSSProperties } from 'react'
+
+export interface MentionsInputViewProps {
+  readonly rootRef: (element: HTMLDivElement | null) => void
+  readonly rootClassName: string
+  readonly style?: CSSProperties
+  readonly singleLine: boolean
+  readonly controlClassName: string
+  readonly highlighter: React.ReactNode
+  readonly input: React.ReactNode
+  readonly inlineSuggestion: React.ReactNode
+  readonly inlineSuggestionLiveRegion: React.ReactNode
+  readonly suggestionsOverlay: React.ReactNode
+  readonly measurementBridge: React.ReactNode
+}
+
+const MentionsInputView = ({
+  rootRef,
+  rootClassName,
+  style,
+  singleLine,
+  controlClassName,
+  highlighter,
+  input,
+  inlineSuggestion,
+  inlineSuggestionLiveRegion,
+  suggestionsOverlay,
+  measurementBridge,
+}: MentionsInputViewProps) => (
+  <div
+    ref={rootRef}
+    className={rootClassName}
+    style={style}
+    data-single-line={singleLine ? 'true' : undefined}
+    data-multi-line={singleLine ? undefined : 'true'}
+  >
+    <div className={controlClassName} data-slot="control">
+      {highlighter}
+      {input}
+      {inlineSuggestion}
+      {inlineSuggestionLiveRegion}
+    </div>
+    {suggestionsOverlay}
+    {measurementBridge}
+  </div>
+)
+
+export default MentionsInputView


### PR DESCRIPTION
…. src/MentionsInput.tsx now acts as the orchestration shell, with rendering handed to src/MentionsInputView.tsx, DOM observation moved into src/MeasurementBridge.tsx, layout/math extracted to src/MentionsInputLayout.ts, and read-only suggestion derivation extracted to src/MentionsInputSelectors.ts. Event handlers now enqueue view-sync work through requestViewSync/flushPendingViewSync instead of directly chaining scroll, position, and recompute calls.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized view synchronization and measurement architecture to batch layout updates and improve handling of scroll, resize, and orientation change events.

* **Chores**
  * Excluded database files from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refactor MentionsInput view updates to use a single queued view-sync path
> - Replaces multiple immediate DOM update calls in `MentionsInput` with a single `requestViewSync` + `flushPendingViewSync` mechanism that coalesces scroll sync, suggestions measurement, inline measurement, and selection restore into one RAF per frame.
> - Extracts layout utilities into [`MentionsInputLayout.ts`](https://github.com/hbmartin/react-mentions-ts/pull/174/files#diff-7d40540d82b40ebe0cf0576049c2f8f73039531f16f648e29f85078d7777a473) (position calculations, highlighter/textarea patches, pending sync flag helpers) and pure selectors into [`MentionsInputSelectors.ts`](https://github.com/hbmartin/react-mentions-ts/pull/174/files#diff-c90f618868bcc692e4549e3767f3a52a01f42df6a8d6d2767a705efbb5cf574b).
> - Adds [`MeasurementBridge.tsx`](https://github.com/hbmartin/react-mentions-ts/pull/174/files#diff-f05f418c2b64673088d3968a6d394b6f13b7dc48a13f8e0a4b7088f5a3635787), a new component that replaces three separate measurement callbacks with a single `requestViewSync` prop, observing container/input resize and global viewport events.
> - Introduces [`MentionsInputView.tsx`](https://github.com/hbmartin/react-mentions-ts/pull/174/files#diff-fcf18fbf4fd320b770e70768d0183bddf272b222a5da70c9c509bfc971b08c56) as a presentational wrapper for the root DOM structure.
> - Behavioral change: input scroll now flushes view sync synchronously (`flushNow: true`) rather than scheduling a separate RAF; document scroll triggers measurement in the next frame only when suggestions or inline autocomplete are active.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 8d72484. 9 files reviewed, 4 issues evaluated, 0 issues filtered, 3 comments posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->