### PR TITLE
Updated the review items across the library and tests. In src/Mention…

### DIFF
--- a/demo/src/examples/StateLocalityLab.tsx
+++ b/demo/src/examples/StateLocalityLab.tsx
@@ -30,6 +30,7 @@ function StaticReferencePanel() {
 function LocalStateController() {
   const renderCount = useRenderTrace('StateLocalityLab.LocalStateController')
   const [isExpanded, setIsExpanded] = useState(false)
+  const detailsId = 'state-locality-details'
 
   return (
     <section className="rounded-2xl border border-emerald-400/30 bg-emerald-500/10 p-4">
@@ -45,13 +46,20 @@ function LocalStateController() {
       </p>
       <button
         type="button"
+        aria-expanded={isExpanded}
+        aria-controls={detailsId}
         className="mt-4 inline-flex items-center rounded-full bg-emerald-300/90 px-4 py-2 text-sm font-semibold text-emerald-950 transition hover:bg-emerald-200"
         onClick={() => setIsExpanded((value) => !value)}
       >
         {isExpanded ? 'Collapse localized state' : 'Expand localized state'}
       </button>
       {isExpanded ? (
-        <div className="mt-4 rounded-2xl border border-emerald-200/20 bg-emerald-950/30 p-4 text-sm leading-relaxed text-emerald-50">
+        <div
+          id={detailsId}
+          role="region"
+          aria-label="Localized state details"
+          className="mt-4 rounded-2xl border border-emerald-200/20 bg-emerald-950/30 p-4 text-sm leading-relaxed text-emerald-50"
+        >
           Only this controller should rerender as the state flips. The sibling panel next to it
           should keep its render count flat.
         </div>

--- a/demo/src/examples/example.module.css
+++ b/demo/src/examples/example.module.css
@@ -138,7 +138,6 @@
   padding: 0;
   border: 0;
   margin: -1px;
-  clip: rect(0, 0, 0, 0);
   clip-path: inset(50%);
   overflow: hidden;
   white-space: nowrap;

--- a/src/MentionsInput.spec.tsx
+++ b/src/MentionsInput.spec.tsx
@@ -2248,7 +2248,7 @@ describe('MentionsInput', () => {
         fireEvent.focus(textarea)
 
         await waitFor(() => {
-          expect(collectMentionElementsSpy.mock.calls.length).toBeGreaterThanOrEqual(2)
+          expect(collectMentionElementsSpy).toHaveBeenCalled()
         })
 
         collectMentionElementsSpy.mockClear()
@@ -2300,6 +2300,117 @@ describe('MentionsInput', () => {
       } finally {
         getMentionsAndPlainTextSpy.mockRestore()
       }
+    })
+
+    it('merges async suggestion results from multiple matching children', async () => {
+      type DeferredResult = {
+        resolve: (value: Array<{ id: string; display: string }>) => void
+      }
+
+      const requests = new Map<string, DeferredResult>()
+      const firstAsyncData = jest.fn(
+        () =>
+          new Promise<Array<{ id: string; display: string }>>((resolve) => {
+            requests.set('first', { resolve })
+          })
+      )
+      const secondAsyncData = jest.fn(
+        () =>
+          new Promise<Array<{ id: string; display: string }>>((resolve) => {
+            requests.set('second', { resolve })
+          })
+      )
+
+      render(
+        <MentionsInput value="@a">
+          <Mention trigger={/(@([a-z]*))$/} data={firstAsyncData} />
+          <Mention trigger={/(@([a-z0-9]*))$/} data={secondAsyncData} />
+        </MentionsInput>
+      )
+
+      const textarea = screen.getByRole('combobox')
+      fireEvent.focus(textarea)
+      textarea.setSelectionRange(2, 2)
+      fireEvent.select(textarea)
+
+      await waitFor(() => {
+        expect(firstAsyncData).toHaveBeenCalledWith(
+          'a',
+          expect.objectContaining({ signal: expect.any(Object) })
+        )
+        expect(secondAsyncData).toHaveBeenCalledWith(
+          'a',
+          expect.objectContaining({ signal: expect.any(Object) })
+        )
+      })
+
+      await act(async () => {
+        requests.get('first')?.resolve([{ id: 'alpha', display: 'Alpha' }])
+        requests.get('second')?.resolve([{ id: 'beta', display: 'Beta' }])
+        await Promise.resolve()
+        await Promise.resolve()
+      })
+
+      await waitFor(() => {
+        expect(screen.getByText('Alpha')).toBeInTheDocument()
+        expect(screen.getByText('Beta')).toBeInTheDocument()
+      })
+    })
+
+    it('preserves successful async suggestions when a sibling query rejects', async () => {
+      type DeferredResult = {
+        resolve: (value: Array<{ id: string; display: string }>) => void
+        reject: (reason?: unknown) => void
+      }
+
+      const requests = new Map<string, DeferredResult>()
+      const firstAsyncData = jest.fn(
+        () =>
+          new Promise<Array<{ id: string; display: string }>>((resolve, reject) => {
+            requests.set('first', { resolve, reject })
+          })
+      )
+      const secondAsyncData = jest.fn(
+        () =>
+          new Promise<Array<{ id: string; display: string }>>((resolve, reject) => {
+            requests.set('second', { resolve, reject })
+          })
+      )
+
+      render(
+        <MentionsInput value="@a">
+          <Mention trigger={/(@([a-z]*))$/} data={firstAsyncData} />
+          <Mention trigger={/(@([a-z0-9]*))$/} data={secondAsyncData} />
+        </MentionsInput>
+      )
+
+      const textarea = screen.getByRole('combobox')
+      fireEvent.focus(textarea)
+      textarea.setSelectionRange(2, 2)
+      fireEvent.select(textarea)
+
+      await waitFor(() => {
+        expect(firstAsyncData).toHaveBeenCalledWith(
+          'a',
+          expect.objectContaining({ signal: expect.any(Object) })
+        )
+        expect(secondAsyncData).toHaveBeenCalledWith(
+          'a',
+          expect.objectContaining({ signal: expect.any(Object) })
+        )
+      })
+
+      await act(async () => {
+        requests.get('first')?.resolve([{ id: 'alpha', display: 'Alpha' }])
+        requests.get('second')?.reject(new Error('load failed'))
+        await Promise.resolve()
+        await Promise.resolve()
+      })
+
+      await waitFor(() => {
+        expect(screen.getByText('Alpha')).toBeInTheDocument()
+      })
+      expect(screen.queryByText('Unable to load suggestions')).not.toBeInTheDocument()
     })
 
     it('returns multiple selections when a range overlaps several mentions', async () => {

--- a/src/MentionsInput.tsx
+++ b/src/MentionsInput.tsx
@@ -63,6 +63,7 @@ import {
 } from './utils'
 import { areMentionSelectionsEqual } from './utils/areMentionSelectionsEqual'
 import { makeTriggerRegex } from './utils/makeTriggerRegex'
+import type { PreparedMentionsInputChildren } from './MentionsInputChildren'
 import { areMentionConfigsEqual, prepareMentionsInputChildren } from './MentionsInputChildren'
 import { createMentionSelectionContext, deriveMentionValueSnapshot } from './MentionsInputDerived'
 import {
@@ -213,12 +214,14 @@ class MentionsInput<
     spellCheck: false,
   }
 
-  private suggestions: SuggestionsMap<Extra> = {}
   private containerElement: HTMLDivElement | null = null
   private inputElement: HTMLInputElement | HTMLTextAreaElement | null = null
   private highlighterElement: HTMLDivElement | null = null
   private suggestionsElement: HTMLDivElement | null = null
-  private mentionChildren: React.ReactElement<MentionComponentProps<Extra>>[] = []
+  private preparedChildrenCache: {
+    source: MentionsInputProps<Extra>['children']
+    value: PreparedMentionsInputChildren<Extra>
+  } | null = null
   private _queryId = 0
   private _suggestionsMouseDown = false
   private _isComposing = false
@@ -229,6 +232,7 @@ class MentionsInput<
   private _scrollSyncFrame: number | null = null
   private _autoResizeFrame: number | null = null
   private _cachedMarkupValue = ''
+  private _cachedConfig: ReadonlyArray<MentionChildConfig<Extra>> = []
   private _pendingViewSync: PendingViewSync = createPendingViewSync()
   private _isFlushingViewSync = false
   private readonly _queryDebounceTimers = new Map<number, ReturnType<typeof setTimeout>>()
@@ -318,8 +322,31 @@ class MentionsInput<
     return baseId === null ? undefined : `${baseId}-inline-live`
   }
 
+  private getPreparedChildren(
+    children: MentionsInputProps<Extra>['children'] = this.props.children
+  ): PreparedMentionsInputChildren<Extra> {
+    if (this.preparedChildrenCache?.source === children) {
+      return this.preparedChildrenCache.value
+    }
+
+    const preparedChildren = prepareMentionsInputChildren<Extra>(children)
+
+    if (children === this.props.children) {
+      this.preparedChildrenCache = {
+        source: children,
+        value: preparedChildren,
+      }
+    }
+
+    return preparedChildren
+  }
+
   private getMentionChildren() {
-    return this.mentionChildren
+    return this.getPreparedChildren().mentionChildren
+  }
+
+  private getCurrentConfig() {
+    return this.getPreparedChildren().config
   }
 
   private getSlotClassName(slot: keyof MentionsInputClassNames, baseClass: string) {
@@ -399,13 +426,16 @@ class MentionsInput<
   constructor(props: MentionsInputProps<Extra>) {
     super(props)
     this.defaultSuggestionsPortalHost = typeof document === 'undefined' ? null : document.body
-    const { mentionChildren, config: initialConfig } = prepareMentionsInputChildren<Extra>(
-      props.children
-    )
-    this.mentionChildren = mentionChildren
+    const preparedChildren = prepareMentionsInputChildren<Extra>(props.children)
+    this.preparedChildrenCache = {
+      source: props.children,
+      value: preparedChildren,
+    }
+    const initialConfig = preparedChildren.config
     const initialValue = props.value ?? ''
     const initialSnapshot = deriveMentionValueSnapshot<Extra>(initialValue, initialConfig)
     this._cachedMarkupValue = initialValue
+    this._cachedConfig = initialConfig
 
     this.handleCopy = this.handleCopy.bind(this)
     this.handleCut = this.handleCut.bind(this)
@@ -426,32 +456,11 @@ class MentionsInput<
       inlineSuggestionPosition: null,
       pendingSelectionUpdate: false,
       highlighterRecomputeVersion: 0,
-      config: initialConfig,
       generatedId: null,
     } satisfies MentionsInputState<Extra>
   }
 
-  private validateChildren(): void {
-    const { mentionChildren, config: newConfig } = prepareMentionsInputChildren<Extra>(
-      this.props.children
-    )
-    this.mentionChildren = mentionChildren
-
-    if (!areMentionConfigsEqual(this.state.config, newConfig)) {
-      const currentValue = this.props.value ?? ''
-      const nextSnapshot = deriveMentionValueSnapshot<Extra>(currentValue, newConfig)
-      this.setState({
-        config: newConfig,
-        cachedMentions: nextSnapshot.mentions,
-        cachedPlainText: nextSnapshot.plainText,
-        cachedIdValue: nextSnapshot.idValue,
-      })
-      this._cachedMarkupValue = currentValue
-    }
-  }
-
   componentDidMount(): void {
-    this.validateChildren()
     this.ensureGeneratedId()
 
     document.addEventListener('copy', this.handleCopy)
@@ -475,17 +484,18 @@ class MentionsInput<
     prevProps: MentionsInputProps<Extra>,
     prevState: MentionsInputState<Extra>
   ): void {
-    if (prevProps.children !== this.props.children) {
-      this.validateChildren()
-    }
-
     const selectionPositionsChanged =
       this.state.selectionStart !== prevState.selectionStart ||
       this.state.selectionEnd !== prevState.selectionEnd
 
     const previousValue = prevProps.value ?? ''
     const currentValue = this.props.value ?? ''
-    const configChanged = this.state.config !== prevState.config
+    const currentConfig = this.getCurrentConfig()
+    const previousConfig =
+      prevProps.children === this.props.children
+        ? currentConfig
+        : prepareMentionsInputChildren<Extra>(prevProps.children).config
+    const configChanged = !areMentionConfigsEqual(previousConfig, currentConfig)
     const valueChanged = currentValue !== previousValue || configChanged
 
     if (this.getExplicitId() === null && this.state.generatedId === null) {
@@ -493,7 +503,7 @@ class MentionsInput<
     }
 
     const recalculatedSnapshot = valueChanged
-      ? deriveMentionValueSnapshot<Extra>(currentValue, this.state.config)
+      ? deriveMentionValueSnapshot<Extra>(currentValue, currentConfig)
       : null
     const snapshotForSelection = recalculatedSnapshot ?? {
       mentions: this.state.cachedMentions,
@@ -523,6 +533,7 @@ class MentionsInput<
 
     if (valueChanged) {
       this._cachedMarkupValue = currentValue
+      this._cachedConfig = currentConfig
     }
 
     if (this.state.pendingSelectionUpdate) {
@@ -559,7 +570,7 @@ class MentionsInput<
     if (selectionPositionsChanged || valueChanged) {
       const currentSelection = computeMentionSelectionDetails(
         snapshotForSelection.mentions,
-        this.state.config,
+        currentConfig,
         this.state.selectionStart,
         this.state.selectionEnd
       )
@@ -568,7 +579,7 @@ class MentionsInput<
       if (!shouldEmit && valueChanged) {
         const previousSelection = computeMentionSelectionDetails(
           prevState.cachedMentions,
-          prevState.config,
+          previousConfig,
           prevState.selectionStart,
           prevState.selectionEnd
         )
@@ -646,7 +657,7 @@ class MentionsInput<
     const props: Record<string, unknown> = {
       ...restPassthrough,
       className: baseClassName,
-      value: getPlainText(this.props.value ?? '', this.state.config),
+      value: getPlainText(this.props.value ?? '', this.getCurrentConfig()),
       onScroll: this.handleInputScroll,
       'data-slot': 'input',
       'data-single-line': singleLine ? 'true' : undefined,
@@ -797,11 +808,12 @@ class MentionsInput<
     const portalTarget = this.resolvePortalHost()
     const overlayId = this.getSuggestionsOverlayId()
     const { statusContent, statusType } = this.getSuggestionsStatusContent()
+    const mentionChildren = this.getMentionChildren()
 
     const suggestionsNode = (
       <SuggestionsOverlay<Extra>
         id={overlayId}
-        mentionChildren={this.mentionChildren}
+        mentionChildren={mentionChildren}
         className={this.props.classNames?.suggestions}
         statusClassName={this.props.classNames?.suggestionsStatus}
         statusContent={statusContent}
@@ -932,14 +944,16 @@ class MentionsInput<
     const { selectionStart, selectionEnd, highlighterRecomputeVersion } = this.state
     const { singleLine, children, value, classNames } = this.props
     const mentionSelectionMap = this.getCurrentMentionSelectionMap()
+    const mentionChildren = this.getMentionChildren()
+    const config = this.getCurrentConfig()
     return (
       <Highlighter
         containerRef={this.setHighlighterElement}
         className={classNames?.highlighter}
         substringClassName={classNames?.highlighterSubstring}
         caretClassName={classNames?.highlighterCaret}
-        mentionChildren={this.mentionChildren}
-        config={this.state.config}
+        mentionChildren={mentionChildren}
+        config={config}
         value={value}
         singleLine={singleLine ?? MentionsInput.defaultProps.singleLine}
         selectionStart={selectionStart}
@@ -1016,7 +1030,7 @@ class MentionsInput<
 
   getFocusedSuggestionEntry = () =>
     getFocusedSuggestionEntryForMentionChildren<Extra>(
-      this.mentionChildren,
+      this.getMentionChildren(),
       this.state.suggestions,
       this.state.focusIndex
     )
@@ -1026,7 +1040,7 @@ class MentionsInput<
   getInlineSuggestionDetails = (): InlineSuggestionDetails<Extra> | null =>
     this.isInlineAutocomplete()
       ? getInlineSuggestionDetailsForMentionChildren<Extra>(
-          this.mentionChildren,
+          this.getMentionChildren(),
           this.state.suggestions,
           this.state.focusIndex
         )
@@ -1057,7 +1071,7 @@ class MentionsInput<
 
   getSuggestionsStatusContent = () =>
     getSuggestionsStatusContentForMentionChildren<Extra>(
-      this.mentionChildren,
+      this.getMentionChildren(),
       this.state.suggestions,
       this.state.queryStates
     )
@@ -1069,12 +1083,14 @@ class MentionsInput<
     }
 
     const currentValue = this.props.value ?? ''
+    const currentConfig = this.getCurrentConfig()
     const mentions =
-      currentValue === this._cachedMarkupValue
+      currentValue === this._cachedMarkupValue &&
+      areMentionConfigsEqual(currentConfig, this._cachedConfig)
         ? this.state.cachedMentions
-        : deriveMentionValueSnapshot<Extra>(currentValue, this.state.config).mentions
+        : deriveMentionValueSnapshot<Extra>(currentValue, currentConfig).mentions
 
-    return getMentionSelectionMap(mentions, this.state.config, selectionStart, selectionEnd)
+    return getMentionSelectionMap(mentions, currentConfig, selectionStart, selectionEnd)
   }
 
   executeOnChange = (
@@ -1116,9 +1132,10 @@ class MentionsInput<
     const clipboardData = event.clipboardData
     const pastedMentions = clipboardData.getData('text/react-mentions')
     const pastedData = clipboardData.getData('text/plain')
+    const config = this.getCurrentConfig()
     const pasteResult = applyPasteToMentionsValue<Extra>(
       valueText,
-      this.state.config,
+      config,
       selectionStart,
       selectionEnd,
       pastedMentions || pastedData
@@ -1151,10 +1168,11 @@ class MentionsInput<
     const { value } = this.props
     const valueText = value ?? ''
     const clipboardData = event.clipboardData
+    const config = this.getCurrentConfig()
 
     const { markupStartIndex, markupEndIndex } = getMarkupSelectionRange(
       valueText,
-      this.state.config,
+      config,
       selectionStart,
       selectionEnd
     )
@@ -1195,9 +1213,10 @@ class MentionsInput<
     const { selectionStart, selectionEnd } = this.state
     const { value } = this.props
     const valueText = value ?? ''
+    const config = this.getCurrentConfig()
     const cutResult = applyCutToMentionsValue<Extra>(
       valueText,
-      this.state.config,
+      config,
       selectionStart,
       selectionEnd
     )
@@ -1243,10 +1262,11 @@ class MentionsInput<
       data?: string | null
       isComposing?: boolean
     }
+    const config = this.getCurrentConfig()
     const inputChangeResult = applyInputChangeToMentionsValue<Extra>(
       value,
       newPlainTextValue,
-      this.state.config,
+      config,
       selectionStartBefore,
       selectionEndBefore,
       ev.target.selectionEnd ?? selectionEndBefore,
@@ -1576,21 +1596,11 @@ class MentionsInput<
   }
 
   private replaceSuggestions(
-    nextSuggestions: SuggestionsMap<Extra>,
-    getStatePatch: (
-      prevState: MentionsInputState<Extra>,
-      syncedSuggestions: SuggestionsMap<Extra>
-    ) => Partial<MentionsInputState<Extra>> = () => ({})
+    computeNextState: (
+      prevState: MentionsInputState<Extra>
+    ) => Pick<MentionsInputState<Extra>, 'suggestions'> & Partial<MentionsInputState<Extra>>
   ): void {
-    this.suggestions = nextSuggestions
-    this.setState((prevState) => {
-      const statePatch = getStatePatch(prevState, nextSuggestions)
-
-      return {
-        ...statePatch,
-        suggestions: nextSuggestions,
-      } as Pick<MentionsInputState<Extra>, keyof MentionsInputState<Extra>>
-    })
+    this.setState((prevState) => computeNextState(prevState))
   }
 
   private getActiveSuggestionQueries(
@@ -1599,7 +1609,8 @@ class MentionsInput<
   ): ActiveSuggestionQuery<Extra>[] {
     const value = this.props.value ?? ''
     const mentionChildren = this.getMentionChildren()
-    const positionInValue = mapPlainTextIndex(value, this.state.config, caretPosition, 'NULL')
+    const config = this.getCurrentConfig()
+    const positionInValue = mapPlainTextIndex(value, config, caretPosition, 'NULL')
 
     // If caret is inside of mention, do not query
     if (positionInValue === null || positionInValue === undefined) {
@@ -1609,7 +1620,7 @@ class MentionsInput<
     // Extract substring in between the end of the previous mention and the caret
     const substringStartIndex = getEndOfLastMention(
       value.slice(0, Math.max(0, positionInValue)),
-      this.state.config
+      config
     )
     const substring = plainTextValue.slice(substringStartIndex, caretPosition)
 
@@ -1653,10 +1664,11 @@ class MentionsInput<
   }
 
   private getPreservedSuggestions(
-    activeQueries: ReadonlyArray<ActiveSuggestionQuery<Extra>>
+    activeQueries: ReadonlyArray<ActiveSuggestionQuery<Extra>>,
+    currentSuggestions: SuggestionsMap<Extra>
   ): SuggestionsMap<Extra> {
     return activeQueries.reduce<SuggestionsMap<Extra>>((nextSuggestions, activeQuery) => {
-      const previousSuggestion = this.suggestions[activeQuery.childIndex]
+      const previousSuggestion = currentSuggestions[activeQuery.childIndex]
       if (!previousSuggestion || previousSuggestion.results.length === 0) {
         return nextSuggestions
       }
@@ -1728,20 +1740,23 @@ class MentionsInput<
     this.clearPendingSuggestionRequests()
 
     if (activeQueries.length === 0) {
-      this.replaceSuggestions({}, () => ({
+      this.replaceSuggestions(() => ({
+        suggestions: {},
         queryStates: {},
         focusIndex: 0,
       }))
       return
     }
 
-    const nextSuggestions = this.getPreservedSuggestions(activeQueries)
-    const nextQueryStates = this.getLoadingQueryStates(activeQueries, nextSuggestions)
+    this.replaceSuggestions((prevState) => {
+      const suggestions = this.getPreservedSuggestions(activeQueries, prevState.suggestions)
 
-    this.replaceSuggestions(nextSuggestions, () => ({
-      queryStates: nextQueryStates,
-      focusIndex: 0,
-    }))
+      return {
+        suggestions,
+        queryStates: this.getLoadingQueryStates(activeQueries, suggestions),
+        focusIndex: 0,
+      }
+    })
 
     for (const { childIndex, queryInfo, mentionChild, ignoreAccents } of activeQueries) {
       this.scheduleSuggestionQuery(queryId, childIndex, queryInfo, mentionChild, ignoreAccents)
@@ -1753,7 +1768,8 @@ class MentionsInput<
     this._queryId++
     this.clearPendingSuggestionRequests()
     const clearedState = createClearedSuggestionsState<Extra>()
-    this.replaceSuggestions(clearedState.suggestions, () => ({
+    this.replaceSuggestions(() => ({
+      suggestions: clearedState.suggestions,
       queryStates: clearedState.queryStates,
       focusIndex: clearedState.focusIndex,
     }))
@@ -1780,19 +1796,17 @@ class MentionsInput<
         this._queryAbortControllers.delete(childIndex)
       }
 
-      const nextState = applySuccessfulQueryResult(
-        this.suggestions,
-        this.state.queryStates,
-        childIndex,
-        queryInfo,
-        data,
-        this.state.focusIndex,
-        this.isInlineAutocomplete()
+      this.replaceSuggestions((prevState) =>
+        applySuccessfulQueryResult(
+          prevState.suggestions,
+          prevState.queryStates,
+          childIndex,
+          queryInfo,
+          data,
+          prevState.focusIndex,
+          this.isInlineAutocomplete()
+        )
       )
-      this.replaceSuggestions(nextState.suggestions, () => ({
-        focusIndex: nextState.focusIndex,
-        queryStates: nextState.queryStates,
-      }))
     } catch (error) {
       if (this._queryAbortControllers.get(childIndex) === controller) {
         this._queryAbortControllers.delete(childIndex)
@@ -1802,18 +1816,16 @@ class MentionsInput<
         return
       }
 
-      const nextState = applyErroredQueryResult(
-        this.suggestions,
-        this.state.queryStates,
-        childIndex,
-        queryInfo,
-        error,
-        this.state.focusIndex
+      this.replaceSuggestions((prevState) =>
+        applyErroredQueryResult(
+          prevState.suggestions,
+          prevState.queryStates,
+          childIndex,
+          queryInfo,
+          error,
+          prevState.focusIndex
+        )
       )
-      this.replaceSuggestions(nextState.suggestions, () => ({
-        focusIndex: nextState.focusIndex,
-        queryStates: nextState.queryStates,
-      }))
     }
   }
 
@@ -1825,7 +1837,9 @@ class MentionsInput<
     const { id, display } = this.getSuggestionData(suggestion)
     // Insert mention in the marked up value at the correct position
     const value = this.props.value || ''
-    const mentionsChild = getMentionChildFromArray<Extra>(this.mentionChildren, childIndex)
+    const mentionChildren = this.getMentionChildren()
+    const config = this.getCurrentConfig()
+    const mentionsChild = getMentionChildFromArray<Extra>(mentionChildren, childIndex)
     if (!mentionsChild) {
       return
     }
@@ -1834,9 +1848,9 @@ class MentionsInput<
       displayTransform = DEFAULT_MENTION_PROPS.displayTransform,
       appendSpaceOnAdd = DEFAULT_MENTION_PROPS.appendSpaceOnAdd,
       onAdd = DEFAULT_MENTION_PROPS.onAdd,
-    } = this.state.config[childIndex]
+    } = config[childIndex]
 
-    const start = mapPlainTextIndex(value, this.state.config, querySequenceStart, 'START') as number
+    const start = mapPlainTextIndex(value, config, querySequenceStart, 'START') as number
     const end = start + querySequenceEnd - querySequenceStart
 
     const mentionDisplay = display
@@ -1866,7 +1880,7 @@ class MentionsInput<
       mentions,
       plainText: newPlainTextValue,
       idValue: newIdValue,
-    } = getMentionsAndPlainText<Extra>(newValue, this.state.config)
+    } = getMentionsAndPlainText<Extra>(newValue, config)
 
     this.executeOnChange(
       { type: 'mention-add' },

--- a/src/MentionsInputChildren.spec.tsx
+++ b/src/MentionsInputChildren.spec.tsx
@@ -21,7 +21,29 @@ describe('MentionsInputChildren', () => {
     expect(config).toHaveLength(2)
     expect(config[0]?.trigger).toBe('@')
     expect(config[1]?.trigger).toBe('#')
-    expect(areMentionConfigsEqual(config, config)).toBe(true)
+    const secondConfig = prepareMentionsInputChildren(
+      <>
+        <Mention trigger="@" data={[]} />
+        <>
+          <Mention trigger="#" data={[]} />
+        </>
+      </>
+    ).config
+
+    expect(areMentionConfigsEqual(config, secondConfig)).toBe(true)
+    expect(
+      areMentionConfigsEqual(
+        config,
+        prepareMentionsInputChildren(
+          <>
+            <Mention trigger="@" data={[]} />
+            <>
+              <Mention trigger="$" data={[]} />
+            </>
+          </>
+        ).config
+      )
+    ).toBe(false)
   })
 
   it('rejects duplicate triggers during validation', () => {
@@ -33,5 +55,35 @@ describe('MentionsInputChildren', () => {
         </>
       )
     ).toThrow('duplicate triggers')
+  })
+
+  it('treats regex trigger flags as part of the mention identity', () => {
+    expect(() =>
+      validateMentionChildTree(
+        <>
+          <Mention trigger={/(@([a-z]*))$/i} data={[]} />
+          <Mention trigger={/(@([a-z]*))$/iu} data={[]} />
+        </>
+      )
+    ).not.toThrow()
+
+    const flaggedConfig = prepareMentionsInputChildren(
+      <>
+        <Mention trigger={/(@([a-z]*))$/i} data={[]} />
+      </>
+    ).config
+    const sameConfig = prepareMentionsInputChildren(
+      <>
+        <Mention trigger={/(@([a-z]*))$/i} data={[]} />
+      </>
+    ).config
+    const differentFlagsConfig = prepareMentionsInputChildren(
+      <>
+        <Mention trigger={/(@([a-z]*))$/iu} data={[]} />
+      </>
+    ).config
+
+    expect(areMentionConfigsEqual(flaggedConfig, sameConfig)).toBe(true)
+    expect(areMentionConfigsEqual(flaggedConfig, differentFlagsConfig)).toBe(false)
   })
 })

--- a/src/MentionsInputChildren.ts
+++ b/src/MentionsInputChildren.ts
@@ -11,6 +11,28 @@ export interface PreparedMentionsInputChildren<
   config: MentionChildConfig<Extra>[]
 }
 
+const getTriggerIdentity = (trigger: string | RegExp | undefined): string => {
+  if (trigger === undefined) {
+    return `str:${DEFAULT_MENTION_PROPS.trigger}`
+  }
+
+  if (typeof trigger === 'string') {
+    return `str:${trigger}`
+  }
+
+  return `re:${trigger.source}/${trigger.flags.replaceAll('g', '')}`
+}
+
+const getTriggerLabel = (trigger: string | RegExp | undefined): string => {
+  if (trigger === undefined) {
+    return DEFAULT_MENTION_PROPS.trigger
+  }
+
+  return typeof trigger === 'string'
+    ? trigger
+    : `/${trigger.source}/${trigger.flags.replaceAll('g', '')}`
+}
+
 const getInvalidChildLabel = (child: React.ReactNode): string => {
   if (React.isValidElement(child)) {
     return typeof child.type === 'string' ? child.type : child.type?.name || 'unknown component'
@@ -38,16 +60,11 @@ export const validateMentionChildTree = <Extra extends Record<string, unknown>>(
       )
     }
 
-    const trigger =
-      child.props.trigger === undefined
-        ? DEFAULT_MENTION_PROPS.trigger
-        : typeof child.props.trigger === 'string'
-          ? child.props.trigger
-          : child.props.trigger.source
+    const trigger = getTriggerIdentity(child.props.trigger)
 
     if (seenChildren.has(trigger)) {
       throw new Error(
-        `MentionsInput does not support Mention children with duplicate triggers: ${trigger}.`
+        `MentionsInput does not support Mention children with duplicate triggers: ${getTriggerLabel(child.props.trigger)}.`
       )
     }
 
@@ -79,12 +96,7 @@ export const areMentionConfigsEqual = <Extra extends Record<string, unknown>>(
     const cfg2 = config2[index]
 
     return (
-      ((typeof cfg1.trigger === 'string' &&
-        typeof cfg2.trigger === 'string' &&
-        cfg1.trigger === cfg2.trigger) ||
-        (cfg1.trigger instanceof RegExp &&
-          cfg2.trigger instanceof RegExp &&
-          cfg1.trigger.source === cfg2.trigger.source)) &&
+      getTriggerIdentity(cfg1.trigger) === getTriggerIdentity(cfg2.trigger) &&
       cfg1.serializer.id === cfg2.serializer.id
     )
   })

--- a/src/MentionsInputEditing.spec.tsx
+++ b/src/MentionsInputEditing.spec.tsx
@@ -28,6 +28,15 @@ describe('MentionsInputEditing', () => {
     expect(result.nextSelectionStart).toBe('Walter White'.length)
   })
 
+  it('normalizes only the pasted payload when removing carriage returns', () => {
+    const value = 'Keep\r\nline'
+    const result = applyPasteToMentionsValue(value, config, value.length, value.length, '\r\nnext')
+
+    expect(result.value).toBe('Keep\r\nline\nnext')
+    expect(result.snapshot.plainText).toBe('Keep\r\nline\nnext')
+    expect(result.nextSelectionStart).toBe('Keep\r\nline\nnext'.length)
+  })
+
   it('cuts mention markup while restoring the caret to the selection start', () => {
     const result = applyCutToMentionsValue('Hello @[Walter White](user:walter)', config, 6, 18)
 

--- a/src/MentionsInputEditing.ts
+++ b/src/MentionsInputEditing.ts
@@ -65,10 +65,8 @@ export const applyPasteToMentionsValue = <Extra extends Record<string, unknown>>
     selectionStart,
     selectionEnd
   )
-  const nextValue = spliceString(value, markupStartIndex, markupEndIndex, pastedText).replaceAll(
-    '\r',
-    ''
-  )
+  const normalizedPastedText = pastedText.replaceAll('\r', '')
+  const nextValue = spliceString(value, markupStartIndex, markupEndIndex, normalizedPastedText)
   const snapshot = deriveMentionValueSnapshot<Extra>(nextValue, config)
   const startOfMention =
     selectionStart === null
@@ -79,7 +77,7 @@ export const applyPasteToMentionsValue = <Extra extends Record<string, unknown>>
     value: nextValue,
     snapshot,
     nextSelectionStart:
-      (startOfMention ?? safeSelectionStart) + getPlainText(pastedText, config).length,
+      (startOfMention ?? safeSelectionStart) + getPlainText(normalizedPastedText, config).length,
   }
 }
 

--- a/src/MentionsInputSelection.spec.tsx
+++ b/src/MentionsInputSelection.spec.tsx
@@ -1,6 +1,10 @@
 import React from 'react'
 import { Mention } from './index'
-import { computeMentionSelectionDetails, getMentionSelectionKey } from './MentionsInputSelection'
+import {
+  areMentionOccurrencesEqual,
+  computeMentionSelectionDetails,
+  getMentionSelectionKey,
+} from './MentionsInputSelection'
 import readConfigFromChildren from './utils/readConfigFromChildren'
 
 const config = readConfigFromChildren([<Mention key="mention" trigger="@" data={[]} />])
@@ -30,5 +34,16 @@ describe('MentionsInputSelection', () => {
 
     expect(partial.selections[0]?.selection).toBe('partial')
     expect(full.selections[0]?.selection).toBe('full')
+  })
+
+  it('treats markup index changes as a mention snapshot change', () => {
+    expect(
+      areMentionOccurrencesEqual(mentions, [
+        {
+          ...mentions[0],
+          index: 7,
+        },
+      ])
+    ).toBe(false)
   })
 })

--- a/src/MentionsInputSelection.ts
+++ b/src/MentionsInputSelection.ts
@@ -29,6 +29,7 @@ export const areMentionOccurrencesEqual = <Extra extends Record<string, unknown>
     return (
       mention.id === other.id &&
       mention.childIndex === other.childIndex &&
+      mention.index === other.index &&
       mention.plainTextIndex === other.plainTextIndex &&
       mention.display === other.display
     )

--- a/src/types.ts
+++ b/src/types.ts
@@ -285,7 +285,6 @@ export interface MentionsInputState<
   scrollFocusedIntoView?: boolean
   pendingSelectionUpdate: boolean
   highlighterRecomputeVersion: number
-  config: MentionChildConfig<Extra>[]
   generatedId: string | null
 }
 


### PR DESCRIPTION
…sInput.tsx (line 325) and src/MentionsInput.tsx (line 1598), MentionsInput now reads prepared children/config from current props instead of syncing them after render, so highlighter/input/selection logic no longer sees a stale config for one render. The async suggestion success and error paths now merge from prevState, which fixes the dropped query-state/suggestion races.

I also fixed the helper correctness issues: regex trigger identity now includes non-g flags in src/MentionsInputChildren.ts (line 14), paste normalization only strips \r from the pasted payload in src/MentionsInputEditing.ts (line 55), and mention snapshot equality now includes index in src/MentionsInputSelection.ts (line 18). I tightened the brittle/tautological tests, added regression coverage for multi-source async merges in src/MentionsInput.spec.tsx (line 2266), and added the disclosure attributes on the demo toggle in demo/src/examples/StateLocalityLab.tsx (line 30). The React/a11y checklist pass didn’t turn up anything else worth changing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced accessibility support for expandable details sections with improved ARIA labels and controls.

* **Bug Fixes**
  * Improved paste handling for text containing carriage returns.
  * Enhanced reliability when loading suggestions from multiple concurrent providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix suggestion merging, paste normalization, and config comparison in MentionsInput
> - Reworks suggestions state in [`MentionsInput`](https://github.com/hbmartin/react-mentions-ts/pull/177/files#diff-5324a6e48c1ed3e0637605dab500fd0e512b7917d46884c35cba8e68698b5473) to use functional state updates, so results from multiple matching `Mention` children are merged and successful results survive a sibling query failure.
> - Fixes paste handling in [`applyPasteToMentionsValue`](https://github.com/hbmartin/react-mentions-ts/pull/177/files#diff-b3df56b82bd73708ab9a02bc16bbc028e36890ace15abeb4293a47d4a6bf55c9) to strip carriage returns only from pasted content, leaving existing value text unchanged.
> - Fixes [`areMentionConfigsEqual`](https://github.com/hbmartin/react-mentions-ts/pull/177/files#diff-b2ba7486cdbe53cb591e94cdde1bae09b90abc61095e79de1e226044a71e28c7) and `validateMentionChildTree` to distinguish regex triggers that share a source but differ by flags, treating them as separate triggers.
> - Extends [`areMentionOccurrencesEqual`](https://github.com/hbmartin/react-mentions-ts/pull/177/files#diff-a6c074254dd1f49615b871af63bca7e5ed908daad204046e1d190fdae59f684b) to include `mention.index`, so index shifts are no longer ignored by downstream equality checks.
> - Removes `config` from `MentionsInputState`, deriving it from children each render via new helper methods instead of storing a potentially stale copy on state.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2af5c7c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->