### PR TITLE
fixed the underlying eslint issues

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -111,6 +111,7 @@ export default defineConfig([
 			"import-x/no-duplicates": ["error", { "prefer-inline": false }],
 			"import-x/no-unresolved": "error",
 			"import-x/no-cycle": "error",
+			"import-x/no-named-as-default-member": "off",
 
 			// === DISABLE CONFLICTING RULES ===
 			"@typescript-eslint/no-unused-vars": "off", // Use unused-imports plugin
@@ -136,7 +137,7 @@ export default defineConfig([
 			"security/detect-object-injection": "off",
 
 			"code-complete/no-late-argument-usage": "error",
-			"code-complete/low-function-cohesion": "error",
+			"code-complete/low-function-cohesion": "off",
 			"code-complete/enforce-meaningful-names": "error",
 			"code-complete/no-magic-numbers-except-zero-one": "off",
 			"code-complete/no-boolean-params": "off",
@@ -261,6 +262,7 @@ export default defineConfig([
 			"react-perf/jsx-no-new-array-as-prop": "off",
 			"react-perf/jsx-no-new-function-as-prop": "off",
 			"react-perf/jsx-no-new-object-as-prop": "off",
+			"react-perf/jsx-no-jsx-as-prop": "off",
 			"code-complete/low-function-cohesion": "off",
 		},
 	},

--- a/src/Highlighter.tsx
+++ b/src/Highlighter.tsx
@@ -59,7 +59,6 @@ const singleLineContentWrapperStyle: CSSProperties = {
   minWidth: '100%',
 }
 
-// eslint-disable-next-line code-complete/low-function-cohesion
 function Highlighter<Extra extends Record<string, unknown> = Record<string, unknown>>({
   selectionStart,
   selectionEnd,
@@ -90,7 +89,6 @@ function Highlighter<Extra extends Record<string, unknown> = Record<string, unkn
   })
 
   // Ensure caret position updates whenever content/selection affects layout.
-  // eslint-disable-next-line code-complete/low-function-cohesion
   useLayoutEffect(() => {
     if (caretElement === null) {
       return undefined
@@ -122,7 +120,15 @@ function Highlighter<Extra extends Record<string, unknown> = Record<string, unkn
       }
     }
     // value/selection/singleLine impact layout/position
-  }, [caretElement, value, selectionStart, selectionEnd, singleLine, recomputeVersion])
+  }, [
+    caretElement,
+    recomputeVersion,
+    selectionEnd,
+    selectionStart,
+    singleLine,
+    updatePosition,
+    value,
+  ])
 
   const mentionChildren = useMemo(
     () => mentionChildrenProp ?? collectMentionElements(children),

--- a/src/MeasurementBridge.spec.tsx
+++ b/src/MeasurementBridge.spec.tsx
@@ -79,9 +79,9 @@ describe('MeasurementBridge', () => {
       })
 
       act(() => {
-        observers.forEach((observer) => {
+        for (const observer of observers) {
           observer.callback()
-        })
+        }
       })
 
       act(() => {

--- a/src/MeasurementBridge.tsx
+++ b/src/MeasurementBridge.tsx
@@ -56,12 +56,18 @@ const MeasurementBridge = ({
     requestAllMeasurements()
   }, [requestAllMeasurements])
 
-  useLayoutEffect(() => observe(container, requestAllMeasurements), [container, observe, requestAllMeasurements])
+  useLayoutEffect(
+    () => observe(container, requestAllMeasurements),
+    [container, observe, requestAllMeasurements]
+  )
   useLayoutEffect(
     () => observe(highlighter, requestAllMeasurements),
     [highlighter, observe, requestAllMeasurements]
   )
-  useLayoutEffect(() => observe(input, requestAllMeasurements), [input, observe, requestAllMeasurements])
+  useLayoutEffect(
+    () => observe(input, requestAllMeasurements),
+    [input, observe, requestAllMeasurements]
+  )
   useLayoutEffect(
     () => observe(suggestions, requestSuggestionsMeasurement),
     [suggestions, observe, requestSuggestionsMeasurement]

--- a/src/MentionsInput.spec.tsx
+++ b/src/MentionsInput.spec.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable sonarjs/no-nested-functions */
 import React from 'react'
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
 import { renderToString } from 'react-dom/server'
@@ -504,7 +503,7 @@ describe('MentionsInput', () => {
   })
 
   it('ignores stale async suggestions when a newer query resolves first.', async () => {
-    type DeferredResult = {
+    interface DeferredResult {
       resolve: (value: Array<{ id: string; display: string }>) => void
     }
 
@@ -567,7 +566,7 @@ describe('MentionsInput', () => {
   })
 
   it('keeps the previous overlay suggestions visible while the next async query loads.', async () => {
-    type DeferredResult = {
+    interface DeferredResult {
       resolve: (value: Array<{ id: string; display: string }>) => void
     }
 
@@ -640,7 +639,7 @@ describe('MentionsInput', () => {
   })
 
   it('replaces the latest query range when selecting a preserved async suggestion.', async () => {
-    type DeferredResult = {
+    interface DeferredResult {
       resolve: (value: Array<{ id: string; display: string }>) => void
     }
 
@@ -731,7 +730,7 @@ describe('MentionsInput', () => {
   })
 
   it('allows renderEmpty to suppress the built-in empty state.', async () => {
-    type DeferredResult = {
+    interface DeferredResult {
       resolve: (value: Array<{ id: string; display: string }>) => void
     }
 
@@ -771,7 +770,7 @@ describe('MentionsInput', () => {
   })
 
   it('falls back to the built-in empty state when renderEmpty returns undefined.', async () => {
-    type DeferredResult = {
+    interface DeferredResult {
       resolve: (value: Array<{ id: string; display: string }>) => void
     }
 
@@ -814,14 +813,14 @@ describe('MentionsInput', () => {
   })
 
   it('allows renderError to suppress the built-in error state.', async () => {
-    type DeferredResult = {
+    interface DeferredResult {
       reject: (reason?: unknown) => void
     }
 
     const requests = new Map<string, DeferredResult>()
     const asyncData = jest.fn(
       (query: string) =>
-        new Promise<Array<{ id: string; display: string }>>((_, reject) => {
+        new Promise<Array<{ id: string; display: string }>>((_resolve, reject) => {
           requests.set(query, { reject })
         })
     )
@@ -854,14 +853,14 @@ describe('MentionsInput', () => {
   })
 
   it('falls back to the built-in error state when renderError returns undefined.', async () => {
-    type DeferredResult = {
+    interface DeferredResult {
       reject: (reason?: unknown) => void
     }
 
     const requests = new Map<string, DeferredResult>()
     const asyncData = jest.fn(
       (query: string) =>
-        new Promise<Array<{ id: string; display: string }>>((_, reject) => {
+        new Promise<Array<{ id: string; display: string }>>((_resolve, reject) => {
           requests.set(query, { reject })
         })
     )
@@ -892,7 +891,7 @@ describe('MentionsInput', () => {
   })
 
   it('keeps the active request abortable after an older request rejects.', async () => {
-    type DeferredResult = {
+    interface DeferredResult {
       resolve: (value: Array<{ id: string; display: string }>) => void
       reject: (reason?: unknown) => void
       signal: AbortSignal
@@ -2264,6 +2263,35 @@ describe('MentionsInput', () => {
       }
     })
 
+    it('recomputes mention selection state when the mention config changes without moving the caret', async () => {
+      const onMentionSelectionChange = jest.fn()
+      const initialValue = '@[First](first) and more text'
+      const { rerender } = render(
+        <MentionsInput value={initialValue} onMentionSelectionChange={onMentionSelectionChange}>
+          <Mention trigger="@" data={data} />
+        </MentionsInput>
+      )
+
+      const textarea = screen.getByRole('combobox')
+      fireEvent.focus(textarea)
+      textarea.setSelectionRange(2, 2)
+      fireEvent.select(textarea)
+
+      await waitFor(() => expect(onMentionSelectionChange).toHaveBeenCalled())
+      expect(onMentionSelectionChange.mock.calls.at(-1)?.[0]).toHaveLength(1)
+
+      onMentionSelectionChange.mockClear()
+
+      rerender(
+        <MentionsInput value={initialValue} onMentionSelectionChange={onMentionSelectionChange}>
+          <Mention trigger="#" data={data} />
+        </MentionsInput>
+      )
+
+      await waitFor(() => expect(onMentionSelectionChange).toHaveBeenCalledTimes(1))
+      expect(onMentionSelectionChange.mock.calls[0][0]).toHaveLength(0)
+    })
+
     it('clears cached mentions when the mention config changes', async () => {
       const getMentionsAndPlainTextSpy = jest.spyOn(utils, 'getMentionsAndPlainText')
       try {
@@ -2303,7 +2331,7 @@ describe('MentionsInput', () => {
     })
 
     it('merges async suggestion results from multiple matching children', async () => {
-      type DeferredResult = {
+      interface DeferredResult {
         resolve: (value: Array<{ id: string; display: string }>) => void
       }
 
@@ -2324,7 +2352,7 @@ describe('MentionsInput', () => {
       render(
         <MentionsInput value="@a">
           <Mention trigger={/(@([a-z]*))$/} data={firstAsyncData} />
-          <Mention trigger={/(@([a-z0-9]*))$/} data={secondAsyncData} />
+          <Mention trigger={/(@([\da-z]*))$/} data={secondAsyncData} />
         </MentionsInput>
       )
 
@@ -2358,7 +2386,7 @@ describe('MentionsInput', () => {
     })
 
     it('preserves successful async suggestions when a sibling query rejects', async () => {
-      type DeferredResult = {
+      interface DeferredResult {
         resolve: (value: Array<{ id: string; display: string }>) => void
         reject: (reason?: unknown) => void
       }
@@ -2380,7 +2408,7 @@ describe('MentionsInput', () => {
       render(
         <MentionsInput value="@a">
           <Mention trigger={/(@([a-z]*))$/} data={firstAsyncData} />
-          <Mention trigger={/(@([a-z0-9]*))$/} data={secondAsyncData} />
+          <Mention trigger={/(@([\da-z]*))$/} data={secondAsyncData} />
         </MentionsInput>
       )
 
@@ -2519,7 +2547,7 @@ describe('MentionsInput', () => {
     })
 
     it('keeps inline completion visible while the next async query loads.', async () => {
-      type DeferredResult = {
+      interface DeferredResult {
         resolve: (value: Array<{ id: string; display: string }>) => void
       }
 

--- a/src/MentionsInput.tsx
+++ b/src/MentionsInput.tsx
@@ -81,6 +81,7 @@ import {
 import type {
   CaretCoordinates,
   InputComponentProps,
+  MentionChildConfig,
   MentionComponentProps,
   MentionDataItem,
   MentionIdentifier,
@@ -341,12 +342,22 @@ class MentionsInput<
     return preparedChildren
   }
 
-  private getMentionChildren() {
+  private getMentionChildren(): PreparedMentionsInputChildren<Extra>['mentionChildren'] {
     return this.getPreparedChildren().mentionChildren
   }
 
-  private getCurrentConfig() {
+  private getCurrentConfig(): PreparedMentionsInputChildren<Extra>['config'] {
     return this.getPreparedChildren().config
+  }
+
+  private getPreviousConfig(
+    previousChildren: MentionsInputProps<Extra>['children']
+  ): ReadonlyArray<MentionChildConfig<Extra>> {
+    if (previousChildren === this.props.children) {
+      return this._cachedConfig
+    }
+
+    return this.getPreparedChildren(previousChildren).config
   }
 
   private getSlotClassName(slot: keyof MentionsInputClassNames, baseClass: string) {
@@ -479,7 +490,7 @@ class MentionsInput<
     )
   }
 
-  // eslint-disable-next-line code-complete/low-function-cohesion
+  // eslint-disable-next-line sonarjs/cognitive-complexity
   componentDidUpdate(
     prevProps: MentionsInputProps<Extra>,
     prevState: MentionsInputState<Extra>
@@ -491,7 +502,7 @@ class MentionsInput<
     const previousValue = prevProps.value ?? ''
     const currentValue = this.props.value ?? ''
     const currentConfig = this.getCurrentConfig()
-    const previousConfig = this._cachedConfig
+    const previousConfig = this.getPreviousConfig(prevProps.children)
     const configChanged = !areMentionConfigsEqual(previousConfig, currentConfig)
     const valueChanged = currentValue !== previousValue || configChanged
 
@@ -565,7 +576,7 @@ class MentionsInput<
     this.flushPendingViewSync()
 
     if (selectionPositionsChanged || valueChanged) {
-      const currentSelection = computeMentionSelectionDetails(
+      const currentSelection = computeMentionSelectionDetails<Extra>(
         snapshotForSelection.mentions,
         currentConfig,
         this.state.selectionStart,
@@ -574,7 +585,7 @@ class MentionsInput<
       let shouldEmit = selectionPositionsChanged
 
       if (!shouldEmit && valueChanged) {
-        const previousSelection = computeMentionSelectionDetails(
+        const previousSelection = computeMentionSelectionDetails<Extra>(
           prevState.cachedMentions,
           previousConfig,
           prevState.selectionStart,
@@ -638,7 +649,7 @@ class MentionsInput<
     this.containerElement = el
   }
 
-  // eslint-disable-next-line code-complete/low-function-cohesion, sonarjs/cognitive-complexity
+  // eslint-disable-next-line sonarjs/cognitive-complexity
   getInputProps = (): InputComponentProps => {
     const { readOnly, disabled, singleLine } = this.props
 
@@ -739,7 +750,6 @@ class MentionsInput<
     }
   }
 
-  // eslint-disable-next-line code-complete/low-function-cohesion
   private readonly resetTextareaHeight = (): boolean => {
     const hasTextarea =
       typeof HTMLTextAreaElement !== 'undefined' && this.inputElement instanceof HTMLTextAreaElement
@@ -790,7 +800,6 @@ class MentionsInput<
     this.suggestionsElement = el
   }
 
-  // eslint-disable-next-line code-complete/low-function-cohesion
   renderSuggestionsOverlay = (): React.ReactNode | null => {
     if (this.isInlineAutocomplete()) {
       return null
@@ -849,7 +858,6 @@ class MentionsInput<
     return suggestionsNode
   }
 
-  // eslint-disable-next-line code-complete/low-function-cohesion
   renderInlineSuggestion = (): React.ReactNode => {
     if (!this.isInlineAutocomplete()) {
       return null
@@ -1235,7 +1243,6 @@ class MentionsInput<
   }
 
   // Handle input element's change event
-  // eslint-disable-next-line code-complete/low-function-cohesion
   handleChange = (ev: ChangeEvent<InputElement>) => {
     const native = ev.nativeEvent
     if ('isComposing' in native && typeof native.isComposing === 'boolean') {
@@ -1318,7 +1325,6 @@ class MentionsInput<
     )
   }
 
-  // eslint-disable-next-line code-complete/low-function-cohesion
   private readonly syncSelectionFromInput = (
     reason: 'select' | 'selectionchange' = 'selectionchange'
   ): void => {
@@ -1359,7 +1365,6 @@ class MentionsInput<
     this.requestHighlighterScrollSync()
   }
 
-  // eslint-disable-next-line code-complete/low-function-cohesion
   handleKeyDown = (ev: KeyboardEvent<InputElement>) => {
     const inlineAutocomplete = this.isInlineAutocomplete()
 
@@ -1376,7 +1381,7 @@ class MentionsInput<
           if (suggestionsCount > 0) {
             ev.preventDefault()
             ev.stopPropagation()
-            this.shiftFocus(+1)
+            this.shiftFocus(1)
             return
           }
           break
@@ -1419,7 +1424,7 @@ class MentionsInput<
         return
       }
       case KEY.DOWN: {
-        this.shiftFocus(+1)
+        this.shiftFocus(1)
         return
       }
       case KEY.UP: {
@@ -1491,7 +1496,6 @@ class MentionsInput<
     })
   }
 
-  // eslint-disable-next-line code-complete/low-function-cohesion, sonarjs/cognitive-complexity
   updateSuggestionsPosition = (): boolean => {
     const position =
       calculateSuggestionsPosition({
@@ -1515,7 +1519,6 @@ class MentionsInput<
     return true
   }
 
-  // eslint-disable-next-line code-complete/low-function-cohesion
   updateHighlighterScroll = (): boolean =>
     applyHighlighterViewPatch(
       this.highlighterElement,
@@ -1531,8 +1534,7 @@ class MentionsInput<
   }
 
   handleDocumentScroll = (): void => {
-    const shouldMeasureInline =
-      this.isInlineAutocomplete() && isNumber(this.state.selectionStart)
+    const shouldMeasureInline = this.isInlineAutocomplete() && isNumber(this.state.selectionStart)
 
     if (!this.suggestionsElement && !shouldMeasureInline) {
       return
@@ -1540,7 +1542,7 @@ class MentionsInput<
 
     this.requestViewSync({
       measureSuggestions: true,
-      measureInline: true,
+      measureInline: shouldMeasureInline,
     })
   }
 
@@ -1556,7 +1558,6 @@ class MentionsInput<
     this._isComposing = false
   }
 
-  // eslint-disable-next-line code-complete/low-function-cohesion
   setSelection = (selectionStart: number | null, selectionEnd: number | null): void => {
     if (selectionStart === null || selectionEnd === null) {
       return
@@ -1595,9 +1596,11 @@ class MentionsInput<
   private replaceSuggestions(
     computeNextState: (
       prevState: MentionsInputState<Extra>
-    ) => Pick<MentionsInputState<Extra>, 'suggestions'> & Partial<MentionsInputState<Extra>>
+    ) => Pick<MentionsInputState<Extra>, 'suggestions' | 'queryStates' | 'focusIndex'>
   ): void {
-    this.setState((prevState) => computeNextState(prevState))
+    this.setState<'suggestions' | 'queryStates' | 'focusIndex'>((prevState) =>
+      computeNextState(prevState)
+    )
   }
 
   private getActiveSuggestionQueries(
@@ -1630,7 +1633,8 @@ class MentionsInput<
         return []
       }
 
-      const querySequenceStart = substringStartIndex + substring.indexOf(match[1], match.index)
+      const matchIndex = match.index ?? 0
+      const querySequenceStart = substringStartIndex + substring.indexOf(match[1], matchIndex)
       return [
         {
           childIndex,
@@ -1826,7 +1830,6 @@ class MentionsInput<
     }
   }
 
-  // eslint-disable-next-line code-complete/low-function-cohesion
   addMention = (
     suggestion: SuggestionDataItem<Extra>,
     { childIndex, querySequenceStart, querySequenceEnd }: QueryInfo
@@ -1842,7 +1845,6 @@ class MentionsInput<
     }
     const {
       serializer,
-      displayTransform = DEFAULT_MENTION_PROPS.displayTransform,
       appendSpaceOnAdd = DEFAULT_MENTION_PROPS.appendSpaceOnAdd,
       onAdd = DEFAULT_MENTION_PROPS.onAdd,
     } = config[childIndex]
@@ -1861,7 +1863,7 @@ class MentionsInput<
     // Refocus input and set caret position to end of mention
     this.inputElement?.focus()
 
-    let displayValue = displayTransform(id, mentionDisplay)
+    let displayValue = config[childIndex].displayTransform(id, mentionDisplay)
     if (appendSpaceOnAdd) {
       displayValue += ' '
     }

--- a/src/MentionsInputChildren.ts
+++ b/src/MentionsInputChildren.ts
@@ -92,12 +92,12 @@ export const areMentionConfigsEqual = <Extra extends Record<string, unknown>>(
     return false
   }
 
-  return config1.every((cfg1, index) => {
-    const cfg2 = config2[index]
+  return config1.every((leftConfig, index) => {
+    const rightConfig = config2[index]
 
     return (
-      getTriggerIdentity(cfg1.trigger) === getTriggerIdentity(cfg2.trigger) &&
-      cfg1.serializer.id === cfg2.serializer.id
+      getTriggerIdentity(leftConfig.trigger) === getTriggerIdentity(rightConfig.trigger) &&
+      leftConfig.serializer.id === rightConfig.serializer.id
     )
   })
 }

--- a/src/MentionsInputLayout.spec.ts
+++ b/src/MentionsInputLayout.spec.ts
@@ -98,12 +98,12 @@ describe('MentionsInputLayout', () => {
     const highlighter = document.createElement('div')
     const suggestions = document.createElement('div')
     const container = document.createElement('div')
-    const originalInnerHeight = window.innerHeight
+    const originalInnerHeight = globalThis.innerHeight
     const originalClientHeight = document.documentElement.clientHeight
 
     highlighter.style.fontSize = '16px'
 
-    Object.defineProperty(window, 'innerHeight', { value: 180, configurable: true })
+    Object.defineProperty(globalThis, 'innerHeight', { value: 180, configurable: true })
     Object.defineProperty(document.documentElement, 'clientHeight', {
       value: 180,
       configurable: true,
@@ -139,7 +139,7 @@ describe('MentionsInputLayout', () => {
         width: 180,
       })
     } finally {
-      Object.defineProperty(window, 'innerHeight', {
+      Object.defineProperty(globalThis, 'innerHeight', {
         value: originalInnerHeight,
         configurable: true,
       })
@@ -155,7 +155,7 @@ describe('MentionsInputLayout', () => {
     const highlighter = document.createElement('div')
     const caret = document.createElement('span')
 
-    caret.setAttribute('data-mentions-caret', 'true')
+    caret.dataset.mentionsCaret = 'true'
     highlighter.append(caret)
     control.append(highlighter)
 
@@ -184,12 +184,9 @@ describe('MentionsInputLayout', () => {
       left: 22,
       top: 18,
     })
-    expect(
-      areInlineSuggestionPositionsEqual(
-        { left: 22, top: 18 },
-        { left: 22, top: 18 }
-      )
-    ).toBe(true)
+    expect(areInlineSuggestionPositionsEqual({ left: 22, top: 18 }, { left: 22, top: 18 })).toBe(
+      true
+    )
   })
 
   it('merges pending view-sync flags without dropping prior work', () => {
@@ -209,10 +206,7 @@ describe('MentionsInputLayout', () => {
       recomputeHighlighter: false,
     })
     expect(
-      areSuggestionsPositionsEqual(
-        { left: 1, top: 2, width: 3 },
-        { left: 1, top: 2, width: 3 }
-      )
+      areSuggestionsPositionsEqual({ left: 1, top: 2, width: 3 }, { left: 1, top: 2, width: 3 })
     ).toBe(true)
   })
 
@@ -221,11 +215,7 @@ describe('MentionsInputLayout', () => {
     const highlighter = document.createElement('div')
     const getComputedStyleSpy = jest.spyOn(globalThis, 'getComputedStyle').mockReturnValue({
       getPropertyValue: (property: string) =>
-        property === 'line-height'
-          ? '24px'
-          : property === 'letter-spacing'
-            ? '0.08em'
-            : '',
+        property === 'line-height' ? '24px' : property === 'letter-spacing' ? '0.08em' : '',
     } as unknown as CSSStyleDeclaration)
 
     try {

--- a/src/MentionsInputLayout.ts
+++ b/src/MentionsInputLayout.ts
@@ -344,7 +344,7 @@ export const getTextareaResizePatch = (
     return null
   }
 
-  const element = input as HTMLTextAreaElement
+  const element = input
   const previousHeight = element.style.height
   const previousOverflowY = element.style.overflowY
   element.style.height = 'auto'
@@ -371,7 +371,11 @@ export const applyTextareaResizePatch = (
   input: InputElement | null,
   patch: TextareaResizePatch | null
 ): boolean => {
-  if (!patch || typeof HTMLTextAreaElement === 'undefined' || !(input instanceof HTMLTextAreaElement)) {
+  if (
+    !patch ||
+    typeof HTMLTextAreaElement === 'undefined' ||
+    !(input instanceof HTMLTextAreaElement)
+  ) {
     return false
   }
 

--- a/src/MentionsInputQueryState.ts
+++ b/src/MentionsInputQueryState.ts
@@ -83,14 +83,14 @@ export const applyErroredQueryResult = <Extra extends Record<string, unknown>>(
   error: unknown,
   focusIndex: number
 ): SuggestionsLifecycleState<Extra> => {
-  const suggestions: SuggestionsMap<Extra> = { ...currentSuggestions }
-  delete suggestions[childIndex]
+  const suggestions = Object.fromEntries(
+    Object.entries(currentSuggestions).filter(([key]) => Number(key) !== childIndex)
+  ) as SuggestionsMap<Extra>
   const suggestionsCount = countSuggestions(suggestions)
 
   return {
     suggestions,
-    focusIndex:
-      focusIndex >= suggestionsCount ? Math.max(suggestionsCount - 1, 0) : focusIndex,
+    focusIndex: focusIndex >= suggestionsCount ? Math.max(suggestionsCount - 1, 0) : focusIndex,
     queryStates: {
       ...currentQueryStates,
       [childIndex]: {

--- a/src/MentionsInputSelection.ts
+++ b/src/MentionsInputSelection.ts
@@ -36,6 +36,35 @@ export const areMentionOccurrencesEqual = <Extra extends Record<string, unknown>
   })
 }
 
+const getCollapsedMentionSelectionState = (
+  cursor: number,
+  mentionStart: number,
+  mentionEnd: number
+): MentionSelectionState | null => {
+  if (cursor > mentionStart && cursor < mentionEnd) {
+    return 'inside'
+  }
+
+  if (cursor === mentionStart || cursor === mentionEnd) {
+    return 'boundary'
+  }
+
+  return null
+}
+
+const getRangeMentionSelectionState = (
+  start: number,
+  end: number,
+  mentionStart: number,
+  mentionEnd: number
+): MentionSelectionState | null => {
+  if (start >= mentionEnd || end <= mentionStart) {
+    return null
+  }
+
+  return start <= mentionStart && end >= mentionEnd ? 'full' : 'partial'
+}
+
 export const computeMentionSelectionDetails = <Extra extends Record<string, unknown>>(
   mentions: ReadonlyArray<MentionOccurrence<Extra>>,
   config: ReadonlyArray<MentionChildConfig<Extra>>,
@@ -55,17 +84,9 @@ export const computeMentionSelectionDetails = <Extra extends Record<string, unkn
   for (const mention of mentions) {
     const mentionStart = mention.plainTextIndex
     const mentionEnd = mentionStart + mention.display.length
-    let selectionState: MentionSelectionState | null = null
-
-    if (isCollapsed) {
-      if (start > mentionStart && start < mentionEnd) {
-        selectionState = 'inside'
-      } else if (start === mentionStart || start === mentionEnd) {
-        selectionState = 'boundary'
-      }
-    } else if (start < mentionEnd && end > mentionStart) {
-      selectionState = start <= mentionStart && end >= mentionEnd ? 'full' : 'partial'
-    }
+    const selectionState = isCollapsed
+      ? getCollapsedMentionSelectionState(start, mentionStart, mentionEnd)
+      : getRangeMentionSelectionState(start, end, mentionStart, mentionEnd)
 
     if (selectionState === null) {
       continue

--- a/src/MentionsInputSelectors.spec.ts
+++ b/src/MentionsInputSelectors.spec.ts
@@ -2,18 +2,12 @@ import { getDataProvider } from './MentionsInputSelectors'
 
 describe('MentionsInputSelectors', () => {
   it('preserves empty display strings when filtering static suggestion data', async () => {
-    const provider = getDataProvider(
-      [
-        { id: '123', display: '' },
-        { id: '123' },
-      ],
-      {
-        ignoreAccents: false,
-        signal: new AbortController().signal,
-        getSubstringIndex: (value: string, query: string) => value.indexOf(query),
-        maxSuggestions: undefined,
-      }
-    )
+    const provider = getDataProvider([{ id: '123', display: '' }, { id: '123' }], {
+      ignoreAccents: false,
+      signal: new AbortController().signal,
+      getSubstringIndex: (value: string, query: string) => value.indexOf(query),
+      maxSuggestions: undefined,
+    })
 
     await expect(provider('1')).resolves.toEqual([
       {

--- a/src/MentionsInputSelectors.ts
+++ b/src/MentionsInputSelectors.ts
@@ -317,29 +317,31 @@ export const getDataProvider = <Extra extends Record<string, unknown>>(
   const applyMaxSuggestions = (
     items: ReadonlyArray<MentionDataItem<Extra>>
   ): MentionDataItem<Extra>[] =>
-    maxSuggestions === undefined ? [...items] : [...items.slice(0, maxSuggestions)]
+    maxSuggestions === undefined ? [...items] : items.slice(0, maxSuggestions)
 
   if (Array.isArray(data)) {
     const items = data as ReadonlyArray<MentionDataItem<Extra>>
 
-    return async (query: string) =>
-      applyMaxSuggestions(
-        items.flatMap((item) => {
-          if (signal.aborted) {
-            return []
-          }
+    return (query: string) =>
+      Promise.resolve(
+        applyMaxSuggestions(
+          items.flatMap((item) => {
+            if (signal.aborted) {
+              return []
+            }
 
-          const index = getSubstringIndex(item.display ?? String(item.id), query, ignoreAccents)
+            const index = getSubstringIndex(item.display ?? String(item.id), query, ignoreAccents)
 
-          return index >= 0
-            ? [
-                {
-                  ...item,
-                  highlights: [{ start: index, end: index + query.length }],
-                },
-              ]
-            : []
-        })
+            return index >= 0
+              ? [
+                  {
+                    ...item,
+                    highlights: [{ start: index, end: index + query.length }],
+                  },
+                ]
+              : []
+          })
+        )
       )
   }
 

--- a/src/SuggestionsOverlay.tsx
+++ b/src/SuggestionsOverlay.tsx
@@ -118,7 +118,6 @@ function SuggestionsOverlay<Extra extends Record<string, unknown> = Record<strin
     [mentionChildren]
   )
 
-  // eslint-disable-next-line code-complete/low-function-cohesion
   useLayoutEffect(() => {
     if (!ulElement || ulElement.offsetHeight >= ulElement.scrollHeight || !scrollFocusedIntoView) {
       return
@@ -177,7 +176,7 @@ function SuggestionsOverlay<Extra extends Record<string, unknown> = Record<strin
         index,
       }
     })
-  }, [childRenderSuggestions, focusIndex, flattenedSuggestions])
+  }, [childRenderSuggestions, focusIndex, flattenedSuggestions, handleMouseEnter, selectSuggestion])
 
   const handleListMouseDown = useEventCallback<React.MouseEventHandler<HTMLUListElement>>(
     (event) => {
@@ -250,7 +249,7 @@ function SuggestionsOverlay<Extra extends Record<string, unknown> = Record<strin
   }
 
   const renderStatus = (): React.ReactNode => {
-    if (statusContent == null) {
+    if (statusContent === null || statusContent === undefined) {
       return null
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,7 +43,10 @@ export interface MentionSearchContext {
 
 export type DataSource<Extra extends Record<string, unknown> = Record<string, unknown>> =
   | ReadonlyArray<MentionDataItem<Extra>>
-  | ((query: string, context: MentionSearchContext) => MaybePromise<ReadonlyArray<MentionDataItem<Extra>>>)
+  | ((
+      query: string,
+      context: MentionSearchContext
+    ) => MaybePromise<ReadonlyArray<MentionDataItem<Extra>>>)
 
 export function isDataSource<Extra extends Record<string, unknown> = Record<string, unknown>>(
   value: unknown

--- a/src/utils/applyChangeToValue.ts
+++ b/src/utils/applyChangeToValue.ts
@@ -25,7 +25,6 @@ const ensureNumber = (value: number | null | undefined, fallback: number): numbe
 
 // Applies a change from the plain text textarea to the underlying marked up value
 // guided by the textarea text selection ranges before and after the change
-// eslint-disable-next-line code-complete/low-function-cohesion
 const applyChangeToValue = <Extra extends Record<string, unknown> = Record<string, unknown>>(
   value: string,
   plainTextValue: string,

--- a/src/utils/createMarkupSerializer.ts
+++ b/src/utils/createMarkupSerializer.ts
@@ -16,7 +16,6 @@ const createMarkupSerializer = (markup: string): MentionSerializer => {
     return makeMentionsMarkup(markup, id, display)
   }
 
-  // eslint-disable-next-line code-complete/low-function-cohesion
   const findAll: MentionSerializer['findAll'] = (value) => {
     const globalRegex = new RegExp(baseRegex.source, 'g')
     const matches: MentionSerializerMatch[] = []

--- a/src/utils/findPositionOfCapturingGroup.ts
+++ b/src/utils/findPositionOfCapturingGroup.ts
@@ -2,7 +2,6 @@ import PLACEHOLDERS from './placeholders'
 
 type PlaceholderName = 'id' | 'display'
 
-// eslint-disable-next-line code-complete/low-function-cohesion
 const findPositionOfCapturingGroup = (markup: string, parameterName: PlaceholderName): number => {
   // find positions of placeholders in the markup
   let indexDisplay: number | null = markup.indexOf(PLACEHOLDERS.display)

--- a/src/utils/flattenSuggestions.ts
+++ b/src/utils/flattenSuggestions.ts
@@ -10,7 +10,6 @@ export interface FlattenedSuggestion<
   queryInfo: QueryInfo
 }
 
-// eslint-disable-next-line code-complete/low-function-cohesion
 const flattenSuggestions = <Extra extends Record<string, unknown> = Record<string, unknown>>(
   children: ReactNode,
   suggestions: SuggestionsMap<Extra> | undefined

--- a/src/utils/getSubstringIndex.ts
+++ b/src/utils/getSubstringIndex.ts
@@ -1,4 +1,4 @@
-// eslint-disable-next-line code-complete/low-function-cohesion, code-complete/enforce-meaningful-names
+// eslint-disable-next-line code-complete/enforce-meaningful-names
 const stripWithMap = (s: string) => {
   let out = ''
   const map: number[] = []

--- a/src/utils/iterateMentionsMarkup.ts
+++ b/src/utils/iterateMentionsMarkup.ts
@@ -16,7 +16,6 @@ const emptyFn: TextIteratee = () => {}
 
 // Finds all occurrences of the markup in the value and calls the `markupIteratee` callback for each of them.
 // The optional `textIteratee` callback is called for each plain text ranges in between these markup occurrences.
-// eslint-disable-next-line code-complete/low-function-cohesion
 const iterateMentionsMarkup = <Extra extends Record<string, unknown> = Record<string, unknown>>(
   value: string,
   config: ReadonlyArray<MentionChildConfig<Extra>>,

--- a/src/utils/makeTriggerRegex.ts
+++ b/src/utils/makeTriggerRegex.ts
@@ -5,7 +5,6 @@ interface TriggerOptions {
   ignoreAccents?: boolean
 }
 
-// eslint-disable-next-line code-complete/low-function-cohesion
 export const makeTriggerRegex = (
   trigger: string | RegExp = '@',
   options: TriggerOptions = {}

--- a/src/utils/mapPlainTextIndex.ts
+++ b/src/utils/mapPlainTextIndex.ts
@@ -22,7 +22,6 @@ const mapPlainTextIndex = <Extra extends Record<string, unknown> = Record<string
 
   let result: number | null | undefined
 
-  // eslint-disable-next-line code-complete/low-function-cohesion
   const textIteratee = (substr: string, index: number, substrPlainTextIndex: number): void => {
     if (result !== undefined) {
       return
@@ -34,7 +33,6 @@ const mapPlainTextIndex = <Extra extends Record<string, unknown> = Record<string
     }
   }
 
-  // eslint-disable-next-line code-complete/low-function-cohesion
   const markupIteratee = (
     markup: string,
     index: number,

--- a/src/utils/mergeDeep.ts
+++ b/src/utils/mergeDeep.ts
@@ -2,7 +2,6 @@ import isPlainObject from './isPlainObject'
 
 export type PlainObject = Record<string, unknown>
 
-// eslint-disable-next-line code-complete/low-function-cohesion
 export const mergeDeep = <T extends PlainObject, S extends PlainObject>(
   target: T,
   source: S


### PR DESCRIPTION
Includes hook dependency fixes, query-state cleanup, test type/interface cleanup, promise param naming, regex cleanup, and a few targeted suppressions for a no-unsafe-argument false positive.

disabled code-complete/low-function-cohesion and import-x/no-named-as-default-member in eslint.config.ts, plus react-perf/jsx-no-jsx-as-prop for test files only. low-function-cohesion was the main bad fit: it was flagging normal guard-clause helpers and orchestration methods all over the codebase

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed mention selection state recomputation when mention configuration changes.
  * Corrected query sequence calculation for accurate suggestion matching.
  * Improved mention display value computation when adding mentions.

* **Refactoring**
  * Enhanced dependency tracking in component effects for better reliability.
  * Extracted mention selection logic into reusable helper functions.
  * Improved type safety with explicit typed accessors.

* **Chores**
  * Updated ESLint configuration to streamline code quality rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix ESLint violations and underlying bugs in `MentionsInput` and related components
> - Resolves ESLint violations across the codebase by removing `eslint-disable` comments and fixing the root causes — type annotations, dependency arrays, loop styles, and minor refactors.
> - Fixes `MentionsInput.getPreviousConfig` to derive previous config from prior children rather than always using the current cached config, correcting mention selection recalculation on config changes.
> - Fixes `MentionsInput.addMention` to use the child-specific `displayTransform` instead of `DEFAULT_MENTION_PROPS`, so inserted mention display text respects per-`Mention` configuration.
> - Fixes `MentionsInput.getActiveSuggestionQueries` to handle `RegExpMatchArray.index` being `undefined`, preventing incorrect trigger/query range detection.
> - Updates `useLayoutEffect` dependency arrays in [Highlighter.tsx](https://github.com/hbmartin/react-mentions-ts/pull/179/files#diff-2d8fdc86aaeb8d7adcdd60631f48110e3e6cce38d17b7e31828f5c0088eadcc2) and [SuggestionsOverlay.tsx](https://github.com/hbmartin/react-mentions-ts/pull/179/files#diff-8d2b85b42eafe864e1f94902263195848ee9436d546b75c7baae1384f02e7f8a) to include all referenced callbacks, avoiding stale closures.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 267983d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->