### PR TITLE
async refresh preservation in MentionsInput.tsx (line 1805). updateMe…

### DIFF
--- a/demo/src/examples/InlineAutocomplete.tsx
+++ b/demo/src/examples/InlineAutocomplete.tsx
@@ -4,11 +4,13 @@ import { Mention, MentionsInput } from '../../../src'
 import type { MentionDataItem } from '../../../src'
 import ExampleCard from './ExampleCard'
 import { inlineMentionsClassNames, mentionPillClass, mergeClassNames } from './mentionsClassNames'
+import styles from './example.module.css'
 
 const inlineItalicClasses = mergeClassNames(inlineMentionsClassNames, {
-  inlineSuggestion:
-    'pointer-events-none [font-family:inherit] [font-size:inherit] [letter-spacing:inherit] [font-weight:inherit] italic text-slate-400',
-  inlineSuggestionSuffix: 'text-slate-400 italic',
+  inlineSuggestion: styles.inlineSuggestion,
+  inlineSuggestionText: styles.inlineSuggestionText,
+  inlineSuggestionPrefix: styles.inlineSuggestionPrefix,
+  inlineSuggestionSuffix: styles.inlineSuggestionSuffix,
 })
 
 export default function InlineAutocomplete({ data }: { data: MentionDataItem[] }) {

--- a/demo/src/examples/example.module.css
+++ b/demo/src/examples/example.module.css
@@ -109,3 +109,43 @@
   border-radius: 9999px;
   font-weight: 600;
 }
+
+.inlineSuggestion {
+  position: absolute;
+  z-index: 2;
+  pointer-events: none;
+  white-space: pre;
+  font-family: inherit;
+  font-size: inherit;
+  font-style: italic;
+  font-weight: inherit;
+  letter-spacing: inherit;
+  line-height: inherit;
+  color: #94a3b8;
+}
+
+.inlineSuggestionText {
+  position: relative;
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0;
+}
+
+.inlineSuggestionPrefix {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  border: 0;
+  margin: -1px;
+  clip: rect(0, 0, 0, 0);
+  clip-path: inset(50%);
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.inlineSuggestionSuffix {
+  white-space: pre;
+  color: inherit;
+  font-style: inherit;
+}

--- a/demo/src/examples/mentionsClassNames.ts
+++ b/demo/src/examples/mentionsClassNames.ts
@@ -25,6 +25,8 @@ export const multilineMentionsClassNames: MentionsInputClassNames = {
   inlineSuggestionPrefix: 'sr-only',
   inlineSuggestionSuffix: 'whitespace-pre text-slate-400',
   suggestions: baseSuggestions,
+  suggestionsStatus:
+    'px-4 py-2.5 text-left text-sm data-[status-type=empty]:text-slate-600 data-[status-type=error]:text-rose-600',
   suggestionsList: baseSuggestionsList,
   suggestionItem: baseSuggestionItem,
   suggestionItemFocused: baseSuggestionItemFocused,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "react-mentions-ts",
 	"private": false,
-	"version": "5.4.8",
+	"version": "6.0.0",
 	"description": "A React component that enables Facebook/Twitter-style @mentions and tagging in textarea inputs with full TypeScript support.",
 	"type": "module",
 	"packageManager": "pnpm@10.33.0",

--- a/src/MentionsInput.spec.tsx
+++ b/src/MentionsInput.spec.tsx
@@ -565,6 +565,149 @@ describe('MentionsInput', () => {
     expect(screen.getByText('Fresh Result')).toBeInTheDocument()
   })
 
+  it('keeps the previous overlay suggestions visible while the next async query loads.', async () => {
+    type DeferredResult = {
+      resolve: (value: Array<{ id: string; display: string }>) => void
+    }
+
+    const requests = new Map<string, DeferredResult>()
+    const asyncData = jest.fn(
+      (query: string) =>
+        new Promise<Array<{ id: string; display: string }>>((resolve) => {
+          requests.set(query, { resolve })
+        })
+    )
+
+    const { rerender } = render(
+      <MentionsInput value="@a">
+        <Mention trigger="@" data={asyncData} />
+      </MentionsInput>
+    )
+
+    const textarea = screen.getByRole('combobox')
+    fireEvent.focus(textarea)
+    textarea.setSelectionRange(2, 2)
+    fireEvent.select(textarea)
+
+    await waitFor(() => {
+      expect(asyncData).toHaveBeenCalledWith(
+        'a',
+        expect.objectContaining({ signal: expect.any(Object) })
+      )
+    })
+
+    requests.get('a')?.resolve([{ id: 'alpha', display: 'Alpha' }])
+
+    await waitFor(() => {
+      expect(screen.getByText('Alpha')).toBeInTheDocument()
+    })
+
+    const initialOverlay = document.querySelector('[data-slot="suggestions"]')
+    expect(initialOverlay).not.toBeNull()
+    expect(initialOverlay).toHaveAttribute('aria-busy', 'false')
+
+    rerender(
+      <MentionsInput value="@ab">
+        <Mention trigger="@" data={asyncData} />
+      </MentionsInput>
+    )
+
+    textarea.setSelectionRange(3, 3)
+    fireEvent.select(textarea)
+
+    await waitFor(() => {
+      expect(asyncData).toHaveBeenCalledWith(
+        'ab',
+        expect.objectContaining({ signal: expect.any(Object) })
+      )
+    })
+
+    const loadingOverlay = document.querySelector('[data-slot="suggestions"]')
+    expect(loadingOverlay).not.toBeNull()
+    expect(loadingOverlay).toHaveAttribute('aria-busy', 'true')
+    expect(screen.getByText('Alpha')).toBeInTheDocument()
+    expect(screen.getAllByRole('option', { hidden: true })).toHaveLength(1)
+
+    requests.get('ab')?.resolve([{ id: 'albert', display: 'Albert' }])
+
+    await waitFor(() => {
+      expect(screen.getByText('Albert')).toBeInTheDocument()
+    })
+
+    expect(screen.queryByText('Alpha')).not.toBeInTheDocument()
+    expect(document.querySelector('[data-slot="suggestions"]')).not.toBeNull()
+  })
+
+  it('replaces the latest query range when selecting a preserved async suggestion.', async () => {
+    type DeferredResult = {
+      resolve: (value: Array<{ id: string; display: string }>) => void
+    }
+
+    const requests = new Map<string, DeferredResult>()
+    const asyncData = jest.fn(
+      (query: string) =>
+        new Promise<Array<{ id: string; display: string }>>((resolve) => {
+          requests.set(query, { resolve })
+        })
+    )
+    const onMentionsChange = jest.fn()
+
+    const { rerender } = render(
+      <MentionsInput value="@a" onMentionsChange={onMentionsChange}>
+        <Mention trigger="@" data={asyncData} />
+      </MentionsInput>
+    )
+
+    const textarea = screen.getByRole('combobox')
+    fireEvent.focus(textarea)
+    textarea.setSelectionRange(2, 2)
+    fireEvent.select(textarea)
+
+    await waitFor(() => {
+      expect(asyncData).toHaveBeenCalledWith(
+        'a',
+        expect.objectContaining({ signal: expect.any(Object) })
+      )
+    })
+
+    requests.get('a')?.resolve([{ id: 'alpha', display: 'Alpha' }])
+
+    await waitFor(() => {
+      expect(screen.getByText('Alpha')).toBeInTheDocument()
+    })
+
+    rerender(
+      <MentionsInput value="@ab" onMentionsChange={onMentionsChange}>
+        <Mention trigger="@" data={asyncData} />
+      </MentionsInput>
+    )
+
+    textarea.setSelectionRange(3, 3)
+    fireEvent.select(textarea)
+
+    await waitFor(() => {
+      expect(asyncData).toHaveBeenCalledWith(
+        'ab',
+        expect.objectContaining({ signal: expect.any(Object) })
+      )
+    })
+
+    expect(screen.getByText('Alpha')).toBeInTheDocument()
+
+    fireEvent.keyDown(textarea, { key: 'Enter', keyCode: 13 })
+
+    await waitFor(() => {
+      expect(onMentionsChange).toHaveBeenCalled()
+    })
+
+    const payload = getLastMentionsChange(onMentionsChange)
+    expect(payload.value).toBe('@[Alpha](alpha)')
+    expect(payload.plainTextValue).toBe('Alpha')
+    expect(payload.idValue).toBe('alpha')
+    expect(payload.mentionId).toBe('alpha')
+    expect(payload.trigger.type).toBe('mention-add')
+  })
+
   it('renders an error state when an async provider rejects.', async () => {
     const asyncData = jest.fn(async () => {
       throw new Error('boom')
@@ -662,6 +805,11 @@ describe('MentionsInput', () => {
     await waitFor(() => {
       expect(screen.getByText('No suggestions found')).toBeInTheDocument()
     })
+
+    const status = document.querySelector('[data-slot="suggestions-status"]')
+    expect(status).not.toBeNull()
+    expect(status).toHaveAttribute('role', 'status')
+    expect(status).toHaveAttribute('data-status-type', 'empty')
   })
 
   it('allows renderError to suppress the built-in error state.', async () => {
@@ -2227,6 +2375,71 @@ describe('MentionsInput', () => {
       expect(combobox).not.toHaveAttribute('aria-describedby')
     })
 
+    it('keeps inline completion visible while the next async query loads.', async () => {
+      type DeferredResult = {
+        resolve: (value: Array<{ id: string; display: string }>) => void
+      }
+
+      const requests = new Map<string, DeferredResult>()
+      const asyncData = jest.fn(
+        (query: string) =>
+          new Promise<Array<{ id: string; display: string }>>((resolve) => {
+            requests.set(query, { resolve })
+          })
+      )
+
+      const { rerender } = render(
+        <MentionsInput value="@a" suggestionsDisplay="inline">
+          <Mention trigger="@" data={asyncData} />
+        </MentionsInput>
+      )
+
+      const combobox = screen.getByRole('combobox')
+      fireEvent.focus(combobox)
+      combobox.setSelectionRange(2, 2)
+      fireEvent.select(combobox)
+
+      await waitFor(() => {
+        expect(asyncData).toHaveBeenCalledWith(
+          'a',
+          expect.objectContaining({ signal: expect.any(Object) })
+        )
+      })
+
+      requests.get('a')?.resolve([{ id: 'alpha', display: 'Alpha' }])
+
+      await waitFor(() => {
+        expect(screen.getByText('lpha')).toBeInTheDocument()
+      })
+
+      rerender(
+        <MentionsInput value="@al" suggestionsDisplay="inline">
+          <Mention trigger="@" data={asyncData} />
+        </MentionsInput>
+      )
+
+      combobox.setSelectionRange(3, 3)
+      fireEvent.select(combobox)
+
+      await waitFor(() => {
+        expect(asyncData).toHaveBeenCalledWith(
+          'al',
+          expect.objectContaining({ signal: expect.any(Object) })
+        )
+      })
+
+      expect(screen.getByText('pha')).toBeInTheDocument()
+      expect(screen.queryByText('lpha')).not.toBeInTheDocument()
+
+      requests.get('al')?.resolve([{ id: 'alfred', display: 'Alfred' }])
+
+      await waitFor(() => {
+        expect(screen.getByText('fred')).toBeInTheDocument()
+      })
+
+      expect(screen.queryByText('pha')).not.toBeInTheDocument()
+    })
+
     it('can accept the inline suggestion with Tab', async () => {
       const onMentionsChange = jest.fn()
       const textbox = renderInlineMentionsInput({ onMentionsChange })
@@ -2459,11 +2672,49 @@ describe('MentionsInput', () => {
       })
 
       expect(updateSpy).toHaveBeenCalled()
-      expect(instance._isScrolling).toBe(false)
 
       raf.mockRestore()
       updateSpy.mockRestore()
       unmount()
+    })
+
+    it('falls back to immediate document scroll sync when requestAnimationFrame is unavailable.', () => {
+      const ref = React.createRef<MentionsInput>()
+      const { unmount } = render(
+        <MentionsInput ref={ref} value="">
+          <Mention trigger="@" data={data} />
+        </MentionsInput>
+      )
+
+      const instance = ref.current as unknown as any
+      instance.suggestionsElement = document.createElement('div')
+      const updateSpy = jest
+        .spyOn(instance, 'updateSuggestionsPosition')
+        .mockImplementation(() => undefined)
+      const originalRAF = globalThis.requestAnimationFrame
+
+      delete (globalThis as typeof globalThis & { requestAnimationFrame?: unknown })
+        .requestAnimationFrame
+
+      try {
+        act(() => {
+          instance.handleDocumentScroll()
+        })
+
+        expect(updateSpy).toHaveBeenCalled()
+      } finally {
+        if (originalRAF === undefined) {
+          delete (globalThis as typeof globalThis & { requestAnimationFrame?: unknown })
+            .requestAnimationFrame
+        } else {
+          ;(globalThis as typeof globalThis & {
+            requestAnimationFrame?: typeof globalThis.requestAnimationFrame
+          }).requestAnimationFrame = originalRAF
+        }
+
+        updateSpy.mockRestore()
+        unmount()
+      }
     })
 
     it('tracks composition state transitions.', () => {
@@ -2676,7 +2927,7 @@ describe('MentionsInput', () => {
       )
 
       const instance = ref.current as unknown as any
-      const updateSpy = jest.spyOn(instance, 'updateHighlighterScroll').mockImplementation(() => {})
+      const updateSpy = jest.spyOn(instance, 'updateHighlighterScroll').mockImplementation(() => false)
       const flushSpy = jest.spyOn(instance, 'flushPendingViewSync')
       const raf = jest
         .spyOn(globalThis, 'requestAnimationFrame')

--- a/src/MentionsInput.tsx
+++ b/src/MentionsInput.tsx
@@ -180,6 +180,13 @@ interface MentionSelectionComputation<Extra extends Record<string, unknown>> {
   selectionMap: Record<string, MentionSelectionState>
 }
 
+interface ActiveSuggestionQuery<Extra extends Record<string, unknown>> {
+  childIndex: number
+  queryInfo: QueryInfo
+  mentionChild: React.ReactElement<MentionComponentProps<Extra>>
+  ignoreAccents: boolean
+}
+
 const visuallyHiddenStyles: CSSProperties = {
   position: 'absolute',
   width: 1,
@@ -243,7 +250,6 @@ class MentionsInput<
   private _suggestionsMouseDown = false
   private _isComposing = false
   private readonly defaultSuggestionsPortalHost: HTMLElement | null
-  private _isScrolling = false
   private _pendingHighlighterRecompute = false
   private _queuedHighlighterRecompute = false
   private _didUnmount = false
@@ -1738,17 +1744,13 @@ class MentionsInput<
   }
 
   handleDocumentScroll = (): void => {
-    if (this._isScrolling || (!this.suggestionsElement && !this.isInlineAutocomplete())) {
+    if (!this.suggestionsElement && !this.isInlineAutocomplete()) {
       return
     }
 
-    this._isScrolling = true
-    globalThis.requestAnimationFrame(() => {
-      this.requestViewSync({
-        measureSuggestions: true,
-        measureInline: true,
-      })
-      this._isScrolling = false
+    this.requestViewSync({
+      measureSuggestions: true,
+      measureInline: true,
     })
   }
 
@@ -1800,20 +1802,96 @@ class MentionsInput<
     }
   }
 
-  private setQueryState(childIndex: number, queryState: SuggestionQueryState<Extra> | null): void {
-    this.setState((prevState) => {
-      const nextQueryStates: SuggestionQueryStateMap<Extra> = { ...prevState.queryStates }
+  private replaceSuggestions(
+    nextSuggestions: SuggestionsMap<Extra>,
+    getStatePatch: (
+      prevState: MentionsInputState<Extra>,
+      syncedSuggestions: SuggestionsMap<Extra>
+    ) => Partial<MentionsInputState<Extra>> = () => ({})
+  ): void {
+    this.suggestions = nextSuggestions
+    this.setState((prevState) => ({
+      suggestions: nextSuggestions,
+      ...getStatePatch(prevState, nextSuggestions),
+    }))
+  }
 
-      if (queryState === null) {
-        delete nextQueryStates[childIndex]
-      } else {
-        nextQueryStates[childIndex] = queryState
+  private getActiveSuggestionQueries(
+    plainTextValue: string,
+    caretPosition: number
+  ): ActiveSuggestionQuery<Extra>[] {
+    const value = this.props.value ?? ''
+    const mentionChildren = this.getMentionChildren()
+    const positionInValue = mapPlainTextIndex(value, this.state.config, caretPosition, 'NULL')
+
+    // If caret is inside of mention, do not query
+    if (positionInValue === null || positionInValue === undefined) {
+      return []
+    }
+
+    // Extract substring in between the end of the previous mention and the caret
+    const substringStartIndex = getEndOfLastMention(
+      value.slice(0, Math.max(0, positionInValue)),
+      this.state.config
+    )
+    const substring = plainTextValue.slice(substringStartIndex, caretPosition)
+
+    return mentionChildren.flatMap((mentionChild, childIndex) => {
+      const triggerProp = mentionChild.props.trigger ?? '@'
+      const regex = resolveTriggerRegex(triggerProp)
+      const match = substring.match(regex)
+
+      if (match?.[1] === undefined || match[2] === undefined) {
+        return []
       }
 
-      return {
-        queryStates: nextQueryStates,
-      }
+      const querySequenceStart = substringStartIndex + substring.indexOf(match[1], match.index)
+      return [
+        {
+          childIndex,
+          queryInfo: {
+            childIndex,
+            query: match[2],
+            querySequenceStart,
+            querySequenceEnd: querySequenceStart + match[1].length,
+          },
+          mentionChild,
+          ignoreAccents: regex.flags.includes('u'),
+        },
+      ]
     })
+  }
+
+  private getLoadingQueryStates(
+    activeQueries: ReadonlyArray<ActiveSuggestionQuery<Extra>>,
+    nextSuggestions: SuggestionsMap<Extra>
+  ): SuggestionQueryStateMap<Extra> {
+    return activeQueries.reduce<SuggestionQueryStateMap<Extra>>((queryStates, activeQuery) => {
+      queryStates[activeQuery.childIndex] = {
+        queryInfo: activeQuery.queryInfo,
+        results: nextSuggestions[activeQuery.childIndex]?.results ?? [],
+        status: 'loading',
+      }
+      return queryStates
+    }, {})
+  }
+
+  private getPreservedSuggestions(
+    activeQueries: ReadonlyArray<ActiveSuggestionQuery<Extra>>
+  ): SuggestionsMap<Extra> {
+    return activeQueries.reduce<SuggestionsMap<Extra>>((nextSuggestions, activeQuery) => {
+      const previousSuggestion = this.suggestions[activeQuery.childIndex]
+      if (!previousSuggestion || previousSuggestion.results.length === 0) {
+        return nextSuggestions
+      }
+
+      nextSuggestions[activeQuery.childIndex] = {
+        queryInfo: activeQuery.queryInfo,
+        results: previousSuggestion.results,
+      }
+
+      return nextSuggestions
+    }, {})
   }
 
   private scheduleSuggestionQuery(
@@ -1837,11 +1915,6 @@ class MentionsInput<
 
     const controller = new AbortController()
     this._queryAbortControllers.set(childIndex, controller)
-    this.setQueryState(childIndex, {
-      queryInfo,
-      results: [],
-      status: 'loading',
-    })
 
     const executeQuery = () => {
       this._queryDebounceTimers.delete(childIndex)
@@ -1871,54 +1944,31 @@ class MentionsInput<
   }
 
   updateMentionsQueries = (plainTextValue: string, caretPosition: number): void => {
+    const activeQueries = this.getActiveSuggestionQueries(plainTextValue, caretPosition)
+
     // Invalidate previous queries. Async results for previous queries will be neglected.
-    this._queryId++
+    const queryId = this._queryId + 1
+    this._queryId = queryId
     this.clearPendingSuggestionRequests()
-    this.suggestions = {}
-    this.setState({
-      suggestions: {},
-      queryStates: {},
-      focusIndex: 0,
-    })
 
-    const value = this.props.value ?? ''
-    const mentionChildren = this.getMentionChildren()
-
-    const positionInValue = mapPlainTextIndex(value, this.state.config, caretPosition, 'NULL')
-
-    // If caret is inside of mention, do not query
-    if (positionInValue === null || positionInValue === undefined) {
+    if (activeQueries.length === 0) {
+      this.replaceSuggestions({}, () => ({
+        queryStates: {},
+        focusIndex: 0,
+      }))
       return
     }
 
-    // Extract substring in between the end of the previous mention and the caret
-    const substringStartIndex = getEndOfLastMention(
-      value.slice(0, Math.max(0, positionInValue)),
-      this.state.config
-    )
-    const substring = plainTextValue.slice(substringStartIndex, caretPosition)
+    const nextSuggestions = this.getPreservedSuggestions(activeQueries)
+    const nextQueryStates = this.getLoadingQueryStates(activeQueries, nextSuggestions)
 
-    // Check if suggestions have to be shown:
-    // Match the trigger patterns of all Mention children on the extracted substring
-    for (const [childIndex, child] of mentionChildren.entries()) {
-      const triggerProp = child.props.trigger ?? '@'
-      const regex = resolveTriggerRegex(triggerProp)
-      const match = substring.match(regex)
-      if (match?.[1] !== undefined && match[2] !== undefined) {
-        const querySequenceStart = substringStartIndex + substring.indexOf(match[1], match.index)
-        this.scheduleSuggestionQuery(
-          this._queryId,
-          childIndex,
-          {
-            childIndex,
-            query: match[2],
-            querySequenceStart,
-            querySequenceEnd: querySequenceStart + match[1].length,
-          },
-          child,
-          regex.flags.includes('u')
-        )
-      }
+    this.replaceSuggestions(nextSuggestions, () => ({
+      queryStates: nextQueryStates,
+      focusIndex: 0,
+    }))
+
+    for (const { childIndex, queryInfo, mentionChild, ignoreAccents } of activeQueries) {
+      this.scheduleSuggestionQuery(queryId, childIndex, queryInfo, mentionChild, ignoreAccents)
     }
   }
 
@@ -1926,12 +1976,10 @@ class MentionsInput<
     // Invalidate previous queries. Async results for previous queries will be neglected.
     this._queryId++
     this.clearPendingSuggestionRequests()
-    this.suggestions = {}
-    this.setState({
-      suggestions: {},
+    this.replaceSuggestions({}, () => ({
       queryStates: {},
       focusIndex: 0,
-    })
+    }))
   }
 
   updateSuggestions = async (
@@ -1955,7 +2003,7 @@ class MentionsInput<
         this._queryAbortControllers.delete(childIndex)
       }
 
-      this.suggestions = {
+      const nextSuggestions = {
         ...this.suggestions,
         [childIndex]: {
           queryInfo,
@@ -1963,26 +2011,26 @@ class MentionsInput<
         },
       }
 
-      const { focusIndex } = this.state
-      const suggestionsCount = countSuggestions(this.suggestions)
-      const nextFocusIndex = this.isInlineAutocomplete()
-        ? 0
-        : focusIndex >= suggestionsCount
-          ? Math.max(suggestionsCount - 1, 0)
-          : focusIndex
+      this.replaceSuggestions(nextSuggestions, (prevState, syncedSuggestions) => {
+        const suggestionsCount = countSuggestions(syncedSuggestions)
+        const nextFocusIndex = this.isInlineAutocomplete()
+          ? 0
+          : prevState.focusIndex >= suggestionsCount
+            ? Math.max(suggestionsCount - 1, 0)
+            : prevState.focusIndex
 
-      this.setState((prevState) => ({
-        suggestions: this.suggestions,
-        focusIndex: nextFocusIndex,
-        queryStates: {
-          ...prevState.queryStates,
-          [childIndex]: {
-            queryInfo,
-            results: data,
-            status: 'success',
+        return {
+          focusIndex: nextFocusIndex,
+          queryStates: {
+            ...prevState.queryStates,
+            [childIndex]: {
+              queryInfo,
+              results: data,
+              status: 'success',
+            },
           },
-        },
-      }))
+        }
+      })
     } catch (error) {
       if (this._queryAbortControllers.get(childIndex) === controller) {
         this._queryAbortControllers.delete(childIndex)
@@ -1992,9 +2040,10 @@ class MentionsInput<
         return
       }
 
-      delete this.suggestions[childIndex]
-      this.setState((prevState) => ({
-        suggestions: { ...this.suggestions },
+      const nextSuggestions = { ...this.suggestions }
+      delete nextSuggestions[childIndex]
+
+      this.replaceSuggestions(nextSuggestions, (prevState) => ({
         queryStates: {
           ...prevState.queryStates,
           [childIndex]: {

--- a/src/MentionsInputLayout.spec.ts
+++ b/src/MentionsInputLayout.spec.ts
@@ -4,6 +4,7 @@ import {
   calculateInlineSuggestionPosition,
   calculateSuggestionsPosition,
   createPendingViewSync,
+  getHighlighterViewPatch,
   mergePendingViewSync,
 } from './MentionsInputLayout'
 
@@ -93,6 +94,62 @@ describe('MentionsInputLayout', () => {
     })
   })
 
+  it('places non-portal suggestions above the caret when its offset creates enough viewport space', () => {
+    const highlighter = document.createElement('div')
+    const suggestions = document.createElement('div')
+    const container = document.createElement('div')
+    const originalInnerHeight = window.innerHeight
+    const originalClientHeight = document.documentElement.clientHeight
+
+    highlighter.style.fontSize = '16px'
+
+    Object.defineProperty(window, 'innerHeight', { value: 180, configurable: true })
+    Object.defineProperty(document.documentElement, 'clientHeight', {
+      value: 180,
+      configurable: true,
+    })
+    Object.defineProperty(highlighter, 'getBoundingClientRect', {
+      value: () => ({
+        left: 10,
+        top: 40,
+        right: 0,
+        bottom: 0,
+        width: 0,
+        height: 0,
+      }),
+    })
+    Object.defineProperty(highlighter, 'offsetWidth', { value: 180, configurable: true })
+    Object.defineProperty(container, 'offsetWidth', { value: 220, configurable: true })
+    Object.defineProperty(suggestions, 'offsetHeight', { value: 80, configurable: true })
+
+    try {
+      const position = calculateSuggestionsPosition({
+        caretPosition: { left: 32, top: 100 },
+        suggestionsPlacement: 'auto',
+        anchorMode: 'caret',
+        resolvedPortalHost: null,
+        suggestions,
+        highlighter,
+        container,
+      })
+
+      expect(position).toEqual({
+        left: 32,
+        top: 4,
+        width: 180,
+      })
+    } finally {
+      Object.defineProperty(window, 'innerHeight', {
+        value: originalInnerHeight,
+        configurable: true,
+      })
+      Object.defineProperty(document.documentElement, 'clientHeight', {
+        value: originalClientHeight,
+        configurable: true,
+      })
+    }
+  })
+
   it('calculates inline suggestion offsets from the caret marker', () => {
     const control = document.createElement('div')
     const highlighter = document.createElement('div')
@@ -157,5 +214,33 @@ describe('MentionsInputLayout', () => {
         { left: 1, top: 2, width: 3 }
       )
     ).toBe(true)
+  })
+
+  it('reads highlighter typography from a single computed style snapshot', () => {
+    const input = document.createElement('textarea')
+    const highlighter = document.createElement('div')
+    const getComputedStyleSpy = jest.spyOn(globalThis, 'getComputedStyle').mockReturnValue({
+      getPropertyValue: (property: string) =>
+        property === 'line-height'
+          ? '24px'
+          : property === 'letter-spacing'
+            ? '0.08em'
+            : '',
+    } as unknown as CSSStyleDeclaration)
+
+    try {
+      const patch = getHighlighterViewPatch(input, highlighter)
+
+      expect(getComputedStyleSpy).toHaveBeenCalledTimes(1)
+      expect(patch?.typography).toHaveLength(2)
+      expect(patch?.typography).toEqual(
+        expect.arrayContaining([
+          { property: 'line-height', value: '24px' },
+          { property: 'letter-spacing', value: '0.08em' },
+        ])
+      )
+    } finally {
+      getComputedStyleSpy.mockRestore()
+    }
   })
 })

--- a/src/MentionsInputLayout.ts
+++ b/src/MentionsInputLayout.ts
@@ -121,6 +121,7 @@ export const getInputInlineStyle = (singleLine?: boolean): CSSProperties => {
   }
 
   if (!singleLine && isMobileSafari()) {
+    // iOS Safari shifts multiline textarea content relative to the mirrored overlay.
     style.marginTop = 1
     style.marginLeft = -3
   }
@@ -216,8 +217,7 @@ export const calculateSuggestionsPosition = ({
     suggestionsPlacement === 'above' ||
     (suggestionsPlacement === 'auto' &&
       viewportRelative.top - highlighter.scrollTop + suggestions.offsetHeight > viewportHeight &&
-      suggestions.offsetHeight <
-        caretOffsetParentRect.top - caretHeight - highlighter.scrollTop)
+      suggestions.offsetHeight < viewportRelative.top - highlighter.scrollTop - caretHeight)
 
   position.top = shouldShowAboveCaret ? top - suggestions.offsetHeight - caretHeight : top
 
@@ -270,18 +270,18 @@ export const getHighlighterViewPatch = (
   }
 
   const height = input.clientHeight ? `${input.clientHeight}px` : null
-  const typography =
-    typeof globalThis.getComputedStyle !== 'function'
-      ? []
-      : TYPOGRAPHIC_STYLE_PROPS.flatMap((property) => {
-          const computed = globalThis.getComputedStyle(input)
-          const value =
-            typeof computed.getPropertyValue === 'function'
-              ? computed.getPropertyValue(property)
-              : ((computed as unknown as Record<string, string | undefined>)[property] ?? '')
+  let typography: Array<{ property: string; value: string }> = []
+  if (typeof globalThis.getComputedStyle === 'function') {
+    const computed = globalThis.getComputedStyle(input)
+    typography = TYPOGRAPHIC_STYLE_PROPS.flatMap((property) => {
+      const value =
+        typeof computed.getPropertyValue === 'function'
+          ? computed.getPropertyValue(property)
+          : ((computed as unknown as Record<string, string | undefined>)[property] ?? '')
 
-          return value ? [{ property, value }] : []
-        })
+      return value ? [{ property, value }] : []
+    })
+  }
 
   return {
     scrollLeft: input.scrollLeft,

--- a/src/MentionsInputSelectors.spec.ts
+++ b/src/MentionsInputSelectors.spec.ts
@@ -1,0 +1,25 @@
+import { getDataProvider } from './MentionsInputSelectors'
+
+describe('MentionsInputSelectors', () => {
+  it('preserves empty display strings when filtering static suggestion data', async () => {
+    const provider = getDataProvider(
+      [
+        { id: '123', display: '' },
+        { id: '123' },
+      ],
+      {
+        ignoreAccents: false,
+        signal: new AbortController().signal,
+        getSubstringIndex: (value: string, query: string) => value.indexOf(query),
+        maxSuggestions: undefined,
+      }
+    )
+
+    await expect(provider('1')).resolves.toEqual([
+      {
+        id: '123',
+        highlights: [{ start: 0, end: 1 }],
+      },
+    ])
+  })
+})

--- a/src/MentionsInputSelectors.ts
+++ b/src/MentionsInputSelectors.ts
@@ -269,7 +269,7 @@ export const getDataProvider = <Extra extends Record<string, unknown>>(
             return []
           }
 
-          const index = getSubstringIndex(item.display || String(item.id), query, ignoreAccents)
+          const index = getSubstringIndex(item.display ?? String(item.id), query, ignoreAccents)
 
           return index >= 0
             ? [

--- a/src/SuggestionsOverlay.spec.tsx
+++ b/src/SuggestionsOverlay.spec.tsx
@@ -233,6 +233,93 @@ describe('SuggestionsOverlay', () => {
     expect(listItems[1]).toHaveClass('custom-item')
   })
 
+  it('applies built-in styling to plain-text empty status content', () => {
+    const { container } = render(
+      <SuggestionsOverlay
+        id="empty-status-overlay"
+        suggestions={{}}
+        focusIndex={0}
+        isOpened
+        statusContent="No suggestions found"
+        statusType="empty"
+      >
+        <Mention trigger="@" data={[]} />
+      </SuggestionsOverlay>
+    )
+
+    const status = container.querySelector('[data-slot="suggestions-status"]')
+    expect(status).not.toBeNull()
+    expect(status).toHaveTextContent('No suggestions found')
+    expect(status).toHaveAttribute('role', 'status')
+    expect(status).toHaveAttribute('data-status-type', 'empty')
+    expect(status).toHaveClass('px-4', 'py-2.5', 'text-left', 'text-sm', 'text-muted-foreground')
+  })
+
+  it('applies the error variant to plain-text status content', () => {
+    const { container } = render(
+      <SuggestionsOverlay
+        id="error-status-overlay"
+        suggestions={{}}
+        focusIndex={0}
+        isOpened
+        statusContent="Unable to load suggestions"
+        statusType="error"
+      >
+        <Mention trigger="@" data={[]} />
+      </SuggestionsOverlay>
+    )
+
+    const status = container.querySelector('[data-slot="suggestions-status"]')
+    expect(status).not.toBeNull()
+    expect(status).toHaveTextContent('Unable to load suggestions')
+    expect(status).toHaveAttribute('role', 'alert')
+    expect(status).toHaveAttribute('data-status-type', 'error')
+    expect(status).toHaveClass('px-4', 'py-2.5', 'text-left', 'text-sm', 'text-destructive')
+    expect(status).not.toHaveClass('text-muted-foreground')
+  })
+
+  it('merges custom status classes with the built-in plain-text status styling', () => {
+    const { container } = render(
+      <SuggestionsOverlay
+        id="custom-status-overlay"
+        suggestions={{}}
+        focusIndex={0}
+        isOpened
+        statusContent="No suggestions found"
+        statusType="empty"
+        statusClassName="custom-status uppercase"
+      >
+        <Mention trigger="@" data={[]} />
+      </SuggestionsOverlay>
+    )
+
+    const status = container.querySelector('[data-slot="suggestions-status"]')
+    expect(status).not.toBeNull()
+    expect(status).toHaveClass('custom-status', 'uppercase', 'px-4', 'py-2.5', 'text-sm')
+  })
+
+  it('does not force built-in status styling onto custom status nodes', () => {
+    const { container, getByTestId } = render(
+      <SuggestionsOverlay
+        id="custom-node-status-overlay"
+        suggestions={{}}
+        focusIndex={0}
+        isOpened
+        statusContent={<span data-testid="custom-status-node">Nothing here</span>}
+        statusType="empty"
+        statusClassName="custom-status"
+      >
+        <Mention trigger="@" data={[]} />
+      </SuggestionsOverlay>
+    )
+
+    const status = container.querySelector('[data-slot="suggestions-status"]')
+    expect(status).not.toBeNull()
+    expect(getByTestId('custom-status-node')).toBeInTheDocument()
+    expect(status).toHaveClass('custom-status')
+    expect(status).not.toHaveClass('px-4', 'py-2.5', 'text-sm', 'text-muted-foreground')
+  })
+
   it('should notify when the user clicks on a suggestion.', () => {
     const suggestions = [
       { id: '1', display: 'First' },

--- a/src/SuggestionsOverlay.tsx
+++ b/src/SuggestionsOverlay.tsx
@@ -55,6 +55,17 @@ const overlayStyles = cva(
 )
 const listStyles =
   'm-0 max-h-64 list-none divide-y divide-border overflow-y-auto scroll-py-1 p-0 focus:outline-none'
+const statusStyles = cva('px-4 py-2.5 text-left text-sm leading-relaxed', {
+  variants: {
+    type: {
+      empty: 'text-muted-foreground',
+      error: 'text-destructive',
+    },
+  },
+  defaultVariants: {
+    type: 'empty',
+  },
+})
 
 function SuggestionsOverlay<Extra extends Record<string, unknown> = Record<string, unknown>>({
   id,
@@ -238,9 +249,16 @@ function SuggestionsOverlay<Extra extends Record<string, unknown> = Record<strin
       return null
     }
 
+    const isPlainTextStatus =
+      typeof statusContent === 'string' || typeof statusContent === 'number'
+    const statusClassNameResolved = cn(
+      isPlainTextStatus ? statusStyles({ type: statusType ?? 'empty' }) : undefined,
+      statusClassName
+    )
+
     return (
       <div
-        className={statusClassName}
+        className={statusClassNameResolved}
         data-slot="suggestions-status"
         data-status-type={statusType ?? undefined}
         role={statusType === 'error' ? 'alert' : 'status'}


### PR DESCRIPTION
…ntionsQueries now computes active queries before invalidating requests, preserves current non-empty suggestions for still-active children with refreshed queryInfo, resets those queries to loading without clearing the rendered list, and uses one helper to keep the instance cache and React state aligned across clear, success, and error updates.

handleDocumentScroll now relies on the existing requestViewSync batching instead of wrapping it in another requestAnimationFrame, the non-portal auto-placement check now accounts for the caret’s viewport-relative position, getHighlighterViewPatch reuses one computed-style snapshot, the Mobile Safari offset hack is documented, and suggestion filtering now preserves empty-string display values instead of falling back to id.

changed InlineAutocomplete.tsx to use explicit CSS-module classes from example.module.css for the inline hint wrapper, text, hidden prefix, and suffix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added visual status indicators for empty and error suggestion states with dedicated styling
  * Enhanced inline autocomplete suggestion styling with improved visual presentation

* **Bug Fixes**
  * Improved suggestions overlay positioning logic
  * Refined async suggestion loading behavior with better state management

* **Chores**
  * Bumped version to 6.0.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve async suggestions in `MentionsInput` while new queries are loading
> - Refactors `updateMentionsQueries` in [MentionsInput.tsx](https://github.com/hbmartin/react-mentions-ts/pull/175/files#diff-5324a6e48c1ed3e0637605dab500fd0e512b7917d46884c35cba8e68698b5473) to keep prior suggestions visible while async queries are in-flight, marking query state as `loading` until results arrive.
> - Introduces `replaceSuggestions` helper for atomic state updates to suggestions, `queryStates`, and `focusIndex`, reducing off-by-one focus issues when results arrive or fail.
> - Removes `requestAnimationFrame` from `handleDocumentScroll` so suggestion positioning syncs immediately on scroll.
> - Fixes `getDataProvider` in [MentionsInputSelectors.ts](https://github.com/hbmartin/react-mentions-ts/pull/175/files#diff-c90f618868bcc692e4549e3767f3a52a01f42df6a8d6d2767a705efbb5cf574b) to preserve empty-string display values using nullish coalescing instead of `||`.
> - Bumps package version from `5.4.8` to `6.0.0`.
> - Behavioral Change: suggestions no longer disappear between async fetches; users see stale results until fresh ones arrive.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9f231b3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->