### PR TITLE
MentionsInput now delegates child preparation, derived mention snapsh…

### DIFF
--- a/demo/src/examples/AsyncGithubUserMentions.tsx
+++ b/demo/src/examples/AsyncGithubUserMentions.tsx
@@ -9,6 +9,8 @@ import {
   mergeClassNames,
   multilineMentionsClassNames,
 } from './mentionsClassNames'
+import RenderTraceBadge from './profiling/RenderTraceBadge'
+import { useRenderTrace } from './profiling/useRenderTrace'
 
 async function fetchUsers(
   query: string,
@@ -34,12 +36,14 @@ const githubSuggestions = mergeClassNames(multilineMentionsClassNames, {
 
 export default function AsyncGithubUserMentions() {
   const [value, setValue] = useState('')
+  const renderCount = useRenderTrace('AsyncGithubUserMentions')
   const onMentionsChange = ({ value: nextValue }: MentionsInputChangeEvent) => setValue(nextValue)
 
   return (
     <ExampleCard
       title="Async GitHub mentions"
-      description="Hit the public GitHub API as you type — the component handles debouncing and focus management."
+      description="Hit the public GitHub API as you type — the component handles debouncing, cancellation, and stale-result suppression."
+      actions={<RenderTraceBadge count={renderCount} label="Card renders" />}
     >
       <MentionsInput
         value={value}

--- a/demo/src/examples/AutoResize.tsx
+++ b/demo/src/examples/AutoResize.tsx
@@ -7,6 +7,8 @@ import {
   mergeClassNames,
   multilineMentionsClassNames,
 } from './mentionsClassNames'
+import RenderTraceBadge from './profiling/RenderTraceBadge'
+import { useRenderTrace } from './profiling/useRenderTrace'
 
 const autoResizeClasses = mergeClassNames(multilineMentionsClassNames, {
   control: 'min-h-[4.5rem]',
@@ -24,6 +26,7 @@ export default function AutoResize({
   const [value, setValue] = useState(
     'Start typing to watch the composer grow. Try mentioning @[Walter White](user:walter)!'
   )
+  const renderCount = useRenderTrace('AutoResize')
 
   const handleMentionsChange = ({ value: nextValue }: MentionsInputChangeEvent) =>
     setValue(nextValue)
@@ -31,7 +34,8 @@ export default function AutoResize({
   return (
     <ExampleCard
       title="Auto-resizing composer"
-      description="Enable `autoResize` to mirror the textarea height to its scroll height after every change."
+      description="Enable `autoResize` to mirror the textarea height to its scroll height after every change and keep measurement work near the composer."
+      actions={<RenderTraceBadge count={renderCount} label="Card renders" />}
     >
       <MentionsInput
         autoResize

--- a/demo/src/examples/Examples.tsx
+++ b/demo/src/examples/Examples.tsx
@@ -3,9 +3,11 @@ import AsyncGithubUserMentions from './AsyncGithubUserMentions'
 import Emojis from './Emojis'
 import CutCopyPaste from './CutCopyPaste'
 import MultipleTriggers from './MultipleTriggers'
+import ProfilingHarness from './ProfilingHarness'
 import Scrollable from './Scrollable'
 import SingleLine from './SingleLine'
 import SingleLineIgnoringAccents from './SingleLineIgnoringAccents'
+import StateLocalityLab from './StateLocalityLab'
 import SuggestionPortal from './SuggestionPortal'
 import CustomSuggestionsContainer from './CustomSuggestionsContainer'
 import InlineAutocomplete from './InlineAutocomplete'
@@ -77,6 +79,8 @@ const users = [
 export default function Examples() {
   return (
     <div className="grid gap-8">
+      <ProfilingHarness />
+      <StateLocalityLab />
       <MultipleTriggers data={users} onAdd={(addParams) => console.log('onAdd', addParams)} />
       <SingleLine data={users} onAdd={(addParams) => console.log('onAdd', addParams)} />
       <AllowSpaceInQuery data={users} />

--- a/demo/src/examples/InlineAutocomplete.tsx
+++ b/demo/src/examples/InlineAutocomplete.tsx
@@ -4,6 +4,8 @@ import { Mention, MentionsInput } from '../../../src'
 import type { MentionDataItem } from '../../../src'
 import ExampleCard from './ExampleCard'
 import { inlineMentionsClassNames, mentionPillClass, mergeClassNames } from './mentionsClassNames'
+import RenderTraceBadge from './profiling/RenderTraceBadge'
+import { useRenderTrace } from './profiling/useRenderTrace'
 import styles from './example.module.css'
 
 const inlineItalicClasses = mergeClassNames(inlineMentionsClassNames, {
@@ -15,11 +17,13 @@ const inlineItalicClasses = mergeClassNames(inlineMentionsClassNames, {
 
 export default function InlineAutocomplete({ data }: { data: MentionDataItem[] }) {
   const [value, setValue] = useState('')
+  const renderCount = useRenderTrace('InlineAutocomplete')
 
   return (
     <ExampleCard
       title="Inline autocomplete"
-      description="Guide users with subtle, inline completions that respond to Tab, Enter, or →."
+      description="Guide users with subtle, inline completions that respond to Tab, Enter, or → while keeping the overlay branch asleep."
+      actions={<RenderTraceBadge count={renderCount} label="Card renders" />}
     >
       <MentionsInput
         value={value}

--- a/demo/src/examples/ProfilingHarness.tsx
+++ b/demo/src/examples/ProfilingHarness.tsx
@@ -1,0 +1,73 @@
+import ExampleCard from './ExampleCard'
+import RenderTraceBadge from './profiling/RenderTraceBadge'
+import { isProfilingConsoleEnabled, useRenderTrace } from './profiling/useRenderTrace'
+
+const caseStudies = [
+  {
+    title: 'Moving state down',
+    href: '#state-locality-lab',
+    body: 'Toggle the localized controller. The static reference panel should keep its render badge stable.',
+  },
+  {
+    title: 'Inline autocomplete',
+    href: '#inline-autocomplete',
+    body: 'Type `@a`, cycle suggestions, and verify only the inline completion branch churns.',
+  },
+  {
+    title: 'Portal positioning',
+    href: '#suggestions-via-portal',
+    body: 'Scroll the portal host and confirm the overlay keeps its viewport-relative positioning without clipping.',
+  },
+  {
+    title: 'Async race cancellation',
+    href: '#async-github-mentions',
+    body: 'Type quickly through multiple queries and verify stale responses never flash back into the list.',
+  },
+  {
+    title: 'Scroll/resize measurement',
+    href: '#scrollable-composer',
+    body: 'Use the scrollable and auto-resize demos together to confirm measurement work stays local to the composer shell.',
+  },
+]
+
+export default function ProfilingHarness() {
+  const renderCount = useRenderTrace('ProfilingHarness')
+
+  return (
+    <ExampleCard
+      title="Modernization profiling harness"
+      description="Use the live demo as the rehearsal surface for each modernization case study before touching the public API."
+      actions={<RenderTraceBadge count={renderCount} label="Harness renders" />}
+    >
+      <div className="rounded-2xl border border-sky-400/20 bg-sky-500/10 p-4 text-sm leading-relaxed text-sky-100">
+        <p>
+          Run <code>pnpm dev</code> to enable why-did-you-render and console trace logs. Run{' '}
+          <code>pnpm demo</code> for the quieter version with just the in-UI render badges.
+        </p>
+        <p className="mt-2 text-sky-100/80">
+          React Strict Mode is enabled in the demo, so development render counts will be higher than
+          production. Compare relative changes, not absolute totals.
+        </p>
+        <p className="mt-2 text-sky-100/80">
+          Console tracing: {isProfilingConsoleEnabled ? 'enabled' : 'disabled'}.
+        </p>
+      </div>
+
+      <div className="grid gap-3 lg:grid-cols-2">
+        {caseStudies.map((caseStudy) => (
+          <a
+            key={caseStudy.title}
+            href={caseStudy.href}
+            className="rounded-2xl border border-white/10 bg-slate-950/60 p-4 transition hover:border-emerald-300/60 hover:bg-slate-950/80"
+          >
+            <div className="text-xs font-semibold uppercase tracking-[0.24em] text-emerald-200">
+              Case study
+            </div>
+            <h4 className="mt-2 text-base font-semibold text-slate-50">{caseStudy.title}</h4>
+            <p className="mt-2 text-sm leading-relaxed text-slate-300">{caseStudy.body}</p>
+          </a>
+        ))}
+      </div>
+    </ExampleCard>
+  )
+}

--- a/demo/src/examples/Scrollable.tsx
+++ b/demo/src/examples/Scrollable.tsx
@@ -9,6 +9,8 @@ import {
   mergeClassNames,
   multilineMentionsClassNames,
 } from './mentionsClassNames'
+import RenderTraceBadge from './profiling/RenderTraceBadge'
+import { useRenderTrace } from './profiling/useRenderTrace'
 
 const scrollableClasses = mergeClassNames(multilineMentionsClassNames, {
   input: 'h-40 overflow-y-auto',
@@ -25,12 +27,14 @@ export default function Scrollable({
   const [value, setValue] = useState(
     "Hi @[John Doe](user:johndoe), \n\n\nlet's add \n\n@[John Doe](user:johndoe) to this conversation... "
   )
+  const renderCount = useRenderTrace('Scrollable')
   const onMentionsChange = ({ value: nextValue }: MentionsInputChangeEvent) => setValue(nextValue)
 
   return (
     <ExampleCard
       title="Scrollable composer"
-      description="Textarea and highlighter stay perfectly in sync, even while scrolling long drafts."
+      description="Textarea and highlighter stay perfectly in sync, even while scrolling long drafts and recomputing overlay placement."
+      actions={<RenderTraceBadge count={renderCount} label="Card renders" />}
     >
       <MentionsInput
         value={value}

--- a/demo/src/examples/StateLocalityLab.tsx
+++ b/demo/src/examples/StateLocalityLab.tsx
@@ -1,0 +1,83 @@
+import React, { useState } from 'react'
+import ExampleCard from './ExampleCard'
+import RenderTraceBadge from './profiling/RenderTraceBadge'
+import { useRenderTrace } from './profiling/useRenderTrace'
+
+function StaticReferencePanel() {
+  const renderCount = useRenderTrace('StateLocalityLab.StaticReferencePanel')
+
+  return (
+    <section className="rounded-2xl border border-white/10 bg-slate-950/70 p-4">
+      <div className="flex items-center justify-between gap-3">
+        <h4 className="text-sm font-semibold uppercase tracking-[0.24em] text-slate-200">
+          Stable sibling
+        </h4>
+        <RenderTraceBadge count={renderCount} label="Panel renders" />
+      </div>
+      <p className="mt-3 text-sm leading-relaxed text-slate-300">
+        This panel has no local state. It sits beside the controller to prove that moving state down
+        keeps unrelated branches out of the render loop.
+      </p>
+      <ul className="mt-4 space-y-2 text-sm text-slate-200">
+        <li>Selection math lives in the mentions shell, not in decorative siblings.</li>
+        <li>Layout measurements should stay near the DOM nodes that actually need them.</li>
+        <li>Composition is cheaper than sprinkling memoization everywhere.</li>
+      </ul>
+    </section>
+  )
+}
+
+function LocalStateController() {
+  const renderCount = useRenderTrace('StateLocalityLab.LocalStateController')
+  const [isExpanded, setIsExpanded] = useState(false)
+
+  return (
+    <section className="rounded-2xl border border-emerald-400/30 bg-emerald-500/10 p-4">
+      <div className="flex items-center justify-between gap-3">
+        <h4 className="text-sm font-semibold uppercase tracking-[0.24em] text-emerald-100">
+          Local controller
+        </h4>
+        <RenderTraceBadge count={renderCount} label="Controller renders" />
+      </div>
+      <p className="mt-3 text-sm leading-relaxed text-emerald-50/90">
+        Toggle this panel to simulate the modernization directive of moving state into the smallest
+        branch that actually needs it.
+      </p>
+      <button
+        type="button"
+        className="mt-4 inline-flex items-center rounded-full bg-emerald-300/90 px-4 py-2 text-sm font-semibold text-emerald-950 transition hover:bg-emerald-200"
+        onClick={() => setIsExpanded((value) => !value)}
+      >
+        {isExpanded ? 'Collapse localized state' : 'Expand localized state'}
+      </button>
+      {isExpanded ? (
+        <div className="mt-4 rounded-2xl border border-emerald-200/20 bg-emerald-950/30 p-4 text-sm leading-relaxed text-emerald-50">
+          Only this controller should rerender as the state flips. The sibling panel next to it
+          should keep its render count flat.
+        </div>
+      ) : null}
+    </section>
+  )
+}
+
+export default function StateLocalityLab() {
+  const renderCount = useRenderTrace('StateLocalityLab')
+
+  return (
+    <ExampleCard
+      title="State locality lab"
+      description="A miniature rehearsal for the “move state down” directive before applying it to MentionsInput internals."
+      actions={<RenderTraceBadge count={renderCount} label="Card renders" />}
+    >
+      <div className="grid gap-4 lg:grid-cols-2">
+        <StaticReferencePanel />
+        <LocalStateController />
+      </div>
+      <p className="text-sm leading-relaxed text-slate-300">
+        Expected outcome: the controller badge increments when you toggle the panel, while the
+        stable sibling stays flat. That is the same locality goal we want from overlay, inline hint,
+        and measurement work in the library.
+      </p>
+    </ExampleCard>
+  )
+}

--- a/demo/src/examples/SuggestionPortal.tsx
+++ b/demo/src/examples/SuggestionPortal.tsx
@@ -8,6 +8,8 @@ import {
   mentionPillClass,
   multilineMentionsClassNames,
 } from './mentionsClassNames'
+import RenderTraceBadge from './profiling/RenderTraceBadge'
+import { useRenderTrace } from './profiling/useRenderTrace'
 
 const portalClassNames = mergeClassNames(multilineMentionsClassNames, {
   suggestions:
@@ -23,11 +25,13 @@ export default function SuggestionPortal({
 }) {
   const [value, setValue] = useState('')
   const [portalHost, setPortalHost] = useState<HTMLDivElement | null>(null)
+  const renderCount = useRenderTrace('SuggestionPortal')
 
   return (
     <ExampleCard
       title="Suggestions via portal"
       description="Pop suggestion menus anywhere in the DOM. Perfect for modals, drawers, or fixed toolbars."
+      actions={<RenderTraceBadge count={renderCount} label="Card renders" />}
     >
       <div className="relative h-72">
         <div

--- a/demo/src/examples/profiling/RenderTraceBadge.tsx
+++ b/demo/src/examples/profiling/RenderTraceBadge.tsx
@@ -1,0 +1,27 @@
+import { clsx } from 'clsx'
+
+interface RenderTraceBadgeProps {
+  count: number
+  label?: string
+  className?: string
+}
+
+export default function RenderTraceBadge({
+  count,
+  label = 'Renders',
+  className,
+}: RenderTraceBadgeProps) {
+  return (
+    <span
+      className={clsx(
+        'inline-flex items-center gap-2 rounded-full border border-white/15 bg-slate-950/80 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.24em] text-emerald-200',
+        className
+      )}
+    >
+      <span>{label}</span>
+      <span className="rounded-full bg-emerald-400/15 px-2 py-0.5 text-emerald-100">
+        {count.toString()}
+      </span>
+    </span>
+  )
+}

--- a/demo/src/examples/profiling/useRenderTrace.ts
+++ b/demo/src/examples/profiling/useRenderTrace.ts
@@ -1,0 +1,21 @@
+import { useEffect, useRef } from 'react'
+
+const wdyrFlag = String(import.meta.env.VITE_WDYR ?? '').toLowerCase()
+export const isProfilingConsoleEnabled =
+  import.meta.env.DEV && (wdyrFlag === 'true' || wdyrFlag === '1')
+
+export function useRenderTrace(label: string): number {
+  const renderCount = useRef(0)
+  renderCount.current += 1
+  const currentCount = renderCount.current
+
+  useEffect(() => {
+    if (!isProfilingConsoleEnabled) {
+      return
+    }
+
+    console.info(`[trace] ${label} render #${currentCount.toString()}`)
+  }, [currentCount, label])
+
+  return currentCount
+}

--- a/src/Highlighter.tsx
+++ b/src/Highlighter.tsx
@@ -20,13 +20,15 @@ const generateComponentKey = (usedKeys: Record<string, number>, id: string) => {
   return `${id}_${usedKeys[id].toString()}`
 }
 
-interface HighlighterProps {
+interface HighlighterProps<Extra extends Record<string, unknown> = Record<string, unknown>> {
   readonly selectionStart: number | null
   readonly selectionEnd: number | null
   readonly value?: string
   readonly onCaretPositionChange: (position: CaretCoordinates) => void
   readonly containerRef?: (node: HTMLDivElement | null) => void
   readonly children: React.ReactNode
+  readonly mentionChildren?: React.ReactElement<MentionComponentProps<Extra>>[]
+  readonly config?: MentionChildConfig<Extra>[]
   readonly singleLine: boolean
   readonly className?: string
   readonly substringClassName?: string
@@ -58,20 +60,22 @@ const singleLineContentWrapperStyle: CSSProperties = {
 }
 
 // eslint-disable-next-line code-complete/low-function-cohesion
-function Highlighter({
+function Highlighter<Extra extends Record<string, unknown> = Record<string, unknown>>({
   selectionStart,
   selectionEnd,
   value = '',
   onCaretPositionChange,
   containerRef,
   children,
+  mentionChildren: mentionChildrenProp,
+  config: configProp,
   singleLine,
   className,
   substringClassName,
   caretClassName,
   recomputeVersion,
   mentionSelectionMap,
-}: HighlighterProps) {
+}: HighlighterProps<Extra>) {
   const [position, setPosition] = useState<CaretCoordinates | null>(null)
   const [caretElement, setCaretElement] = useState<HTMLSpanElement | null>(null)
 
@@ -120,10 +124,13 @@ function Highlighter({
     // value/selection/singleLine impact layout/position
   }, [caretElement, value, selectionStart, selectionEnd, singleLine, recomputeVersion])
 
-  const mentionChildren = useMemo(() => collectMentionElements(children), [children])
-  const config: MentionChildConfig[] = useMemo(
-    () => readConfigFromChildren(mentionChildren),
-    [mentionChildren]
+  const mentionChildren = useMemo(
+    () => mentionChildrenProp ?? collectMentionElements(children),
+    [children, mentionChildrenProp]
+  )
+  const config: MentionChildConfig<Extra>[] = useMemo(
+    () => configProp ?? readConfigFromChildren<Extra>(mentionChildren),
+    [configProp, mentionChildren]
   )
   let caretPositionInMarkup: number | null | undefined
 

--- a/src/MentionsInput.spec.tsx
+++ b/src/MentionsInput.spec.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
 import { renderToString } from 'react-dom/server'
 import * as utils from './utils'
+import * as readConfigFromChildrenModule from './utils/readConfigFromChildren'
 import { makeTriggerRegex } from './utils/makeTriggerRegex'
 import { Mention, MentionsInput } from './index'
 import type { MentionsInputChangeEvent, MentionSerializer } from './types'
@@ -2232,6 +2233,37 @@ describe('MentionsInput', () => {
       }
     })
 
+    it('does not reparse stable mention children on selection-only updates', async () => {
+      const collectMentionElementsSpy = jest.spyOn(
+        readConfigFromChildrenModule,
+        'collectMentionElements'
+      )
+
+      try {
+        const stableChildren = [<Mention key="mention" trigger="@" data={data} />]
+
+        render(<MentionsInput value="@a">{stableChildren}</MentionsInput>)
+
+        const textarea = screen.getByRole('combobox')
+        fireEvent.focus(textarea)
+
+        await waitFor(() => {
+          expect(collectMentionElementsSpy.mock.calls.length).toBeGreaterThanOrEqual(2)
+        })
+
+        collectMentionElementsSpy.mockClear()
+
+        act(() => {
+          textarea.setSelectionRange(1, 1)
+          fireEvent.select(textarea)
+        })
+
+        expect(collectMentionElementsSpy).not.toHaveBeenCalled()
+      } finally {
+        collectMentionElementsSpy.mockRestore()
+      }
+    })
+
     it('clears cached mentions when the mention config changes', async () => {
       const getMentionsAndPlainTextSpy = jest.spyOn(utils, 'getMentionsAndPlainText')
       try {
@@ -2678,6 +2710,29 @@ describe('MentionsInput', () => {
       unmount()
     })
 
+    it('skips document scroll sync for inline autocomplete when there is no active selection.', () => {
+      const ref = React.createRef<MentionsInput>()
+      const { unmount } = render(
+        <MentionsInput ref={ref} value="@a" suggestionsDisplay="inline">
+          <Mention trigger="@" data={data} />
+        </MentionsInput>
+      )
+
+      const instance = ref.current as unknown as any
+      const requestViewSyncSpy = jest
+        .spyOn(instance, 'requestViewSync')
+        .mockImplementation(() => undefined)
+
+      act(() => {
+        instance.handleDocumentScroll()
+      })
+
+      expect(requestViewSyncSpy).not.toHaveBeenCalled()
+
+      requestViewSyncSpy.mockRestore()
+      unmount()
+    })
+
     it('falls back to immediate document scroll sync when requestAnimationFrame is unavailable.', () => {
       const ref = React.createRef<MentionsInput>()
       const { unmount } = render(
@@ -2707,9 +2762,11 @@ describe('MentionsInput', () => {
           delete (globalThis as typeof globalThis & { requestAnimationFrame?: unknown })
             .requestAnimationFrame
         } else {
-          ;(globalThis as typeof globalThis & {
-            requestAnimationFrame?: typeof globalThis.requestAnimationFrame
-          }).requestAnimationFrame = originalRAF
+          ;(
+            globalThis as typeof globalThis & {
+              requestAnimationFrame?: typeof globalThis.requestAnimationFrame
+            }
+          ).requestAnimationFrame = originalRAF
         }
 
         updateSpy.mockRestore()
@@ -2927,7 +2984,9 @@ describe('MentionsInput', () => {
       )
 
       const instance = ref.current as unknown as any
-      const updateSpy = jest.spyOn(instance, 'updateHighlighterScroll').mockImplementation(() => false)
+      const updateSpy = jest
+        .spyOn(instance, 'updateHighlighterScroll')
+        .mockImplementation(() => false)
       const flushSpy = jest.spyOn(instance, 'flushPendingViewSync')
       const raf = jest
         .spyOn(globalThis, 'requestAnimationFrame')

--- a/src/MentionsInput.tsx
+++ b/src/MentionsInput.tsx
@@ -31,22 +31,25 @@ import {
 import type { PendingViewSync, ViewSyncPatch } from './MentionsInputLayout'
 import {
   getDataProvider,
-  getFocusedSuggestionEntry,
   getInlineSuggestionAnnouncement,
-  getInlineSuggestionDetails,
-  getMentionChild,
-  getMentionChildren,
+  getFocusedSuggestionEntryForMentionChildren,
+  getInlineSuggestionDetailsForMentionChildren,
+  getMentionChildFromArray,
   getSuggestionData,
   getSuggestionQueryStateEntries,
-  getSuggestionsStatusContent,
+  getSuggestionsStatusContentForMentionChildren,
 } from './MentionsInputSelectors'
 import type { InlineSuggestionDetails } from './MentionsInputSelectors'
 import MentionsInputView from './MentionsInputView'
 import SuggestionsOverlay from './SuggestionsOverlay'
 import {
-  applyChangeToValue,
+  applyCutToMentionsValue,
+  applyInputChangeToMentionsValue,
+  applyPasteToMentionsValue,
+  getMarkupSelectionRange,
+} from './MentionsInputEditing'
+import {
   countSuggestions,
-  findStartOfMentionInPlainText,
   getEndOfLastMention,
   getPlainText,
   getMentionsAndPlainText,
@@ -59,9 +62,21 @@ import {
   cn,
 } from './utils'
 import { areMentionSelectionsEqual } from './utils/areMentionSelectionsEqual'
-import { isMentionElement } from './utils/isMentionElement'
 import { makeTriggerRegex } from './utils/makeTriggerRegex'
-import readConfigFromChildren from './utils/readConfigFromChildren'
+import { areMentionConfigsEqual, prepareMentionsInputChildren } from './MentionsInputChildren'
+import { createMentionSelectionContext, deriveMentionValueSnapshot } from './MentionsInputDerived'
+import {
+  applyErroredQueryResult,
+  applySuccessfulQueryResult,
+  createClearedSuggestionsState,
+  createLoadingQueryState,
+  isAbortError,
+} from './MentionsInputQueryState'
+import {
+  areMentionOccurrencesEqual,
+  computeMentionSelectionDetails,
+  getMentionSelectionMap,
+} from './MentionsInputSelection'
 import type {
   CaretCoordinates,
   InputComponentProps,
@@ -69,9 +84,7 @@ import type {
   MentionDataItem,
   MentionIdentifier,
   MentionOccurrence,
-  MentionSelection,
   MentionSelectionState,
-  MentionChildConfig,
   MentionsInputProps,
   MentionsInputState,
   MentionsInputClassNames,
@@ -94,14 +107,6 @@ const createGeneratedId = (): string => {
   generatedIdCounter += 1
   return `mentions-${generatedIdCounter.toString()}`
 }
-
-const isAbortError = (error: unknown): boolean =>
-  typeof DOMException !== 'undefined' && error instanceof DOMException
-    ? error.name === 'AbortError'
-    : typeof error === 'object' &&
-      error !== null &&
-      'name' in error &&
-      (error as { name?: string }).name === 'AbortError'
 
 const KEY = {
   TAB: 'Tab',
@@ -145,39 +150,6 @@ const resolveTriggerRegex = (trigger: string | RegExp): RegExp => {
   // Reconstruct provided RegExp without global flag; whitelist flags to avoid surprises.
   /* eslint-disable-next-line security/detect-non-literal-regexp -- reconstructing a vetted RegExp to strip 'g' */
   return new RegExp(trigger.source, flags)
-}
-
-const getMentionSelectionKey = (childIndex: number, plainTextIndex: number): string =>
-  `${childIndex}:${plainTextIndex}`
-
-// Separate from areMentionSelectionsEqual because here we are deduping the raw mentions
-// produced by getMentions. At this point we only care about the immutable identity of the
-// mention in the document (childIndex + plainText location + id/display). Selection-derived
-// metadata (serializerId, selection state) is computed later when we emit the payload, so
-// comparing the lighter-weight occurrences lets us skip work before we build those objects.
-const areMentionOccurrencesEqual = <Extra extends Record<string, unknown>>(
-  prevMentions: ReadonlyArray<MentionOccurrence<Extra>>,
-  nextMentions: ReadonlyArray<MentionOccurrence<Extra>>
-): boolean => {
-  if (prevMentions.length !== nextMentions.length) {
-    return false
-  }
-
-  return prevMentions.every((mention, index) => {
-    const other = nextMentions[index]
-
-    return (
-      mention.id === other.id &&
-      mention.childIndex === other.childIndex &&
-      mention.plainTextIndex === other.plainTextIndex &&
-      mention.display === other.display
-    )
-  })
-}
-
-interface MentionSelectionComputation<Extra extends Record<string, unknown>> {
-  selections: MentionSelection<Extra>[]
-  selectionMap: Record<string, MentionSelectionState>
 }
 
 interface ActiveSuggestionQuery<Extra extends Record<string, unknown>> {
@@ -246,6 +218,7 @@ class MentionsInput<
   private inputElement: HTMLInputElement | HTMLTextAreaElement | null = null
   private highlighterElement: HTMLDivElement | null = null
   private suggestionsElement: HTMLDivElement | null = null
+  private mentionChildren: React.ReactElement<MentionComponentProps<Extra>>[] = []
   private _queryId = 0
   private _suggestionsMouseDown = false
   private _isComposing = false
@@ -346,48 +319,7 @@ class MentionsInput<
   }
 
   private getMentionChildren() {
-    return getMentionChildren<Extra>(this.props.children)
-  }
-
-  private getInvalidChildLabel(child: React.ReactNode): string {
-    if (React.isValidElement(child)) {
-      return typeof child.type === 'string' ? child.type : child.type?.name || 'unknown component'
-    }
-
-    return 'unknown component'
-  }
-
-  private validateChildTree(children: React.ReactNode, seenChildren: Set<string>): void {
-    React.Children.forEach(children, (child) => {
-      if (
-        React.isValidElement<{ children?: React.ReactNode }>(child) &&
-        child.type === React.Fragment
-      ) {
-        this.validateChildTree(child.props.children, seenChildren)
-        return
-      }
-
-      if (!isMentionElement(child)) {
-        throw new Error(
-          `MentionsInput only accepts Mention components as children. Found: ${this.getInvalidChildLabel(child)}`
-        )
-      }
-
-      const trigger =
-        child.props.trigger === undefined
-          ? DEFAULT_MENTION_PROPS.trigger
-          : typeof child.props.trigger === 'string'
-            ? child.props.trigger
-            : child.props.trigger.source
-
-      if (seenChildren.has(trigger)) {
-        throw new Error(
-          `MentionsInput does not support Mention children with duplicate triggers: ${trigger}.`
-        )
-      }
-
-      seenChildren.add(trigger)
-    })
+    return this.mentionChildren
   }
 
   private getSlotClassName(slot: keyof MentionsInputClassNames, baseClass: string) {
@@ -415,7 +347,11 @@ class MentionsInput<
   }
 
   flushPendingViewSync = (): ViewSyncPatch => {
-    if (this._didUnmount || this._isFlushingViewSync || !hasPendingViewSync(this._pendingViewSync)) {
+    if (
+      this._didUnmount ||
+      this._isFlushingViewSync ||
+      !hasPendingViewSync(this._pendingViewSync)
+    ) {
       return createViewSyncPatch()
     }
 
@@ -463,13 +399,12 @@ class MentionsInput<
   constructor(props: MentionsInputProps<Extra>) {
     super(props)
     this.defaultSuggestionsPortalHost = typeof document === 'undefined' ? null : document.body
-    const initialConfig = readConfigFromChildren<Extra>(props.children)
+    const { mentionChildren, config: initialConfig } = prepareMentionsInputChildren<Extra>(
+      props.children
+    )
+    this.mentionChildren = mentionChildren
     const initialValue = props.value ?? ''
-    const {
-      mentions: initialMentions,
-      plainText: initialPlainText,
-      idValue: initialIdValue,
-    } = getMentionsAndPlainText<Extra>(initialValue, initialConfig)
+    const initialSnapshot = deriveMentionValueSnapshot<Extra>(initialValue, initialConfig)
     this._cachedMarkupValue = initialValue
 
     this.handleCopy = this.handleCopy.bind(this)
@@ -481,9 +416,9 @@ class MentionsInput<
       focusIndex: 0,
       selectionStart: null,
       selectionEnd: null,
-      cachedMentions: initialMentions,
-      cachedPlainText: initialPlainText,
-      cachedIdValue: initialIdValue,
+      cachedMentions: initialSnapshot.mentions,
+      cachedPlainText: initialSnapshot.plainText,
+      cachedIdValue: initialSnapshot.idValue,
       suggestions: {},
       queryStates: {},
       caretPosition: null,
@@ -497,50 +432,22 @@ class MentionsInput<
   }
 
   private validateChildren(): void {
-    const seenChildren = new Set<string>()
-    this.validateChildTree(this.props.children, seenChildren)
+    const { mentionChildren, config: newConfig } = prepareMentionsInputChildren<Extra>(
+      this.props.children
+    )
+    this.mentionChildren = mentionChildren
 
-    // Compute new config and update state if changed
-    const newConfig = readConfigFromChildren<Extra>(this.props.children)
-    if (!this.configsEqual(this.state.config, newConfig)) {
+    if (!areMentionConfigsEqual(this.state.config, newConfig)) {
       const currentValue = this.props.value ?? ''
-      const { mentions: nextMentions, plainText: nextPlainText } = getMentionsAndPlainText<Extra>(
-        currentValue,
-        newConfig
-      )
+      const nextSnapshot = deriveMentionValueSnapshot<Extra>(currentValue, newConfig)
       this.setState({
         config: newConfig,
-        cachedMentions: nextMentions,
-        cachedPlainText: nextPlainText,
+        cachedMentions: nextSnapshot.mentions,
+        cachedPlainText: nextSnapshot.plainText,
+        cachedIdValue: nextSnapshot.idValue,
       })
       this._cachedMarkupValue = currentValue
     }
-  }
-
-  private configsEqual(
-    config1: ReadonlyArray<MentionChildConfig<Extra>>,
-    config2: ReadonlyArray<MentionChildConfig<Extra>>
-  ): boolean {
-    if (config1.length !== config2.length) {
-      return false
-    }
-
-    // eslint-disable-next-line code-complete/enforce-meaningful-names
-    return config1.every((cfg1, index) => {
-      // eslint-disable-next-line code-complete/enforce-meaningful-names
-      const cfg2 = config2[index]
-
-      // Compare key properties that determine config identity
-      return (
-        ((typeof cfg1.trigger === 'string' &&
-          typeof cfg2.trigger === 'string' &&
-          cfg1.trigger === cfg2.trigger) ||
-          (cfg1.trigger instanceof RegExp &&
-            cfg2.trigger instanceof RegExp &&
-            cfg1.trigger.source === cfg2.trigger.source)) &&
-        cfg1.serializer.id === cfg2.serializer.id
-      )
-    })
   }
 
   componentDidMount(): void {
@@ -585,19 +492,21 @@ class MentionsInput<
       this.ensureGeneratedId()
     }
 
-    const recalculatedMentions = valueChanged
-      ? getMentionsAndPlainText<Extra>(currentValue, this.state.config)
+    const recalculatedSnapshot = valueChanged
+      ? deriveMentionValueSnapshot<Extra>(currentValue, this.state.config)
       : null
-    const mentionsForSelection = recalculatedMentions?.mentions ?? this.state.cachedMentions
-    const plainTextForSelection = recalculatedMentions?.plainText ?? this.state.cachedPlainText
-    const idValueForSelection = recalculatedMentions?.idValue ?? this.state.cachedIdValue
+    const snapshotForSelection = recalculatedSnapshot ?? {
+      mentions: this.state.cachedMentions,
+      plainText: this.state.cachedPlainText,
+      idValue: this.state.cachedIdValue,
+    }
 
-    if (recalculatedMentions) {
+    if (recalculatedSnapshot) {
       const {
         mentions: nextMentions,
         plainText: nextPlainText,
         idValue: nextIdValue,
-      } = recalculatedMentions
+      } = recalculatedSnapshot
 
       if (
         !areMentionOccurrencesEqual(nextMentions, this.state.cachedMentions) ||
@@ -648,8 +557,8 @@ class MentionsInput<
     this.flushPendingViewSync()
 
     if (selectionPositionsChanged || valueChanged) {
-      const currentSelection = this.computeMentionSelectionDetails(
-        mentionsForSelection,
+      const currentSelection = computeMentionSelectionDetails(
+        snapshotForSelection.mentions,
         this.state.config,
         this.state.selectionStart,
         this.state.selectionEnd
@@ -657,7 +566,7 @@ class MentionsInput<
       let shouldEmit = selectionPositionsChanged
 
       if (!shouldEmit && valueChanged) {
-        const previousSelection = this.computeMentionSelectionDetails(
+        const previousSelection = computeMentionSelectionDetails(
           prevState.cachedMentions,
           prevState.config,
           prevState.selectionStart,
@@ -671,14 +580,11 @@ class MentionsInput<
 
       if (shouldEmit && this.props.onMentionSelectionChange) {
         const selectionMentionIds = currentSelection.selections.map((selection) => selection.id)
-        const selectionContext = {
-          value: currentValue,
-          plainTextValue: plainTextForSelection,
-          idValue: idValueForSelection,
-          mentions: mentionsForSelection,
-          mentionIds: selectionMentionIds,
-          mentionId: selectionMentionIds.length === 1 ? selectionMentionIds[0] : undefined,
-        }
+        const selectionContext = createMentionSelectionContext(
+          currentValue,
+          snapshotForSelection,
+          selectionMentionIds
+        )
 
         this.props.onMentionSelectionChange(currentSelection.selections, selectionContext)
       }
@@ -895,6 +801,7 @@ class MentionsInput<
     const suggestionsNode = (
       <SuggestionsOverlay<Extra>
         id={overlayId}
+        mentionChildren={this.mentionChildren}
         className={this.props.classNames?.suggestions}
         statusClassName={this.props.classNames?.suggestionsStatus}
         statusContent={statusContent}
@@ -1031,6 +938,8 @@ class MentionsInput<
         className={classNames?.highlighter}
         substringClassName={classNames?.highlighterSubstring}
         caretClassName={classNames?.highlighterCaret}
+        mentionChildren={this.mentionChildren}
+        config={this.state.config}
         value={value}
         singleLine={singleLine ?? MentionsInput.defaultProps.singleLine}
         selectionStart={selectionStart}
@@ -1106,14 +1015,18 @@ class MentionsInput<
   isInlineAutocomplete = (): boolean => this.props.suggestionsDisplay === 'inline'
 
   getFocusedSuggestionEntry = () =>
-    getFocusedSuggestionEntry<Extra>(this.props.children, this.state.suggestions, this.state.focusIndex)
+    getFocusedSuggestionEntryForMentionChildren<Extra>(
+      this.mentionChildren,
+      this.state.suggestions,
+      this.state.focusIndex
+    )
 
   getSuggestionData = (suggestion: SuggestionDataItem<Extra>) => getSuggestionData(suggestion)
 
   getInlineSuggestionDetails = (): InlineSuggestionDetails<Extra> | null =>
     this.isInlineAutocomplete()
-      ? getInlineSuggestionDetails<Extra>(
-          this.props.children,
+      ? getInlineSuggestionDetailsForMentionChildren<Extra>(
+          this.mentionChildren,
           this.state.suggestions,
           this.state.focusIndex
         )
@@ -1143,69 +1056,11 @@ class MentionsInput<
   }
 
   getSuggestionsStatusContent = () =>
-    getSuggestionsStatusContent<Extra>(
-      this.props.children,
+    getSuggestionsStatusContentForMentionChildren<Extra>(
+      this.mentionChildren,
       this.state.suggestions,
       this.state.queryStates
     )
-
-  // eslint-disable-next-line code-complete/low-function-cohesion
-  private readonly computeMentionSelectionDetails = (
-    mentions: ReadonlyArray<MentionOccurrence<Extra>>,
-    config: ReadonlyArray<MentionChildConfig<Extra>>,
-    selectionStart: number | null,
-    selectionEnd: number | null
-  ): MentionSelectionComputation<Extra> => {
-    if (selectionStart === null || selectionEnd === null) {
-      return { selections: [], selectionMap: {} }
-    }
-
-    const start = Math.min(selectionStart, selectionEnd)
-    const end = Math.max(selectionStart, selectionEnd)
-    const isCollapsed = start === end
-
-    if (mentions.length === 0) {
-      return { selections: [], selectionMap: {} }
-    }
-
-    const selections: MentionSelection<Extra>[] = []
-    const selectionMap: Record<string, MentionSelectionState> = {}
-
-    for (const mention of mentions) {
-      const mentionStart = mention.plainTextIndex
-      const mentionEnd = mentionStart + mention.display.length
-      let selectionState: MentionSelectionState | null = null
-
-      if (isCollapsed) {
-        if (start > mentionStart && start < mentionEnd) {
-          selectionState = 'inside'
-        } else if (start === mentionStart || start === mentionEnd) {
-          selectionState = 'boundary'
-        }
-      } else if (start < mentionEnd && end > mentionStart) {
-        selectionState = start <= mentionStart && end >= mentionEnd ? 'full' : 'partial'
-      }
-
-      if (selectionState === null) {
-        continue
-      }
-
-      const serializerId = config[mention.childIndex]?.serializer.id ?? ''
-      const entry: MentionSelection<Extra> = {
-        ...mention,
-        selection: selectionState,
-        plainTextStart: mentionStart,
-        plainTextEnd: mentionEnd,
-        serializerId,
-      }
-
-      selections.push(entry)
-      selectionMap[getMentionSelectionKey(mention.childIndex, mention.plainTextIndex)] =
-        selectionState
-    }
-
-    return { selections, selectionMap }
-  }
 
   private readonly getCurrentMentionSelectionMap = (): Record<string, MentionSelectionState> => {
     const { selectionStart, selectionEnd } = this.state
@@ -1217,15 +1072,9 @@ class MentionsInput<
     const mentions =
       currentValue === this._cachedMarkupValue
         ? this.state.cachedMentions
-        : getMentionsAndPlainText<Extra>(currentValue, this.state.config).mentions
+        : deriveMentionValueSnapshot<Extra>(currentValue, this.state.config).mentions
 
-    const { selectionMap } = this.computeMentionSelectionDetails(
-      mentions,
-      this.state.config,
-      selectionStart,
-      selectionEnd
-    )
-    return selectionMap
+    return getMentionSelectionMap(mentions, this.state.config, selectionStart, selectionEnd)
   }
 
   executeOnChange = (
@@ -1264,59 +1113,28 @@ class MentionsInput<
     const { value } = this.props
     const valueText = value ?? ''
 
-    const safeSelectionStart = selectionStart ?? 0
-    const safeSelectionEnd = selectionEnd ?? safeSelectionStart
-
-    const markupStartIndex = mapPlainTextIndex(
-      valueText,
-      this.state.config,
-      safeSelectionStart,
-      'START'
-    ) as number
-    const markupEndIndex = mapPlainTextIndex(
-      valueText,
-      this.state.config,
-      safeSelectionEnd,
-      'END'
-    ) as number
-
     const clipboardData = event.clipboardData
     const pastedMentions = clipboardData.getData('text/react-mentions')
     const pastedData = clipboardData.getData('text/plain')
-
-    const newValue = spliceString(
+    const pasteResult = applyPasteToMentionsValue<Extra>(
       valueText,
-      markupStartIndex,
-      markupEndIndex,
+      this.state.config,
+      selectionStart,
+      selectionEnd,
       pastedMentions || pastedData
-    ).replaceAll('\r', '')
-
-    const {
-      mentions,
-      plainText: newPlainTextValue,
-      idValue: newIdValue,
-    } = getMentionsAndPlainText<Extra>(newValue, this.state.config)
+    )
 
     this.executeOnChange(
       { type: 'paste', nativeEvent: event },
-      newValue,
-      newPlainTextValue,
-      newIdValue,
-      mentions,
+      pasteResult.value,
+      pasteResult.snapshot.plainText,
+      pasteResult.snapshot.idValue,
+      pasteResult.snapshot.mentions,
       valueText
     )
-
-    // Move the cursor position to the end of the pasted data
-    const startOfMention =
-      selectionStart === null
-        ? undefined
-        : findStartOfMentionInPlainText(valueText, this.state.config, selectionStart)
-    const nextPos =
-      (startOfMention ?? safeSelectionStart) +
-      getPlainText(pastedMentions || pastedData, this.state.config).length
     this.setState({
-      selectionStart: nextPos,
-      selectionEnd: nextPos,
+      selectionStart: pasteResult.nextSelectionStart,
+      selectionEnd: pasteResult.nextSelectionStart,
       pendingSelectionUpdate: true,
     })
   }
@@ -1334,18 +1152,12 @@ class MentionsInput<
     const valueText = value ?? ''
     const clipboardData = event.clipboardData
 
-    const markupStartIndex = mapPlainTextIndex(
+    const { markupStartIndex, markupEndIndex } = getMarkupSelectionRange(
       valueText,
       this.state.config,
       selectionStart,
-      'START'
-    ) as number
-    const markupEndIndex = mapPlainTextIndex(
-      valueText,
-      this.state.config,
-      selectionEnd,
-      'END'
-    ) as number
+      selectionEnd
+    )
 
     clipboardData.setData('text/plain', input.value.slice(selectionStart, selectionEnd))
     clipboardData.setData('text/react-mentions', valueText.slice(markupStartIndex, markupEndIndex))
@@ -1383,44 +1195,25 @@ class MentionsInput<
     const { selectionStart, selectionEnd } = this.state
     const { value } = this.props
     const valueText = value ?? ''
-
-    const safeSelectionStart = selectionStart ?? 0
-    const safeSelectionEnd = selectionEnd ?? safeSelectionStart
-
-    const markupStartIndex = mapPlainTextIndex(
+    const cutResult = applyCutToMentionsValue<Extra>(
       valueText,
       this.state.config,
-      safeSelectionStart,
-      'START'
-    ) as number
-    const markupEndIndex = mapPlainTextIndex(
-      valueText,
-      this.state.config,
-      safeSelectionEnd,
-      'END'
-    ) as number
-
-    const newValue = [valueText.slice(0, markupStartIndex), valueText.slice(markupEndIndex)].join(
-      ''
+      selectionStart,
+      selectionEnd
     )
-    const {
-      mentions,
-      plainText: newPlainTextValue,
-      idValue: newIdValue,
-    } = getMentionsAndPlainText<Extra>(newValue, this.state.config)
 
     this.setState({
-      selectionStart: safeSelectionStart,
-      selectionEnd: safeSelectionStart,
+      selectionStart: cutResult.nextSelectionStart,
+      selectionEnd: cutResult.nextSelectionStart,
       pendingSelectionUpdate: true,
     })
 
     this.executeOnChange(
       { type: 'cut', nativeEvent: event },
-      newValue,
-      newPlainTextValue,
-      newIdValue,
-      mentions,
+      cutResult.value,
+      cutResult.snapshot.plainText,
+      cutResult.snapshot.idValue,
+      cutResult.snapshot.mentions,
       valueText
     )
   }
@@ -1446,67 +1239,44 @@ class MentionsInput<
       selectionEndBefore = ev.target.selectionEnd ?? selectionStartBefore
     }
 
-    // Derive the new value to set by applying the local change in the textarea's plain text
-    const newValue = applyChangeToValue(
-      value,
-      newPlainTextValue,
-      {
-        selectionStartBefore,
-        selectionEndBefore,
-        selectionEndAfter: ev.target.selectionEnd ?? selectionEndBefore,
-      },
-      this.state.config
-    )
-
-    // Recalculate derived representations against the updated markup
-    const {
-      mentions,
-      plainText: recalculatedPlainTextValue,
-      idValue: newIdValue,
-    } = getMentionsAndPlainText<Extra>(newValue, this.state.config)
-    newPlainTextValue = recalculatedPlainTextValue
-
-    // Save current selection after change to be able to restore caret position after rerendering
-    let selectionStart = ev.target.selectionStart ?? selectionStartBefore
-    let selectionEnd = ev.target.selectionEnd ?? selectionEndBefore
-    let shouldRestoreSelection = false
     const nativeEvent = ev.nativeEvent as unknown as CompositionEvent<InputElement> & {
       data?: string | null
       isComposing?: boolean
     }
-
-    // Adjust selection range in case a mention will be deleted by the characters outside of the
-    // selection range that are automatically deleted
-    const startOfMention = findStartOfMentionInPlainText(value, this.state.config, selectionStart)
-
-    if (
-      startOfMention !== undefined &&
-      this.state.selectionEnd !== null &&
-      this.state.selectionEnd > startOfMention
-    ) {
-      // only if a deletion has taken place
-      selectionStart = startOfMention + (nativeEvent.data ? nativeEvent.data.length : 0)
-      selectionEnd = selectionStart
-      shouldRestoreSelection = true
-    }
+    const inputChangeResult = applyInputChangeToMentionsValue<Extra>(
+      value,
+      newPlainTextValue,
+      this.state.config,
+      selectionStartBefore,
+      selectionEndBefore,
+      ev.target.selectionEnd ?? selectionEndBefore,
+      this.state.selectionEnd,
+      nativeEvent.data
+    )
+    newPlainTextValue = inputChangeResult.snapshot.plainText
 
     this.setState((prevState) => ({
-      selectionStart,
-      selectionEnd,
-      pendingSelectionUpdate: prevState.pendingSelectionUpdate || shouldRestoreSelection,
+      selectionStart: inputChangeResult.nextSelectionStart,
+      selectionEnd: inputChangeResult.nextSelectionEnd,
+      pendingSelectionUpdate:
+        prevState.pendingSelectionUpdate || inputChangeResult.shouldRestoreSelection,
     }))
 
-    if (nativeEvent.isComposing && selectionStart === selectionEnd && this.inputElement) {
-      this.updateMentionsQueries(this.inputElement.value, selectionStart)
+    if (
+      nativeEvent.isComposing &&
+      inputChangeResult.nextSelectionStart === inputChangeResult.nextSelectionEnd &&
+      this.inputElement
+    ) {
+      this.updateMentionsQueries(this.inputElement.value, inputChangeResult.nextSelectionStart)
     }
 
     // Propagate change
     this.executeOnChange(
       { type: 'input', nativeEvent: ev.nativeEvent },
-      newValue,
+      inputChangeResult.value,
       newPlainTextValue,
-      newIdValue,
-      mentions,
+      inputChangeResult.snapshot.idValue,
+      inputChangeResult.snapshot.mentions,
       value
     )
 
@@ -1744,7 +1514,10 @@ class MentionsInput<
   }
 
   handleDocumentScroll = (): void => {
-    if (!this.suggestionsElement && !this.isInlineAutocomplete()) {
+    const shouldMeasureInline =
+      this.isInlineAutocomplete() && isNumber(this.state.selectionStart)
+
+    if (!this.suggestionsElement && !shouldMeasureInline) {
       return
     }
 
@@ -1810,10 +1583,14 @@ class MentionsInput<
     ) => Partial<MentionsInputState<Extra>> = () => ({})
   ): void {
     this.suggestions = nextSuggestions
-    this.setState((prevState) => ({
-      suggestions: nextSuggestions,
-      ...getStatePatch(prevState, nextSuggestions),
-    }))
+    this.setState((prevState) => {
+      const statePatch = getStatePatch(prevState, nextSuggestions)
+
+      return {
+        ...statePatch,
+        suggestions: nextSuggestions,
+      } as Pick<MentionsInputState<Extra>, keyof MentionsInputState<Extra>>
+    })
   }
 
   private getActiveSuggestionQueries(
@@ -1868,9 +1645,8 @@ class MentionsInput<
   ): SuggestionQueryStateMap<Extra> {
     return activeQueries.reduce<SuggestionQueryStateMap<Extra>>((queryStates, activeQuery) => {
       queryStates[activeQuery.childIndex] = {
-        queryInfo: activeQuery.queryInfo,
+        ...createLoadingQueryState<Extra>(activeQuery.queryInfo),
         results: nextSuggestions[activeQuery.childIndex]?.results ?? [],
-        status: 'loading',
       }
       return queryStates
     }, {})
@@ -1976,9 +1752,10 @@ class MentionsInput<
     // Invalidate previous queries. Async results for previous queries will be neglected.
     this._queryId++
     this.clearPendingSuggestionRequests()
-    this.replaceSuggestions({}, () => ({
-      queryStates: {},
-      focusIndex: 0,
+    const clearedState = createClearedSuggestionsState<Extra>()
+    this.replaceSuggestions(clearedState.suggestions, () => ({
+      queryStates: clearedState.queryStates,
+      focusIndex: clearedState.focusIndex,
     }))
   }
 
@@ -2003,34 +1780,19 @@ class MentionsInput<
         this._queryAbortControllers.delete(childIndex)
       }
 
-      const nextSuggestions = {
-        ...this.suggestions,
-        [childIndex]: {
-          queryInfo,
-          results: data,
-        },
-      }
-
-      this.replaceSuggestions(nextSuggestions, (prevState, syncedSuggestions) => {
-        const suggestionsCount = countSuggestions(syncedSuggestions)
-        const nextFocusIndex = this.isInlineAutocomplete()
-          ? 0
-          : prevState.focusIndex >= suggestionsCount
-            ? Math.max(suggestionsCount - 1, 0)
-            : prevState.focusIndex
-
-        return {
-          focusIndex: nextFocusIndex,
-          queryStates: {
-            ...prevState.queryStates,
-            [childIndex]: {
-              queryInfo,
-              results: data,
-              status: 'success',
-            },
-          },
-        }
-      })
+      const nextState = applySuccessfulQueryResult(
+        this.suggestions,
+        this.state.queryStates,
+        childIndex,
+        queryInfo,
+        data,
+        this.state.focusIndex,
+        this.isInlineAutocomplete()
+      )
+      this.replaceSuggestions(nextState.suggestions, () => ({
+        focusIndex: nextState.focusIndex,
+        queryStates: nextState.queryStates,
+      }))
     } catch (error) {
       if (this._queryAbortControllers.get(childIndex) === controller) {
         this._queryAbortControllers.delete(childIndex)
@@ -2040,19 +1802,17 @@ class MentionsInput<
         return
       }
 
-      const nextSuggestions = { ...this.suggestions }
-      delete nextSuggestions[childIndex]
-
-      this.replaceSuggestions(nextSuggestions, (prevState) => ({
-        queryStates: {
-          ...prevState.queryStates,
-          [childIndex]: {
-            queryInfo,
-            results: [],
-            status: 'error',
-            error,
-          },
-        },
+      const nextState = applyErroredQueryResult(
+        this.suggestions,
+        this.state.queryStates,
+        childIndex,
+        queryInfo,
+        error,
+        this.state.focusIndex
+      )
+      this.replaceSuggestions(nextState.suggestions, () => ({
+        focusIndex: nextState.focusIndex,
+        queryStates: nextState.queryStates,
       }))
     }
   }
@@ -2065,7 +1825,7 @@ class MentionsInput<
     const { id, display } = this.getSuggestionData(suggestion)
     // Insert mention in the marked up value at the correct position
     const value = this.props.value || ''
-    const mentionsChild = getMentionChild<Extra>(this.props.children, childIndex)
+    const mentionsChild = getMentionChildFromArray<Extra>(this.mentionChildren, childIndex)
     if (!mentionsChild) {
       return
     }

--- a/src/MentionsInputChildren.spec.tsx
+++ b/src/MentionsInputChildren.spec.tsx
@@ -1,0 +1,37 @@
+import React from 'react'
+import { Mention } from './index'
+import {
+  areMentionConfigsEqual,
+  prepareMentionsInputChildren,
+  validateMentionChildTree,
+} from './MentionsInputChildren'
+
+describe('MentionsInputChildren', () => {
+  it('prepares mention children and config from fragments once the tree is validated', () => {
+    const { mentionChildren, config } = prepareMentionsInputChildren(
+      <>
+        <Mention trigger="@" data={[]} />
+        <>
+          <Mention trigger="#" data={[]} />
+        </>
+      </>
+    )
+
+    expect(mentionChildren).toHaveLength(2)
+    expect(config).toHaveLength(2)
+    expect(config[0]?.trigger).toBe('@')
+    expect(config[1]?.trigger).toBe('#')
+    expect(areMentionConfigsEqual(config, config)).toBe(true)
+  })
+
+  it('rejects duplicate triggers during validation', () => {
+    expect(() =>
+      validateMentionChildTree(
+        <>
+          <Mention trigger="@" data={[]} />
+          <Mention trigger="@" data={[]} />
+        </>
+      )
+    ).toThrow('duplicate triggers')
+  })
+})

--- a/src/MentionsInputChildren.ts
+++ b/src/MentionsInputChildren.ts
@@ -1,0 +1,91 @@
+import React from 'react'
+import { DEFAULT_MENTION_PROPS } from './MentionDefaultProps'
+import type { MentionChildConfig, MentionComponentProps } from './types'
+import { isMentionElement } from './utils/isMentionElement'
+import readConfigFromChildren, { collectMentionElements } from './utils/readConfigFromChildren'
+
+export interface PreparedMentionsInputChildren<
+  Extra extends Record<string, unknown> = Record<string, unknown>,
+> {
+  mentionChildren: React.ReactElement<MentionComponentProps<Extra>>[]
+  config: MentionChildConfig<Extra>[]
+}
+
+const getInvalidChildLabel = (child: React.ReactNode): string => {
+  if (React.isValidElement(child)) {
+    return typeof child.type === 'string' ? child.type : child.type?.name || 'unknown component'
+  }
+
+  return 'unknown component'
+}
+
+export const validateMentionChildTree = <Extra extends Record<string, unknown>>(
+  children: React.ReactNode,
+  seenChildren: Set<string> = new Set<string>()
+): void => {
+  React.Children.forEach(children, (child) => {
+    if (
+      React.isValidElement<{ children?: React.ReactNode }>(child) &&
+      child.type === React.Fragment
+    ) {
+      validateMentionChildTree<Extra>(child.props.children, seenChildren)
+      return
+    }
+
+    if (!isMentionElement<Extra>(child)) {
+      throw new Error(
+        `MentionsInput only accepts Mention components as children. Found: ${getInvalidChildLabel(child)}`
+      )
+    }
+
+    const trigger =
+      child.props.trigger === undefined
+        ? DEFAULT_MENTION_PROPS.trigger
+        : typeof child.props.trigger === 'string'
+          ? child.props.trigger
+          : child.props.trigger.source
+
+    if (seenChildren.has(trigger)) {
+      throw new Error(
+        `MentionsInput does not support Mention children with duplicate triggers: ${trigger}.`
+      )
+    }
+
+    seenChildren.add(trigger)
+  })
+}
+
+export const prepareMentionsInputChildren = <Extra extends Record<string, unknown>>(
+  children: React.ReactNode
+): PreparedMentionsInputChildren<Extra> => {
+  validateMentionChildTree<Extra>(children)
+  const mentionChildren = collectMentionElements<Extra>(children)
+
+  return {
+    mentionChildren,
+    config: readConfigFromChildren<Extra>(mentionChildren),
+  }
+}
+
+export const areMentionConfigsEqual = <Extra extends Record<string, unknown>>(
+  config1: ReadonlyArray<MentionChildConfig<Extra>>,
+  config2: ReadonlyArray<MentionChildConfig<Extra>>
+): boolean => {
+  if (config1.length !== config2.length) {
+    return false
+  }
+
+  return config1.every((cfg1, index) => {
+    const cfg2 = config2[index]
+
+    return (
+      ((typeof cfg1.trigger === 'string' &&
+        typeof cfg2.trigger === 'string' &&
+        cfg1.trigger === cfg2.trigger) ||
+        (cfg1.trigger instanceof RegExp &&
+          cfg2.trigger instanceof RegExp &&
+          cfg1.trigger.source === cfg2.trigger.source)) &&
+      cfg1.serializer.id === cfg2.serializer.id
+    )
+  })
+}

--- a/src/MentionsInputDerived.ts
+++ b/src/MentionsInputDerived.ts
@@ -1,0 +1,41 @@
+import type {
+  MentionChildConfig,
+  MentionIdentifier,
+  MentionOccurrence,
+  MentionSelectionChangeEvent,
+} from './types'
+import { getMentionsAndPlainText } from './utils'
+
+export interface MentionValueSnapshot<
+  Extra extends Record<string, unknown> = Record<string, unknown>,
+> {
+  mentions: MentionOccurrence<Extra>[]
+  plainText: string
+  idValue: string
+}
+
+export const deriveMentionValueSnapshot = <Extra extends Record<string, unknown>>(
+  value: string,
+  config: ReadonlyArray<MentionChildConfig<Extra>>
+): MentionValueSnapshot<Extra> => {
+  const { mentions, plainText, idValue } = getMentionsAndPlainText<Extra>(value, config)
+
+  return {
+    mentions,
+    plainText,
+    idValue,
+  }
+}
+
+export const createMentionSelectionContext = <Extra extends Record<string, unknown>>(
+  value: string,
+  snapshot: MentionValueSnapshot<Extra>,
+  mentionIds: MentionIdentifier[]
+): MentionSelectionChangeEvent<Extra> => ({
+  value,
+  plainTextValue: snapshot.plainText,
+  idValue: snapshot.idValue,
+  mentions: snapshot.mentions,
+  mentionIds,
+  mentionId: mentionIds.length === 1 ? mentionIds[0] : undefined,
+})

--- a/src/MentionsInputEditing.spec.tsx
+++ b/src/MentionsInputEditing.spec.tsx
@@ -1,0 +1,38 @@
+import React from 'react'
+import { Mention } from './index'
+import {
+  applyCutToMentionsValue,
+  applyPasteToMentionsValue,
+  getMarkupSelectionRange,
+} from './MentionsInputEditing'
+import readConfigFromChildren from './utils/readConfigFromChildren'
+
+const config = readConfigFromChildren([<Mention key="mention" trigger="@" data={[]} />])
+
+describe('MentionsInputEditing', () => {
+  it('maps plain-text selections back to markup indices', () => {
+    const range = getMarkupSelectionRange('Hello @[Walter White](user:walter)', config, 6, 18)
+
+    expect(range.safeSelectionStart).toBe(6)
+    expect(range.safeSelectionEnd).toBe(18)
+    expect(range.markupStartIndex).toBe(6)
+    expect(range.markupEndIndex).toBe('Hello @[Walter White](user:walter)'.length)
+  })
+
+  it('derives the next snapshot when pasting mention markup', () => {
+    const result = applyPasteToMentionsValue('', config, 0, 0, '@[Walter White](user:walter)')
+
+    expect(result.value).toBe('@[Walter White](user:walter)')
+    expect(result.snapshot.plainText).toBe('Walter White')
+    expect(result.snapshot.mentions[0]?.id).toBe('user:walter')
+    expect(result.nextSelectionStart).toBe('Walter White'.length)
+  })
+
+  it('cuts mention markup while restoring the caret to the selection start', () => {
+    const result = applyCutToMentionsValue('Hello @[Walter White](user:walter)', config, 6, 18)
+
+    expect(result.value).toBe('Hello ')
+    expect(result.snapshot.plainText).toBe('Hello ')
+    expect(result.nextSelectionStart).toBe(6)
+  })
+})

--- a/src/MentionsInputEditing.ts
+++ b/src/MentionsInputEditing.ts
@@ -1,0 +1,152 @@
+import type { MentionChildConfig } from './types'
+import {
+  applyChangeToValue,
+  findStartOfMentionInPlainText,
+  getPlainText,
+  mapPlainTextIndex,
+  spliceString,
+} from './utils'
+import type { MentionValueSnapshot } from './MentionsInputDerived'
+import { deriveMentionValueSnapshot } from './MentionsInputDerived'
+
+export interface MarkupSelectionRange {
+  safeSelectionStart: number
+  safeSelectionEnd: number
+  markupStartIndex: number
+  markupEndIndex: number
+}
+
+export interface PasteResult<Extra extends Record<string, unknown> = Record<string, unknown>> {
+  value: string
+  snapshot: MentionValueSnapshot<Extra>
+  nextSelectionStart: number
+}
+
+export interface CutResult<Extra extends Record<string, unknown> = Record<string, unknown>> {
+  value: string
+  snapshot: MentionValueSnapshot<Extra>
+  nextSelectionStart: number
+}
+
+export interface InputChangeResult<
+  Extra extends Record<string, unknown> = Record<string, unknown>,
+> extends PasteResult<Extra> {
+  nextSelectionEnd: number
+  shouldRestoreSelection: boolean
+}
+
+export const getMarkupSelectionRange = <Extra extends Record<string, unknown>>(
+  value: string,
+  config: ReadonlyArray<MentionChildConfig<Extra>>,
+  selectionStart: number | null,
+  selectionEnd: number | null
+): MarkupSelectionRange => {
+  const safeSelectionStart = selectionStart ?? 0
+  const safeSelectionEnd = selectionEnd ?? safeSelectionStart
+
+  return {
+    safeSelectionStart,
+    safeSelectionEnd,
+    markupStartIndex: mapPlainTextIndex(value, config, safeSelectionStart, 'START') as number,
+    markupEndIndex: mapPlainTextIndex(value, config, safeSelectionEnd, 'END') as number,
+  }
+}
+
+export const applyPasteToMentionsValue = <Extra extends Record<string, unknown>>(
+  value: string,
+  config: ReadonlyArray<MentionChildConfig<Extra>>,
+  selectionStart: number | null,
+  selectionEnd: number | null,
+  pastedText: string
+): PasteResult<Extra> => {
+  const { safeSelectionStart, markupStartIndex, markupEndIndex } = getMarkupSelectionRange(
+    value,
+    config,
+    selectionStart,
+    selectionEnd
+  )
+  const nextValue = spliceString(value, markupStartIndex, markupEndIndex, pastedText).replaceAll(
+    '\r',
+    ''
+  )
+  const snapshot = deriveMentionValueSnapshot<Extra>(nextValue, config)
+  const startOfMention =
+    selectionStart === null
+      ? undefined
+      : findStartOfMentionInPlainText(value, config, selectionStart)
+
+  return {
+    value: nextValue,
+    snapshot,
+    nextSelectionStart:
+      (startOfMention ?? safeSelectionStart) + getPlainText(pastedText, config).length,
+  }
+}
+
+export const applyCutToMentionsValue = <Extra extends Record<string, unknown>>(
+  value: string,
+  config: ReadonlyArray<MentionChildConfig<Extra>>,
+  selectionStart: number | null,
+  selectionEnd: number | null
+): CutResult<Extra> => {
+  const { safeSelectionStart, markupStartIndex, markupEndIndex } = getMarkupSelectionRange(
+    value,
+    config,
+    selectionStart,
+    selectionEnd
+  )
+  const nextValue = [value.slice(0, markupStartIndex), value.slice(markupEndIndex)].join('')
+
+  return {
+    value: nextValue,
+    snapshot: deriveMentionValueSnapshot<Extra>(nextValue, config),
+    nextSelectionStart: safeSelectionStart,
+  }
+}
+
+export const applyInputChangeToMentionsValue = <Extra extends Record<string, unknown>>(
+  value: string,
+  plainTextValue: string,
+  config: ReadonlyArray<MentionChildConfig<Extra>>,
+  selectionStartBefore: number,
+  selectionEndBefore: number,
+  selectionEndAfter: number,
+  trackedSelectionEnd: number | null,
+  insertedText: string | null | undefined
+): InputChangeResult<Extra> => {
+  const nextValue = applyChangeToValue(
+    value,
+    plainTextValue,
+    {
+      selectionStartBefore,
+      selectionEndBefore,
+      selectionEndAfter,
+    },
+    config
+  )
+  const snapshot = deriveMentionValueSnapshot<Extra>(nextValue, config)
+
+  let nextSelectionStart = selectionEndAfter
+  let nextSelectionEnd = selectionEndAfter
+  let shouldRestoreSelection = false
+
+  const startOfMention = findStartOfMentionInPlainText(value, config, nextSelectionStart)
+
+  if (
+    startOfMention !== undefined &&
+    trackedSelectionEnd !== null &&
+    trackedSelectionEnd > startOfMention
+  ) {
+    nextSelectionStart = startOfMention + (insertedText?.length ?? 0)
+    nextSelectionEnd = nextSelectionStart
+    shouldRestoreSelection = true
+  }
+
+  return {
+    value: nextValue,
+    snapshot,
+    nextSelectionStart,
+    nextSelectionEnd,
+    shouldRestoreSelection,
+  }
+}

--- a/src/MentionsInputQueryState.spec.ts
+++ b/src/MentionsInputQueryState.spec.ts
@@ -1,0 +1,102 @@
+import {
+  applyErroredQueryResult,
+  applySuccessfulQueryResult,
+  createClearedSuggestionsState,
+  createLoadingQueryState,
+} from './MentionsInputQueryState'
+
+const queryInfo = {
+  childIndex: 0,
+  query: 'wal',
+  querySequenceStart: 0,
+  querySequenceEnd: 4,
+}
+
+describe('MentionsInputQueryState', () => {
+  it('creates loading state with empty results by default', () => {
+    expect(createLoadingQueryState(queryInfo)).toEqual({
+      queryInfo,
+      results: [],
+      status: 'loading',
+    })
+  })
+
+  it('resets the suggestions lifecycle to an empty state', () => {
+    expect(createClearedSuggestionsState()).toEqual({
+      suggestions: {},
+      queryStates: {},
+      focusIndex: 0,
+    })
+  })
+
+  it('applies successful results and clamps focus when the list shrinks', () => {
+    const nextState = applySuccessfulQueryResult(
+      {
+        0: {
+          queryInfo,
+          results: [
+            { id: 'first', display: 'First' },
+            { id: 'second', display: 'Second' },
+          ],
+        },
+      },
+      {},
+      0,
+      queryInfo,
+      [{ id: 'first', display: 'First' }],
+      4,
+      false
+    )
+
+    expect(nextState.focusIndex).toBe(0)
+    expect(nextState.suggestions[0]?.results).toHaveLength(1)
+    expect(nextState.queryStates[0]?.status).toBe('success')
+  })
+
+  it('removes failed suggestions while keeping the latest error state', () => {
+    const nextState = applyErroredQueryResult(
+      {
+        0: {
+          queryInfo,
+          results: [{ id: 'first', display: 'First' }],
+        },
+      },
+      {},
+      0,
+      queryInfo,
+      new Error('boom'),
+      1
+    )
+
+    expect(nextState.suggestions[0]).toBeUndefined()
+    expect(nextState.focusIndex).toBe(0)
+    expect(nextState.queryStates[0]?.status).toBe('error')
+  })
+
+  it('clamps focus when an errored query removes the focused preserved results', () => {
+    const nextState = applyErroredQueryResult(
+      {
+        0: {
+          queryInfo,
+          results: [
+            { id: 'first', display: 'First' },
+            { id: 'second', display: 'Second' },
+          ],
+        },
+        1: {
+          queryInfo: { ...queryInfo, childIndex: 1 },
+          results: [{ id: 'third', display: 'Third' }],
+        },
+      },
+      {},
+      1,
+      { ...queryInfo, childIndex: 1 },
+      new Error('boom'),
+      2
+    )
+
+    expect(nextState.suggestions[1]).toBeUndefined()
+    expect(nextState.focusIndex).toBe(1)
+    expect(nextState.queryStates[1]?.status).toBe('error')
+  })
+})

--- a/src/MentionsInputQueryState.ts
+++ b/src/MentionsInputQueryState.ts
@@ -1,0 +1,104 @@
+import { countSuggestions } from './utils'
+import type {
+  MentionDataItem,
+  QueryInfo,
+  SuggestionQueryState,
+  SuggestionQueryStateMap,
+  SuggestionsMap,
+} from './types'
+
+export interface SuggestionsLifecycleState<
+  Extra extends Record<string, unknown> = Record<string, unknown>,
+> {
+  suggestions: SuggestionsMap<Extra>
+  queryStates: SuggestionQueryStateMap<Extra>
+  focusIndex: number
+}
+
+export const createClearedSuggestionsState = <
+  Extra extends Record<string, unknown> = Record<string, unknown>,
+>(): SuggestionsLifecycleState<Extra> => ({
+  suggestions: {},
+  queryStates: {},
+  focusIndex: 0,
+})
+
+export const createLoadingQueryState = <Extra extends Record<string, unknown>>(
+  queryInfo: QueryInfo
+): SuggestionQueryState<Extra> => ({
+  queryInfo,
+  results: [],
+  status: 'loading',
+})
+
+export const isAbortError = (error: unknown): boolean =>
+  typeof DOMException !== 'undefined' && error instanceof DOMException
+    ? error.name === 'AbortError'
+    : typeof error === 'object' &&
+      error !== null &&
+      'name' in error &&
+      (error as { name?: string }).name === 'AbortError'
+
+export const applySuccessfulQueryResult = <Extra extends Record<string, unknown>>(
+  currentSuggestions: SuggestionsMap<Extra>,
+  currentQueryStates: SuggestionQueryStateMap<Extra>,
+  childIndex: number,
+  queryInfo: QueryInfo,
+  results: MentionDataItem<Extra>[],
+  focusIndex: number,
+  inlineAutocomplete: boolean
+): SuggestionsLifecycleState<Extra> => {
+  const suggestions: SuggestionsMap<Extra> = {
+    ...currentSuggestions,
+    [childIndex]: {
+      queryInfo,
+      results,
+    },
+  }
+  const suggestionsCount = countSuggestions(suggestions)
+
+  return {
+    suggestions,
+    focusIndex: inlineAutocomplete
+      ? 0
+      : focusIndex >= suggestionsCount
+        ? Math.max(suggestionsCount - 1, 0)
+        : focusIndex,
+    queryStates: {
+      ...currentQueryStates,
+      [childIndex]: {
+        queryInfo,
+        results,
+        status: 'success',
+      },
+    },
+  }
+}
+
+export const applyErroredQueryResult = <Extra extends Record<string, unknown>>(
+  currentSuggestions: SuggestionsMap<Extra>,
+  currentQueryStates: SuggestionQueryStateMap<Extra>,
+  childIndex: number,
+  queryInfo: QueryInfo,
+  error: unknown,
+  focusIndex: number
+): SuggestionsLifecycleState<Extra> => {
+  const suggestions: SuggestionsMap<Extra> = { ...currentSuggestions }
+  delete suggestions[childIndex]
+  const suggestionsCount = countSuggestions(suggestions)
+
+  return {
+    suggestions,
+    focusIndex:
+      focusIndex >= suggestionsCount ? Math.max(suggestionsCount - 1, 0) : focusIndex,
+    queryStates: {
+      ...currentQueryStates,
+      [childIndex]: {
+        queryInfo,
+        results: [],
+        status: 'error',
+        error,
+      },
+    },
+  }
+}

--- a/src/MentionsInputSelection.spec.tsx
+++ b/src/MentionsInputSelection.spec.tsx
@@ -1,0 +1,34 @@
+import React from 'react'
+import { Mention } from './index'
+import { computeMentionSelectionDetails, getMentionSelectionKey } from './MentionsInputSelection'
+import readConfigFromChildren from './utils/readConfigFromChildren'
+
+const config = readConfigFromChildren([<Mention key="mention" trigger="@" data={[]} />])
+const mentions = [
+  {
+    id: 'walter',
+    display: 'Walter White',
+    childIndex: 0,
+    index: 6,
+    plainTextIndex: 6,
+  },
+]
+
+describe('MentionsInputSelection', () => {
+  it('classifies collapsed caret positions as inside or boundary', () => {
+    const inside = computeMentionSelectionDetails(mentions, config, 9, 9)
+    const boundary = computeMentionSelectionDetails(mentions, config, 6, 6)
+
+    expect(inside.selections[0]?.selection).toBe('inside')
+    expect(boundary.selections[0]?.selection).toBe('boundary')
+    expect(inside.selectionMap[getMentionSelectionKey(0, 6)]).toBe('inside')
+  })
+
+  it('classifies range selections as partial or full', () => {
+    const partial = computeMentionSelectionDetails(mentions, config, 3, 10)
+    const full = computeMentionSelectionDetails(mentions, config, 6, 18)
+
+    expect(partial.selections[0]?.selection).toBe('partial')
+    expect(full.selections[0]?.selection).toBe('full')
+  })
+})

--- a/src/MentionsInputSelection.ts
+++ b/src/MentionsInputSelection.ts
@@ -1,0 +1,94 @@
+import type {
+  MentionChildConfig,
+  MentionOccurrence,
+  MentionSelection,
+  MentionSelectionState,
+} from './types'
+
+export interface MentionSelectionComputation<
+  Extra extends Record<string, unknown> = Record<string, unknown>,
+> {
+  selections: MentionSelection<Extra>[]
+  selectionMap: Record<string, MentionSelectionState>
+}
+
+export const getMentionSelectionKey = (childIndex: number, plainTextIndex: number): string =>
+  `${childIndex}:${plainTextIndex}`
+
+export const areMentionOccurrencesEqual = <Extra extends Record<string, unknown>>(
+  prevMentions: ReadonlyArray<MentionOccurrence<Extra>>,
+  nextMentions: ReadonlyArray<MentionOccurrence<Extra>>
+): boolean => {
+  if (prevMentions.length !== nextMentions.length) {
+    return false
+  }
+
+  return prevMentions.every((mention, index) => {
+    const other = nextMentions[index]
+
+    return (
+      mention.id === other.id &&
+      mention.childIndex === other.childIndex &&
+      mention.plainTextIndex === other.plainTextIndex &&
+      mention.display === other.display
+    )
+  })
+}
+
+export const computeMentionSelectionDetails = <Extra extends Record<string, unknown>>(
+  mentions: ReadonlyArray<MentionOccurrence<Extra>>,
+  config: ReadonlyArray<MentionChildConfig<Extra>>,
+  selectionStart: number | null,
+  selectionEnd: number | null
+): MentionSelectionComputation<Extra> => {
+  if (selectionStart === null || selectionEnd === null || mentions.length === 0) {
+    return { selections: [], selectionMap: {} }
+  }
+
+  const start = Math.min(selectionStart, selectionEnd)
+  const end = Math.max(selectionStart, selectionEnd)
+  const isCollapsed = start === end
+  const selections: MentionSelection<Extra>[] = []
+  const selectionMap: Record<string, MentionSelectionState> = {}
+
+  for (const mention of mentions) {
+    const mentionStart = mention.plainTextIndex
+    const mentionEnd = mentionStart + mention.display.length
+    let selectionState: MentionSelectionState | null = null
+
+    if (isCollapsed) {
+      if (start > mentionStart && start < mentionEnd) {
+        selectionState = 'inside'
+      } else if (start === mentionStart || start === mentionEnd) {
+        selectionState = 'boundary'
+      }
+    } else if (start < mentionEnd && end > mentionStart) {
+      selectionState = start <= mentionStart && end >= mentionEnd ? 'full' : 'partial'
+    }
+
+    if (selectionState === null) {
+      continue
+    }
+
+    const serializerId = config[mention.childIndex]?.serializer.id ?? ''
+    selections.push({
+      ...mention,
+      selection: selectionState,
+      plainTextStart: mentionStart,
+      plainTextEnd: mentionEnd,
+      serializerId,
+    })
+    selectionMap[getMentionSelectionKey(mention.childIndex, mention.plainTextIndex)] =
+      selectionState
+  }
+
+  return { selections, selectionMap }
+}
+
+export const getMentionSelectionMap = <Extra extends Record<string, unknown>>(
+  mentions: ReadonlyArray<MentionOccurrence<Extra>>,
+  config: ReadonlyArray<MentionChildConfig<Extra>>,
+  selectionStart: number | null,
+  selectionEnd: number | null
+): Record<string, MentionSelectionState> =>
+  computeMentionSelectionDetails(mentions, config, selectionStart, selectionEnd).selectionMap

--- a/src/MentionsInputSelectors.ts
+++ b/src/MentionsInputSelectors.ts
@@ -34,6 +34,11 @@ export const DEFAULT_EMPTY_SUGGESTIONS_MESSAGE = 'No suggestions found'
 export const DEFAULT_ERROR_SUGGESTIONS_MESSAGE = 'Unable to load suggestions'
 export const INLINE_AUTOCOMPLETE_FALLBACK_ANNOUNCEMENT = 'No inline suggestions available'
 
+export const getMentionChildFromArray = <Extra extends Record<string, unknown>>(
+  mentionChildren: ReadonlyArray<React.ReactElement<MentionComponentProps<Extra>>>,
+  childIndex: number
+): React.ReactElement<MentionComponentProps<Extra>> | undefined => mentionChildren[childIndex]
+
 export const getMentionChildren = <Extra extends Record<string, unknown>>(
   children: React.ReactNode
 ) => collectMentionElements<Extra>(children)
@@ -71,7 +76,13 @@ export const getSuggestionData = <Extra extends Record<string, unknown>>(
 export const getFlattenedSuggestions = <Extra extends Record<string, unknown>>(
   children: React.ReactNode,
   suggestions: SuggestionsMap<Extra>
-): FlattenedSuggestion<Extra>[] => flattenSuggestions<Extra>(getMentionChildren(children), suggestions)
+): FlattenedSuggestion<Extra>[] =>
+  flattenSuggestions<Extra>(getMentionChildren(children), suggestions)
+
+export const getFlattenedSuggestionsForMentionChildren = <Extra extends Record<string, unknown>>(
+  mentionChildren: ReadonlyArray<React.ReactElement<MentionComponentProps<Extra>>>,
+  suggestions: SuggestionsMap<Extra>
+): FlattenedSuggestion<Extra>[] => flattenSuggestions<Extra>(mentionChildren, suggestions)
 
 export const getFocusedSuggestionEntry = <Extra extends Record<string, unknown>>(
   children: React.ReactNode,
@@ -89,7 +100,26 @@ export const getFocusedSuggestionEntry = <Extra extends Record<string, unknown>>
   return flattened[focusIndex] ?? flattened[0]
 }
 
-export const getInlineSuggestionRemainder = (displayValue: string, queryInfo: QueryInfo): string => {
+export const getFocusedSuggestionEntryForMentionChildren = <Extra extends Record<string, unknown>>(
+  mentionChildren: ReadonlyArray<React.ReactElement<MentionComponentProps<Extra>>>,
+  suggestions: SuggestionsMap<Extra>,
+  focusIndex: number
+): {
+  result: SuggestionDataItem<Extra>
+  queryInfo: QueryInfo
+} | null => {
+  const flattened = getFlattenedSuggestionsForMentionChildren(mentionChildren, suggestions)
+  if (flattened.length === 0) {
+    return null
+  }
+
+  return flattened[focusIndex] ?? flattened[0]
+}
+
+export const getInlineSuggestionRemainder = (
+  displayValue: string,
+  queryInfo: QueryInfo
+): string => {
   const query = queryInfo.query ?? ''
   if (query.length === 0) {
     return displayValue
@@ -105,18 +135,22 @@ export const getInlineSuggestionRemainder = (displayValue: string, queryInfo: Qu
   return displayValue
 }
 
-export const getInlineSuggestionDetails = <Extra extends Record<string, unknown>>(
-  children: React.ReactNode,
+export const getInlineSuggestionDetailsForMentionChildren = <Extra extends Record<string, unknown>>(
+  mentionChildren: ReadonlyArray<React.ReactElement<MentionComponentProps<Extra>>>,
   suggestions: SuggestionsMap<Extra>,
   focusIndex: number
 ): InlineSuggestionDetails<Extra> | null => {
-  const entry = getFocusedSuggestionEntry(children, suggestions, focusIndex)
+  const entry = getFocusedSuggestionEntryForMentionChildren(
+    mentionChildren,
+    suggestions,
+    focusIndex
+  )
   if (!entry) {
     return null
   }
 
   const { queryInfo, result } = entry
-  const mentionChild = getMentionChild<Extra>(children, queryInfo.childIndex)
+  const mentionChild = getMentionChildFromArray<Extra>(mentionChildren, queryInfo.childIndex)
   if (!mentionChild) {
     return null
   }
@@ -151,12 +185,38 @@ export const getInlineSuggestionDetails = <Extra extends Record<string, unknown>
   }
 }
 
+export const getInlineSuggestionDetails = <Extra extends Record<string, unknown>>(
+  children: React.ReactNode,
+  suggestions: SuggestionsMap<Extra>,
+  focusIndex: number
+): InlineSuggestionDetails<Extra> | null => {
+  return getInlineSuggestionDetailsForMentionChildren(
+    getMentionChildren(children),
+    suggestions,
+    focusIndex
+  )
+}
+
 export const getPreferredQueryState = <Extra extends Record<string, unknown>>(
   queryStates: SuggestionQueryStateMap<Extra>
 ): SuggestionQueryState<Extra> | null => getSuggestionQueryStateEntries(queryStates)[0]?.[1] ?? null
 
 export const getSuggestionsStatusContent = <Extra extends Record<string, unknown>>(
   children: React.ReactNode,
+  suggestions: SuggestionsMap<Extra>,
+  queryStates: SuggestionQueryStateMap<Extra>
+): SuggestionsStatusContent => {
+  return getSuggestionsStatusContentForMentionChildren(
+    getMentionChildren(children),
+    suggestions,
+    queryStates
+  )
+}
+
+export const getSuggestionsStatusContentForMentionChildren = <
+  Extra extends Record<string, unknown>,
+>(
+  mentionChildren: ReadonlyArray<React.ReactElement<MentionComponentProps<Extra>>>,
   suggestions: SuggestionsMap<Extra>,
   queryStates: SuggestionQueryStateMap<Extra>
 ): SuggestionsStatusContent => {
@@ -169,14 +229,16 @@ export const getSuggestionsStatusContent = <Extra extends Record<string, unknown
     return { statusContent: null, statusType: null }
   }
 
-  const mentionChild = getMentionChild<Extra>(children, preferredQueryState.queryInfo.childIndex)
+  const mentionChild = getMentionChildFromArray<Extra>(
+    mentionChildren,
+    preferredQueryState.queryInfo.childIndex
+  )
   if (!mentionChild) {
     return { statusContent: null, statusType: null }
   }
 
   if (preferredQueryState.status === 'error') {
-    const renderError =
-      mentionChild.props.renderError ?? DEFAULT_MENTION_PROPS.renderError ?? null
+    const renderError = mentionChild.props.renderError ?? DEFAULT_MENTION_PROPS.renderError ?? null
 
     if (!renderError) {
       return {
@@ -238,19 +300,17 @@ export const getInlineSuggestionAnnouncement = <Extra extends Record<string, unk
 }
 
 export const getDataProvider = <Extra extends Record<string, unknown>>(
-  data: ReadonlyArray<MentionDataItem<Extra>> | ((
-    query: string,
-    context: MentionSearchContext
-  ) => Promise<ReadonlyArray<MentionDataItem<Extra>>> | ReadonlyArray<MentionDataItem<Extra>>),
+  data:
+    | ReadonlyArray<MentionDataItem<Extra>>
+    | ((
+        query: string,
+        context: MentionSearchContext
+      ) => Promise<ReadonlyArray<MentionDataItem<Extra>>> | ReadonlyArray<MentionDataItem<Extra>>),
   options: {
     ignoreAccents: boolean
     maxSuggestions?: number
     signal: AbortSignal
-    getSubstringIndex: (
-      string: string,
-      substring: string,
-      ignoreAccents: boolean
-    ) => number
+    getSubstringIndex: (string: string, substring: string, ignoreAccents: boolean) => number
   }
 ): ((query: string) => Promise<MentionDataItem<Extra>[]>) => {
   const { ignoreAccents, maxSuggestions, signal, getSubstringIndex } = options

--- a/src/SuggestionsOverlay.spec.tsx
+++ b/src/SuggestionsOverlay.spec.tsx
@@ -255,6 +255,27 @@ describe('SuggestionsOverlay', () => {
     expect(status).toHaveClass('px-4', 'py-2.5', 'text-left', 'text-sm', 'text-muted-foreground')
   })
 
+  it('renders numeric zero status content', () => {
+    const { container } = render(
+      <SuggestionsOverlay
+        id="zero-status-overlay"
+        suggestions={{}}
+        focusIndex={0}
+        isOpened
+        statusContent={0}
+        statusType="empty"
+      >
+        <Mention trigger="@" data={[]} />
+      </SuggestionsOverlay>
+    )
+
+    const status = container.querySelector('[data-slot="suggestions-status"]')
+    expect(status).not.toBeNull()
+    expect(status).toHaveTextContent('0')
+    expect(status).toHaveAttribute('role', 'status')
+    expect(status).toHaveClass('px-4', 'py-2.5', 'text-sm', 'text-muted-foreground')
+  })
+
   it('applies the error variant to plain-text status content', () => {
     const { container } = render(
       <SuggestionsOverlay

--- a/src/SuggestionsOverlay.tsx
+++ b/src/SuggestionsOverlay.tsx
@@ -32,6 +32,7 @@ interface SuggestionsOverlayProps<Extra extends Record<string, unknown> = Record
   readonly onSelect?: (suggestion: SuggestionDataItem<Extra>, queryInfo: QueryInfo) => void
   readonly containerRef?: (node: HTMLDivElement | null) => void
   readonly children: React.ReactNode
+  readonly mentionChildren?: React.ReactElement<MentionComponentProps<Extra>>[]
   readonly className?: string
   readonly listClassName?: string
   readonly itemClassName?: string
@@ -83,6 +84,7 @@ function SuggestionsOverlay<Extra extends Record<string, unknown> = Record<strin
   onSelect,
   containerRef,
   children,
+  mentionChildren: mentionChildrenProp,
   className,
   listClassName,
   itemClassName,
@@ -101,7 +103,10 @@ function SuggestionsOverlay<Extra extends Record<string, unknown> = Record<strin
   statusType,
 }: SuggestionsOverlayProps<Extra>) {
   const [ulElement, setUlElement] = useState<HTMLUListElement | null>(null)
-  const mentionChildren = useMemo(() => collectMentionElements(children), [children])
+  const mentionChildren = useMemo(
+    () => mentionChildrenProp ?? collectMentionElements(children),
+    [children, mentionChildrenProp]
+  )
   const childRenderSuggestions: (MentionRenderSuggestion<Extra> | null)[] = useMemo(
     () =>
       mentionChildren.map((child) =>
@@ -245,12 +250,11 @@ function SuggestionsOverlay<Extra extends Record<string, unknown> = Record<strin
   }
 
   const renderStatus = (): React.ReactNode => {
-    if (!statusContent) {
+    if (statusContent == null) {
       return null
     }
 
-    const isPlainTextStatus =
-      typeof statusContent === 'string' || typeof statusContent === 'number'
+    const isPlainTextStatus = typeof statusContent === 'string' || typeof statusContent === 'number'
     const statusClassNameResolved = cn(
       isPlainTextStatus ? statusStyles({ type: statusType ?? 'empty' }) : undefined,
       statusClassName


### PR DESCRIPTION
…ots, editing transforms, selection math, and query-state transitions to new private modules, and the parent shell passes precomputed mention children/config into Highlighter and SuggestionsOverlay so the hot path no longer reparses children on normal state updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added render count profiling badges to demo examples for performance monitoring
  * Introduced profiling harness and state locality lab examples for analyzing component behavior

* **Refactor**
  * Refactored core mention input architecture for improved state management and editing
  * Enhanced generic type support for custom data attributes
  * Improved validation and preprocessing of mention configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Delegate child preparation and mention snapshot derivation out of `MentionsInput`
> - Extracts child validation, config comparison, and mention collection into [`MentionsInputChildren.ts`](https://github.com/hbmartin/react-mentions-ts/pull/176/files#diff-b2ba7486cdbe53cb591e94cdde1bae09b90abc61095e79de1e226044a71e28c7); editing operations (paste, cut, input change) into [`MentionsInputEditing.ts`](https://github.com/hbmartin/react-mentions-ts/pull/176/files#diff-b3df56b82bd73708ab9a02bc16bbc028e36890ace15abeb4293a47d4a6bf55c9); query-state transitions into [`MentionsInputQueryState.ts`](https://github.com/hbmartin/react-mentions-ts/pull/176/files#diff-b59066a5e0773121a0ecf23c7947c70804bec622891e97a9b8eb924188ee5a16); and selection classification into [`MentionsInputSelection.ts`](https://github.com/hbmartin/react-mentions-ts/pull/176/files#diff-a6c074254dd1f49615b871af63bca7e5ed908daad204046e1d190fdae59f684b).
> - `MentionsInput` now caches a `mentionChildren` array on construction and config changes, passing it explicitly to `Highlighter` and `SuggestionsOverlay` instead of re-parsing `props.children` on each call.
> - `Highlighter` and `SuggestionsOverlay` accept optional `mentionChildren` and `config` props to skip internal child collection when precomputed values are available.
> - Fixes a bug where `cachedIdValue` was not recalculated when `Mention` children configuration changed.
> - Fixes `handleDocumentScroll` skipping view measurement in inline mode when no valid `selectionStart` exists.
> - Adds profiling utilities (`useRenderTrace`, `RenderTraceBadge`) and two new demo cards (`ProfilingHarness`, `StateLocalityLab`) to the demo app.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a36390d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->