### PR TITLE
Reduced controlled-keystroke recomputation and array-provider scans

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
 		"demo": "vite --config demo/vite.config.ts",
 		"preview": "vite preview --config demo/vite.config.ts",
 		"test": "BROWSERSLIST_IGNORE_OLD_DATA=true vitest run",
+		"test:perf": "BROWSERSLIST_IGNORE_OLD_DATA=true vitest run src/MentionsInput.performance.spec.tsx src/MentionsInputSelectors.performance.spec.ts",
 		"test:watch": "BROWSERSLIST_IGNORE_OLD_DATA=true vitest",
 		"test:coverage": "BROWSERSLIST_IGNORE_OLD_DATA=true vitest run --coverage",
 		"knip": "knip --strict",

--- a/src/MeasurementBridge.tsx
+++ b/src/MeasurementBridge.tsx
@@ -37,7 +37,9 @@ const MeasurementBridge = ({
   })
 
   const observe = useEventCallback((element: Element | null, callback: () => void) => {
-    const resizeObserverConstructor = globalThis.ResizeObserver
+    const resizeObserverConstructor = Reflect.get(globalThis, 'ResizeObserver') as
+      | typeof ResizeObserver
+      | undefined
 
     if (!element || resizeObserverConstructor === undefined) {
       return undefined
@@ -76,16 +78,22 @@ const MeasurementBridge = ({
   )
 
   useLayoutEffect(() => {
+    const windowObject = Reflect.get(globalThis, 'window') as Window | undefined
+
+    if (windowObject === undefined) {
+      return undefined
+    }
+
     const handleViewportChange = () => {
       requestAllMeasurements()
     }
 
-    globalThis.window.addEventListener('resize', handleViewportChange)
-    globalThis.window.addEventListener('orientationchange', handleViewportChange)
+    windowObject.addEventListener('resize', handleViewportChange)
+    windowObject.addEventListener('orientationchange', handleViewportChange)
 
     return () => {
-      globalThis.window.removeEventListener('resize', handleViewportChange)
-      globalThis.window.removeEventListener('orientationchange', handleViewportChange)
+      windowObject.removeEventListener('resize', handleViewportChange)
+      windowObject.removeEventListener('orientationchange', handleViewportChange)
     }
   }, [requestAllMeasurements])
 

--- a/src/MentionsInput.performance.spec.tsx
+++ b/src/MentionsInput.performance.spec.tsx
@@ -1,0 +1,231 @@
+import React, { useState } from 'react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import MentionsInput from './MentionsInput'
+import Mention from './Mention'
+import * as mentionsInputChildren from './MentionsInputChildren'
+import * as mentionsInputDerived from './MentionsInputDerived'
+import * as mentionsInputLayout from './MentionsInputLayout'
+import * as utils from './utils'
+import { createRenderCounter, emitPerformanceMetric } from './test/performance'
+import type { MentionsInputChangeHandler } from './types'
+
+const mentionData = [
+  { id: 'alice', display: 'Alice' },
+  { id: 'albert', display: 'Albert' },
+  { id: 'bob', display: 'Bob' },
+]
+
+type ControlledMentionsInputProps = Readonly<{
+  initialValue?: string
+  suggestionsDisplay?: 'overlay' | 'inline'
+  onMentionsChange?: MentionsInputChangeHandler
+}>
+
+function ControlledMentionsInput({
+  initialValue,
+  suggestionsDisplay,
+  onMentionsChange,
+}: ControlledMentionsInputProps) {
+  const [value, setValue] = useState(initialValue ?? '')
+
+  return (
+    <MentionsInput
+      value={value}
+      suggestionsDisplay={suggestionsDisplay}
+      onMentionsChange={(change) => {
+        setValue(change.value)
+        onMentionsChange?.(change)
+      }}
+    >
+      <Mention trigger="@" data={mentionData} />
+    </MentionsInput>
+  )
+}
+
+describe('MentionsInput performance', () => {
+  it('reports controlled keystroke work counts', async () => {
+    const getPlainTextSpy = vi.spyOn(utils, 'getPlainText')
+    const deriveSnapshotSpy = vi.spyOn(mentionsInputDerived, 'deriveMentionValueSnapshot')
+    const prepareChildrenSpy = vi.spyOn(mentionsInputChildren, 'prepareMentionsInputChildren')
+
+    render(<ControlledMentionsInput initialValue="@" />)
+
+    getPlainTextSpy.mockClear()
+    deriveSnapshotSpy.mockClear()
+    prepareChildrenSpy.mockClear()
+
+    const combobox = screen.getByRole('combobox')
+    fireEvent.focus(combobox)
+    combobox.setSelectionRange(1, 1)
+    fireEvent.select(combobox)
+    fireEvent.change(combobox, { target: { value: '@a' } })
+
+    await waitFor(() => {
+      expect(combobox).toHaveValue('@a')
+    })
+
+    const metrics = {
+      getPlainTextCalls: getPlainTextSpy.mock.calls.length,
+      deriveMentionValueSnapshotCalls: deriveSnapshotSpy.mock.calls.length,
+      prepareMentionsInputChildrenCalls: prepareChildrenSpy.mock.calls.length,
+    }
+    emitPerformanceMetric('controlled-keystroke', metrics)
+
+    expect(metrics.getPlainTextCalls).toBe(0)
+    expect(metrics.deriveMentionValueSnapshotCalls).toBeLessThanOrEqual(1)
+    expect(metrics.prepareMentionsInputChildrenCalls).toBeLessThanOrEqual(1)
+  })
+
+  it('reports selection-only snapshot derivation count', async () => {
+    const deriveSnapshotSpy = vi.spyOn(mentionsInputDerived, 'deriveMentionValueSnapshot')
+
+    render(<ControlledMentionsInput initialValue="@a" />)
+
+    const combobox = screen.getByRole('combobox')
+    fireEvent.focus(combobox)
+    combobox.setSelectionRange(2, 2)
+    fireEvent.select(combobox)
+
+    await waitFor(() => {
+      expect(combobox).toHaveValue('@a')
+    })
+
+    deriveSnapshotSpy.mockClear()
+
+    combobox.setSelectionRange(1, 1)
+    fireEvent.select(combobox)
+
+    await waitFor(() => {
+      expect(combobox.selectionStart).toBe(1)
+    })
+
+    const metrics = {
+      deriveMentionValueSnapshotCalls: deriveSnapshotSpy.mock.calls.length,
+    }
+    emitPerformanceMetric('selection-only', metrics)
+
+    expect(metrics.deriveMentionValueSnapshotCalls).toBe(0)
+  })
+
+  it('reports layout measurement counts for inline autocomplete interactions', async () => {
+    const overlayPositionSpy = vi.spyOn(mentionsInputLayout, 'calculateSuggestionsPosition')
+    const inlinePositionSpy = vi.spyOn(mentionsInputLayout, 'calculateInlineSuggestionPosition')
+
+    render(<ControlledMentionsInput initialValue="@a" suggestionsDisplay="inline" />)
+
+    overlayPositionSpy.mockClear()
+    inlinePositionSpy.mockClear()
+
+    const combobox = screen.getByRole('combobox')
+    fireEvent.focus(combobox)
+    combobox.setSelectionRange(2, 2)
+    fireEvent.select(combobox)
+
+    await waitFor(() => {
+      expect(combobox.selectionStart).toBe(2)
+    })
+
+    fireEvent.keyDown(combobox, { key: 'ArrowRight' })
+
+    await waitFor(() => {
+      expect(combobox).toHaveValue('Alice')
+    })
+
+    const metrics = {
+      calculateSuggestionsPositionCalls: overlayPositionSpy.mock.calls.length,
+      calculateInlineSuggestionPositionCalls: inlinePositionSpy.mock.calls.length,
+    }
+    emitPerformanceMetric('inline-layout', metrics)
+
+    expect(metrics.calculateSuggestionsPositionCalls).toBe(0)
+    expect(metrics.calculateInlineSuggestionPositionCalls).toBeLessThanOrEqual(1)
+  })
+
+  it('reports layout measurement counts for overlay interactions', async () => {
+    const overlayPositionSpy = vi.spyOn(mentionsInputLayout, 'calculateSuggestionsPosition')
+    const inlinePositionSpy = vi.spyOn(mentionsInputLayout, 'calculateInlineSuggestionPosition')
+
+    render(<ControlledMentionsInput initialValue="@a" suggestionsDisplay="overlay" />)
+
+    overlayPositionSpy.mockClear()
+    inlinePositionSpy.mockClear()
+
+    const combobox = screen.getByRole('combobox')
+    fireEvent.focus(combobox)
+    combobox.setSelectionRange(2, 2)
+    fireEvent.select(combobox)
+
+    await waitFor(() => {
+      const options = screen.getAllByRole('option', { hidden: true })
+      expect(options.length).toBeGreaterThan(0)
+    })
+
+    fireEvent.keyDown(combobox, { key: 'ArrowDown' })
+
+    const metrics = {
+      calculateSuggestionsPositionCalls: overlayPositionSpy.mock.calls.length,
+      calculateInlineSuggestionPositionCalls: inlinePositionSpy.mock.calls.length,
+    }
+    emitPerformanceMetric('overlay-layout', metrics)
+
+    expect(metrics.calculateSuggestionsPositionCalls).toBeLessThanOrEqual(2)
+    expect(metrics.calculateInlineSuggestionPositionCalls).toBe(0)
+  })
+
+  it('reports stable-sibling render counts in a locality fixture', async () => {
+    const counter = createRenderCounter()
+
+    function StableSibling() {
+      return (
+        <counter.Probe label="stable-sibling">
+          <div>Stable sibling</div>
+        </counter.Probe>
+      )
+    }
+
+    function ActiveBranch() {
+      const [value, setValue] = useState('@')
+
+      return (
+        <counter.Probe label="active-branch">
+          <MentionsInput
+            value={value}
+            onMentionsChange={({ value: nextValue }) => setValue(nextValue)}
+          >
+            <Mention trigger="@" data={mentionData} />
+          </MentionsInput>
+        </counter.Probe>
+      )
+    }
+
+    render(
+      <div>
+        <StableSibling />
+        <ActiveBranch />
+      </div>
+    )
+
+    const initialStableCount = counter.getCount('stable-sibling')
+    const initialActiveCount = counter.getCount('active-branch')
+
+    const combobox = screen.getByRole('combobox')
+    fireEvent.focus(combobox)
+    combobox.setSelectionRange(1, 1)
+    fireEvent.select(combobox)
+    fireEvent.change(combobox, { target: { value: '@a' } })
+
+    await waitFor(() => {
+      expect(combobox).toHaveValue('@a')
+    })
+
+    const metrics = {
+      stableSiblingRendersDuringInteraction:
+        counter.getCount('stable-sibling') - initialStableCount,
+      activeBranchRendersDuringInteraction: counter.getCount('active-branch') - initialActiveCount,
+    }
+    emitPerformanceMetric('locality-render-counts', metrics)
+
+    expect(metrics.stableSiblingRendersDuringInteraction).toBe(0)
+    expect(metrics.activeBranchRendersDuringInteraction).toBeLessThanOrEqual(1)
+  })
+})

--- a/src/MentionsInput.spec.tsx
+++ b/src/MentionsInput.spec.tsx
@@ -197,15 +197,23 @@ describe('MentionsInput', () => {
       )
     })
 
-    it('should throw when multiple Mention children share the same trigger.', () => {
-      expect(() =>
-        render(
-          <MentionsInput value="">
-            <Mention trigger="@" data={data} />
-            <Mention trigger="@" data={data} />
-          </MentionsInput>
-        )
-      ).toThrow('MentionsInput does not support Mention children with duplicate triggers: @.')
+    it('should allow multiple Mention children to share the same trigger.', async () => {
+      render(
+        <MentionsInput value="@a">
+          <Mention trigger="@" data={[{ id: 'alice', display: 'Alice' }]} />
+          <Mention trigger="@" data={[{ id: 'acme', display: 'Acme Team' }]} />
+        </MentionsInput>
+      )
+
+      const combobox = screen.getByRole('combobox')
+      fireEvent.focus(combobox)
+      combobox.setSelectionRange(2, 2)
+      fireEvent.select(combobox)
+
+      await waitFor(() => {
+        const options = screen.getAllByRole('option', { hidden: true })
+        expect(options).toHaveLength(2)
+      })
     })
 
     it('should support custom Mention components that wrap the base Mention.', () => {
@@ -1713,10 +1721,11 @@ describe('MentionsInput', () => {
 
     it('should remove a leading mention from the value when the text is cut.', () => {
       const onMentionsChange = vi.fn()
+      const onRemove = vi.fn()
 
       render(
         <MentionsInput value={value} onMentionsChange={onMentionsChange}>
-          <Mention trigger="@[__display__](__id__)" data={data} />
+          <Mention trigger="@[__display__](__id__)" data={data} onRemove={onRemove} />
         </MentionsInput>
       )
 
@@ -1744,19 +1753,24 @@ describe('MentionsInput', () => {
         plainTextValue: newPlainTextValue,
         trigger,
         previousValue,
+        mentionId,
       } = getLastMentionsChange(onMentionsChange)
-      expect(trigger.type).toBe('cut')
+      expect(trigger.type).toBe('mention-remove')
       expect(previousValue).toBe(value)
+      expect(mentionId).toBe('first')
+      expect(onRemove).toHaveBeenCalledTimes(1)
+      expect(onRemove).toHaveBeenCalledWith('first')
       expect(newValue).toMatchSnapshot()
       expect(newPlainTextValue).toMatchSnapshot()
     })
 
     it('should remove a trailing mention from the value when the text is cut.', () => {
       const onMentionsChange = vi.fn()
+      const onRemove = vi.fn()
 
       render(
         <MentionsInput value={value} onMentionsChange={onMentionsChange}>
-          <Mention trigger="@[__display__](__id__)" data={data} />
+          <Mention trigger="@[__display__](__id__)" data={data} onRemove={onRemove} />
         </MentionsInput>
       )
 
@@ -1784,9 +1798,13 @@ describe('MentionsInput', () => {
         plainTextValue: newPlainTextValue,
         trigger,
         previousValue,
+        mentionId,
       } = getLastMentionsChange(onMentionsChange)
-      expect(trigger.type).toBe('cut')
+      expect(trigger.type).toBe('mention-remove')
       expect(previousValue).toBe(value)
+      expect(mentionId).toBe('second')
+      expect(onRemove).toHaveBeenCalledTimes(1)
+      expect(onRemove).toHaveBeenCalledWith('second')
       expect(newValue).toMatchSnapshot()
       expect(newPlainTextValue).toMatchSnapshot()
     })
@@ -1900,6 +1918,38 @@ describe('MentionsInput', () => {
       expect(previousValue).toBe(value)
       expect(newValue).toMatchSnapshot()
       expect(newPlainTextValue).toMatchSnapshot()
+    })
+
+    it('emits mention-remove when paste replaces an existing mention.', () => {
+      const onMentionsChange = vi.fn()
+      const onRemove = vi.fn()
+
+      render(
+        <MentionsInput value={value} onMentionsChange={onMentionsChange}>
+          <Mention trigger="@[__display__](__id__)" data={data} onRemove={onRemove} />
+        </MentionsInput>
+      )
+
+      const textarea = screen.getByRole('combobox')
+      const selectionStart = plainTextValue.indexOf('First')
+      const selectionEnd = selectionStart + 'First'.length
+
+      textarea.setSelectionRange(selectionStart, selectionEnd)
+      fireEvent.select(textarea, {
+        target: { selectionStart, selectionEnd },
+      })
+
+      const event = new Event('paste', { bubbles: true })
+      event.clipboardData = {
+        getData: vi.fn((type) => (type === 'text/plain' ? 'Replacement' : '')),
+      }
+
+      fireEvent(textarea, event)
+
+      const payload = getLastMentionsChange(onMentionsChange)
+      expect(payload.trigger.type).toBe('mention-remove')
+      expect(payload.mentionId).toBe('first')
+      expect(onRemove).toHaveBeenCalledWith('first')
     })
 
     it('should remove carriage returns from pasted values', () => {
@@ -2833,6 +2883,9 @@ describe('MentionsInput', () => {
 
       const instance = ref.current as unknown as any
       instance.suggestionsElement = document.createElement('div')
+      act(() => {
+        instance.setState({ selectionStart: 0, selectionEnd: 0 })
+      })
       const updateSpy = vi
         .spyOn(instance, 'updateSuggestionsPosition')
         .mockImplementation(() => undefined)
@@ -2887,6 +2940,9 @@ describe('MentionsInput', () => {
 
       const instance = ref.current as unknown as any
       instance.suggestionsElement = document.createElement('div')
+      act(() => {
+        instance.setState({ selectionStart: 0, selectionEnd: 0 })
+      })
       const updateSpy = vi
         .spyOn(instance, 'updateSuggestionsPosition')
         .mockImplementation(() => undefined)
@@ -3162,6 +3218,10 @@ describe('MentionsInput', () => {
 
       const instance = ref.current as unknown as any
       const raf = vi.spyOn(globalThis, 'requestAnimationFrame').mockImplementation(() => 9)
+      act(() => {
+        instance.setState({ selectionStart: 0, selectionEnd: 0 })
+      })
+      raf.mockClear()
 
       act(() => {
         instance.requestHighlighterScrollSync()
@@ -3173,7 +3233,7 @@ describe('MentionsInput', () => {
       expect(instance._pendingViewSync).toMatchObject({
         syncScroll: true,
         measureSuggestions: true,
-        measureInline: true,
+        measureInline: false,
       })
 
       raf.mockRestore()

--- a/src/MentionsInput.tsx
+++ b/src/MentionsInput.tsx
@@ -34,7 +34,6 @@ import {
   getInlineSuggestionAnnouncement,
   getFocusedSuggestionEntryForMentionChildren,
   getInlineSuggestionDetailsForMentionChildren,
-  getMentionChildFromArray,
   getSuggestionData,
   getSuggestionQueryStateEntries,
   getSuggestionsStatusContentForMentionChildren,
@@ -51,7 +50,6 @@ import {
 import {
   countSuggestions,
   getEndOfLastMention,
-  getPlainText,
   getMentionsAndPlainText,
   getSubstringIndex,
   getSuggestionHtmlId,
@@ -65,6 +63,7 @@ import { areMentionSelectionsEqual } from './utils/areMentionSelectionsEqual'
 import { makeTriggerRegex } from './utils/makeTriggerRegex'
 import type { PreparedMentionsInputChildren } from './MentionsInputChildren'
 import { areMentionConfigsEqual, prepareMentionsInputChildren } from './MentionsInputChildren'
+import type { MentionValueSnapshot } from './MentionsInputDerived'
 import { createMentionSelectionContext, deriveMentionValueSnapshot } from './MentionsInputDerived'
 import {
   applyErroredQueryResult,
@@ -73,11 +72,7 @@ import {
   createLoadingQueryState,
   isAbortError,
 } from './MentionsInputQueryState'
-import {
-  areMentionOccurrencesEqual,
-  computeMentionSelectionDetails,
-  getMentionSelectionMap,
-} from './MentionsInputSelection'
+import { computeMentionSelectionDetails, getMentionSelectionMap } from './MentionsInputSelection'
 import type {
   CaretCoordinates,
   InputComponentProps,
@@ -102,7 +97,7 @@ import type {
 let generatedIdCounter = 0
 
 const createGeneratedId = (): string => {
-  if (typeof globalThis.crypto?.randomUUID === 'function') {
+  if (typeof globalThis.crypto.randomUUID === 'function') {
     return `mentions-${globalThis.crypto.randomUUID()}`
   }
 
@@ -159,6 +154,40 @@ interface ActiveSuggestionQuery<Extra extends Record<string, unknown>> {
   queryInfo: QueryInfo
   mentionChild: React.ReactElement<MentionComponentProps<Extra>>
   ignoreAccents: boolean
+}
+
+const getMentionDiffKey = <Extra extends Record<string, unknown>>(
+  mention: MentionOccurrence<Extra>
+): string => {
+  return `${mention.childIndex}:${String(mention.id)}:${mention.display}`
+}
+
+const getRemovedMentions = <Extra extends Record<string, unknown>>(
+  previousMentions: ReadonlyArray<MentionOccurrence<Extra>>,
+  nextMentions: ReadonlyArray<MentionOccurrence<Extra>>
+): MentionOccurrence<Extra>[] => {
+  const nextMentionCounts = new Map<string, number>()
+
+  for (const mention of nextMentions) {
+    const key = getMentionDiffKey(mention)
+    nextMentionCounts.set(key, (nextMentionCounts.get(key) ?? 0) + 1)
+  }
+
+  const removedMentions: MentionOccurrence<Extra>[] = []
+
+  for (const mention of previousMentions) {
+    const key = getMentionDiffKey(mention)
+    const count = nextMentionCounts.get(key) ?? 0
+
+    if (count === 0) {
+      removedMentions.push(mention)
+      continue
+    }
+
+    nextMentionCounts.set(key, count - 1)
+  }
+
+  return removedMentions
 }
 
 const visuallyHiddenStyles: CSSProperties = {
@@ -234,6 +263,12 @@ class MentionsInput<
   private _autoResizeFrame: number | null = null
   private _cachedMarkupValue = ''
   private _cachedConfig: ReadonlyArray<MentionChildConfig<Extra>> = []
+  private _lastCommittedConfig: ReadonlyArray<MentionChildConfig<Extra>> = []
+  private _cachedSnapshot: MentionValueSnapshot<Extra> = {
+    mentions: [],
+    plainText: '',
+    idValue: '',
+  }
   private _pendingViewSync: PendingViewSync = createPendingViewSync()
   private _isFlushingViewSync = false
   private readonly _queryDebounceTimers = new Map<number, ReturnType<typeof setTimeout>>()
@@ -241,11 +276,7 @@ class MentionsInput<
 
   private cancelScheduledFrame(frameKey: '_scrollSyncFrame' | '_autoResizeFrame'): void {
     const frame = this[frameKey]
-    if (
-      frame !== null &&
-      globalThis.window !== undefined &&
-      typeof globalThis.cancelAnimationFrame === 'function'
-    ) {
+    if (frame !== null && typeof globalThis.cancelAnimationFrame === 'function') {
       globalThis.cancelAnimationFrame(frame)
       this[frameKey] = null
     }
@@ -263,24 +294,77 @@ class MentionsInput<
     this._queryAbortControllers.clear()
   }
 
+  private cacheSnapshot(
+    value: string,
+    config: ReadonlyArray<MentionChildConfig<Extra>>,
+    snapshot: MentionValueSnapshot<Extra>
+  ): MentionValueSnapshot<Extra> {
+    this._cachedMarkupValue = value
+    this._cachedConfig = [...config]
+    this._cachedSnapshot = snapshot
+    return snapshot
+  }
+
+  private getCurrentSnapshot(
+    value: string = this.props.value ?? '',
+    config: ReadonlyArray<MentionChildConfig<Extra>> = this.getCurrentConfig()
+  ): MentionValueSnapshot<Extra> {
+    if (value === this._cachedMarkupValue && areMentionConfigsEqual(config, this._cachedConfig)) {
+      return this._cachedSnapshot
+    }
+
+    return this.cacheSnapshot(value, config, deriveMentionValueSnapshot<Extra>(value, config))
+  }
+
+  private shouldMeasureSuggestions(): boolean {
+    return !this.isInlineAutocomplete() && isNumber(this.state.selectionStart)
+  }
+
+  private shouldMeasureInline(): boolean {
+    return this.isInlineAutocomplete() && isNumber(this.state.selectionStart)
+  }
+
+  private resolveViewSyncFlags(flags: Partial<PendingViewSync>): Partial<PendingViewSync> {
+    const nextFlags: Partial<PendingViewSync> = {}
+
+    if (flags.restoreSelection === true) {
+      nextFlags.restoreSelection = true
+    }
+    if (flags.syncScroll === true) {
+      nextFlags.syncScroll = true
+    }
+    if (flags.recomputeHighlighter === true) {
+      nextFlags.recomputeHighlighter = true
+    }
+    if (flags.measureSuggestions === true && this.shouldMeasureSuggestions()) {
+      nextFlags.measureSuggestions = true
+    }
+    if (flags.measureInline === true && this.shouldMeasureInline()) {
+      nextFlags.measureInline = true
+    }
+
+    return nextFlags
+  }
+
   requestViewSync = (
     flags: Partial<PendingViewSync>,
     options: {
       flushNow?: boolean
     } = {}
   ): void => {
-    this._pendingViewSync = mergePendingViewSync(this._pendingViewSync, flags)
+    const filteredFlags = this.resolveViewSyncFlags(flags)
+    this._pendingViewSync = mergePendingViewSync(this._pendingViewSync, filteredFlags)
 
     if (!hasPendingViewSync(this._pendingViewSync)) {
       return
     }
 
-    if (options.flushNow) {
+    if (options.flushNow === true) {
       this.flushPendingViewSync()
       return
     }
 
-    if (globalThis.window === undefined || typeof globalThis.requestAnimationFrame !== 'function') {
+    if (typeof globalThis.requestAnimationFrame !== 'function') {
       this.flushPendingViewSync()
       return
     }
@@ -435,8 +519,8 @@ class MentionsInput<
     const initialConfig = preparedChildren.config
     const initialValue = props.value ?? ''
     const initialSnapshot = deriveMentionValueSnapshot<Extra>(initialValue, initialConfig)
-    this._cachedMarkupValue = initialValue
-    this._cachedConfig = initialConfig
+    this.cacheSnapshot(initialValue, initialConfig, initialSnapshot)
+    this._lastCommittedConfig = [...initialConfig]
 
     this.handleCopy = this.handleCopy.bind(this)
     this.handleCut = this.handleCut.bind(this)
@@ -447,9 +531,6 @@ class MentionsInput<
       focusIndex: 0,
       selectionStart: null,
       selectionEnd: null,
-      cachedMentions: initialSnapshot.mentions,
-      cachedPlainText: initialSnapshot.plainText,
-      cachedIdValue: initialSnapshot.idValue,
       suggestions: {},
       queryStates: {},
       caretPosition: null,
@@ -480,60 +561,18 @@ class MentionsInput<
     )
   }
 
-  // eslint-disable-next-line sonarjs/cognitive-complexity
-  componentDidUpdate(
-    prevProps: MentionsInputProps<Extra>,
-    prevState: MentionsInputState<Extra>
-  ): void {
-    const selectionPositionsChanged =
-      this.state.selectionStart !== prevState.selectionStart ||
-      this.state.selectionEnd !== prevState.selectionEnd
-
-    const previousValue = prevProps.value ?? ''
-    const currentValue = this.props.value ?? ''
-    const currentConfig = this.getCurrentConfig()
-    const previousConfig = this._cachedConfig
-    const configChanged = !areMentionConfigsEqual(previousConfig, currentConfig)
-    const valueChanged = currentValue !== previousValue || configChanged
-
+  private ensureGeneratedIdIfNeeded(): void {
     if (this.getExplicitId() === null && this.state.generatedId === null) {
       this.ensureGeneratedId()
     }
+  }
 
-    const recalculatedSnapshot = valueChanged
-      ? deriveMentionValueSnapshot<Extra>(currentValue, currentConfig)
-      : null
-    const snapshotForSelection = recalculatedSnapshot ?? {
-      mentions: this.state.cachedMentions,
-      plainText: this.state.cachedPlainText,
-      idValue: this.state.cachedIdValue,
-    }
-
-    if (recalculatedSnapshot) {
-      const {
-        mentions: nextMentions,
-        plainText: nextPlainText,
-        idValue: nextIdValue,
-      } = recalculatedSnapshot
-
-      if (
-        !areMentionOccurrencesEqual(nextMentions, this.state.cachedMentions) ||
-        nextPlainText !== this.state.cachedPlainText ||
-        nextIdValue !== this.state.cachedIdValue
-      ) {
-        this.setState({
-          cachedMentions: nextMentions,
-          cachedPlainText: nextPlainText,
-          cachedIdValue: nextIdValue,
-        })
-      }
-    }
-
-    if (valueChanged) {
-      this._cachedMarkupValue = currentValue
-      this._cachedConfig = currentConfig
-    }
-
+  private scheduleViewSyncAfterUpdate(
+    prevProps: MentionsInputProps<Extra>,
+    prevState: MentionsInputState<Extra>,
+    valueChanged: boolean,
+    selectionPositionsChanged: boolean
+  ): void {
     if (this.state.pendingSelectionUpdate) {
       this.requestViewSync({ restoreSelection: true })
     }
@@ -564,40 +603,87 @@ class MentionsInput<
     }
 
     this.flushPendingViewSync()
+  }
 
-    if (selectionPositionsChanged || valueChanged) {
-      const currentSelection = computeMentionSelectionDetails<Extra>(
-        snapshotForSelection.mentions,
-        currentConfig,
-        this.state.selectionStart,
-        this.state.selectionEnd
-      )
-      let shouldEmit = selectionPositionsChanged
-
-      if (!shouldEmit && valueChanged) {
-        const previousSelection = computeMentionSelectionDetails<Extra>(
-          prevState.cachedMentions,
-          previousConfig,
-          prevState.selectionStart,
-          prevState.selectionEnd
-        )
-        shouldEmit = !areMentionSelectionsEqual(
-          previousSelection.selections,
-          currentSelection.selections
-        )
-      }
-
-      if (shouldEmit && this.props.onMentionSelectionChange) {
-        const selectionMentionIds = currentSelection.selections.map((selection) => selection.id)
-        const selectionContext = createMentionSelectionContext(
-          currentValue,
-          snapshotForSelection,
-          selectionMentionIds
-        )
-
-        this.props.onMentionSelectionChange(currentSelection.selections, selectionContext)
-      }
+  private emitMentionSelectionChangeIfNeeded(
+    currentValue: string,
+    currentConfig: ReadonlyArray<MentionChildConfig<Extra>>,
+    currentSnapshot: MentionValueSnapshot<Extra>,
+    previousValue: string,
+    previousConfig: ReadonlyArray<MentionChildConfig<Extra>>,
+    prevState: MentionsInputState<Extra>,
+    valueChanged: boolean,
+    selectionPositionsChanged: boolean
+  ): void {
+    if ((!selectionPositionsChanged && !valueChanged) || !this.props.onMentionSelectionChange) {
+      return
     }
+
+    const currentSelection = computeMentionSelectionDetails<Extra>(
+      currentSnapshot.mentions,
+      currentConfig,
+      this.state.selectionStart,
+      this.state.selectionEnd
+    )
+    let shouldEmit = selectionPositionsChanged
+
+    if (!shouldEmit && valueChanged) {
+      const previousSnapshot = deriveMentionValueSnapshot<Extra>(previousValue, previousConfig)
+      const previousSelection = computeMentionSelectionDetails<Extra>(
+        previousSnapshot.mentions,
+        previousConfig,
+        prevState.selectionStart,
+        prevState.selectionEnd
+      )
+      shouldEmit = !areMentionSelectionsEqual(
+        previousSelection.selections,
+        currentSelection.selections
+      )
+    }
+
+    if (!shouldEmit) {
+      return
+    }
+
+    const selectionMentionIds = currentSelection.selections.map((selection) => selection.id)
+    const selectionContext = createMentionSelectionContext(
+      currentValue,
+      currentSnapshot,
+      selectionMentionIds
+    )
+
+    this.props.onMentionSelectionChange(currentSelection.selections, selectionContext)
+  }
+
+  componentDidUpdate(
+    prevProps: MentionsInputProps<Extra>,
+    prevState: MentionsInputState<Extra>
+  ): void {
+    const selectionPositionsChanged =
+      this.state.selectionStart !== prevState.selectionStart ||
+      this.state.selectionEnd !== prevState.selectionEnd
+
+    const previousValue = prevProps.value ?? ''
+    const currentValue = this.props.value ?? ''
+    const previousConfig = this._lastCommittedConfig
+    const currentConfig = this.getCurrentConfig()
+    const configChanged = !areMentionConfigsEqual(previousConfig, currentConfig)
+    const valueChanged = currentValue !== previousValue || configChanged
+    const currentSnapshot = this.getCurrentSnapshot(currentValue, currentConfig)
+
+    this.ensureGeneratedIdIfNeeded()
+    this.scheduleViewSyncAfterUpdate(prevProps, prevState, valueChanged, selectionPositionsChanged)
+    this.emitMentionSelectionChangeIfNeeded(
+      currentValue,
+      currentConfig,
+      currentSnapshot,
+      previousValue,
+      previousConfig,
+      prevState,
+      valueChanged,
+      selectionPositionsChanged
+    )
+    this._lastCommittedConfig = [...currentConfig]
   }
 
   componentWillUnmount(): void {
@@ -642,6 +728,7 @@ class MentionsInput<
   // eslint-disable-next-line sonarjs/cognitive-complexity
   getInputProps = (): InputComponentProps => {
     const { readOnly, disabled, singleLine } = this.props
+    const currentSnapshot = this.getCurrentSnapshot()
 
     const passthroughProps = omit(
       this.props,
@@ -655,11 +742,11 @@ class MentionsInput<
     const props: Record<string, unknown> = {
       ...restPassthrough,
       className: baseClassName,
-      value: getPlainText(this.props.value ?? '', this.getCurrentConfig()),
+      value: currentSnapshot.plainText,
       onScroll: this.handleInputScroll,
       'data-slot': 'input',
-      'data-single-line': singleLine ? 'true' : undefined,
-      'data-multi-line': singleLine ? undefined : 'true',
+      'data-single-line': singleLine === true ? 'true' : undefined,
+      'data-multi-line': singleLine === true ? undefined : 'true',
     }
 
     const inlineStyle = getInputInlineStyle(singleLine)
@@ -668,7 +755,7 @@ class MentionsInput<
       props.style = inlineStyle
     }
 
-    if (!readOnly && !disabled) {
+    if (readOnly !== true && disabled !== true) {
       Object.assign(props, {
         onChange: this.handleChange,
         onSelect: this.handleSelect,
@@ -683,15 +770,16 @@ class MentionsInput<
     const inlineSuggestion = isInlineAutocomplete ? this.getInlineSuggestionDetails() : null
     const isOverlayOpen = !isInlineAutocomplete && this.isOpened()
     const overlayId = this.getSuggestionsOverlayId()
+    const hasOverlayId = overlayId !== undefined
 
     Object.assign(props, {
       role: 'combobox',
       'aria-autocomplete': isInlineAutocomplete ? 'inline' : 'list',
       'aria-expanded': isInlineAutocomplete ? 'false' : this.isOpened() ? 'true' : 'false',
       'aria-haspopup': isInlineAutocomplete ? undefined : 'listbox',
-      'aria-controls': isOverlayOpen && overlayId ? overlayId : undefined,
+      'aria-controls': isOverlayOpen && hasOverlayId ? overlayId : undefined,
       'aria-activedescendant':
-        isOverlayOpen && overlayId
+        isOverlayOpen && hasOverlayId
           ? getSuggestionHtmlId(overlayId, this.state.focusIndex)
           : undefined,
     })
@@ -701,9 +789,9 @@ class MentionsInput<
       const existingDescribedBy =
         typeof props['aria-describedby'] === 'string' ? props['aria-describedby'] : undefined
       const describedBy = [existingDescribedBy, liveRegionId]
-        .filter((value): value is string => Boolean(value && value.trim().length > 0))
+        .filter((value): value is string => typeof value === 'string' && value.trim().length > 0)
         .join(' ')
-      props['aria-describedby'] = describedBy || undefined
+      props['aria-describedby'] = describedBy.length > 0 ? describedBy : undefined
     }
 
     return props as InputComponentProps
@@ -713,13 +801,11 @@ class MentionsInput<
     const { singleLine, inputComponent: CustomInput } = this.props
     const inputProps = this.getInputProps()
 
-    return CustomInput ? (
-      <CustomInput ref={this.setInputRef} {...inputProps} />
-    ) : singleLine ? (
-      this.renderInput(inputProps)
-    ) : (
-      this.renderTextarea(inputProps)
-    )
+    if (CustomInput === undefined) {
+      return singleLine === true ? this.renderInput(inputProps) : this.renderTextarea(inputProps)
+    }
+
+    return <CustomInput ref={this.setInputRef} {...inputProps} />
   }
 
   renderInput = (props: InputComponentProps): React.ReactElement => {
@@ -735,16 +821,13 @@ class MentionsInput<
     const { inputRef } = this.props
     if (typeof inputRef === 'function') {
       inputRef(el)
-    } else if (inputRef) {
+    } else if (inputRef !== undefined) {
       ;(inputRef as React.RefObject<InputElement | null>).current = el
     }
   }
 
   private readonly resetTextareaHeight = (): boolean => {
-    const hasTextarea =
-      typeof HTMLTextAreaElement !== 'undefined' && this.inputElement instanceof HTMLTextAreaElement
-
-    if (!hasTextarea) {
+    if (!(this.inputElement instanceof HTMLTextAreaElement)) {
       return false
     }
 
@@ -757,7 +840,6 @@ class MentionsInput<
     if (
       this.props.singleLine === true ||
       this.props.autoResize !== true ||
-      globalThis.window === undefined ||
       typeof globalThis.requestAnimationFrame !== 'function'
     ) {
       if (this._autoResizeFrame !== null && typeof globalThis.cancelAnimationFrame === 'function') {
@@ -1077,35 +1159,59 @@ class MentionsInput<
       return {}
     }
 
-    const currentValue = this.props.value ?? ''
     const currentConfig = this.getCurrentConfig()
-    const mentions =
-      currentValue === this._cachedMarkupValue &&
-      areMentionConfigsEqual(currentConfig, this._cachedConfig)
-        ? this.state.cachedMentions
-        : deriveMentionValueSnapshot<Extra>(currentValue, currentConfig).mentions
+    const { mentions } = this.getCurrentSnapshot(this.props.value ?? '', currentConfig)
 
     return getMentionSelectionMap(mentions, currentConfig, selectionStart, selectionEnd)
   }
 
+  private emitOnRemoveCallbacks(
+    previousSnapshot: MentionValueSnapshot<Extra>,
+    nextSnapshot: MentionValueSnapshot<Extra>,
+    config: ReadonlyArray<MentionChildConfig<Extra>>
+  ): MentionOccurrence<Extra>[] {
+    const removedMentions = getRemovedMentions(previousSnapshot.mentions, nextSnapshot.mentions)
+
+    for (const mention of removedMentions) {
+      const onRemove = config[mention.childIndex]?.onRemove ?? DEFAULT_MENTION_PROPS.onRemove
+      onRemove(mention.id)
+    }
+
+    return removedMentions
+  }
+
   executeOnChange = (
-    trigger: MentionsInputChangeTrigger,
+    baseTrigger: MentionsInputChangeTrigger,
     newValue: string,
-    newPlainTextValue: string,
-    newIdValue: string,
-    mentions: MentionOccurrence<Extra>[],
+    nextSnapshot: MentionValueSnapshot<Extra>,
     previousValue: string,
+    previousSnapshot: MentionValueSnapshot<Extra>,
+    config: ReadonlyArray<MentionChildConfig<Extra>>,
     mentionId?: MentionIdentifier
   ): void => {
+    const removedMentions =
+      baseTrigger.type === 'mention-add'
+        ? []
+        : this.emitOnRemoveCallbacks(previousSnapshot, nextSnapshot, config)
+    const trigger =
+      removedMentions.length > 0
+        ? {
+            type: 'mention-remove' as const,
+            nativeEvent: baseTrigger.nativeEvent,
+          }
+        : baseTrigger
+    const resolvedMentionId =
+      mentionId ?? (removedMentions.length === 1 ? removedMentions[0]?.id : undefined)
+
     if (this.props.onMentionsChange) {
       this.props.onMentionsChange({
         trigger,
         value: newValue,
-        plainTextValue: newPlainTextValue,
-        idValue: newIdValue,
-        mentions,
+        plainTextValue: nextSnapshot.plainText,
+        idValue: nextSnapshot.idValue,
+        mentions: nextSnapshot.mentions,
         previousValue,
-        mentionId,
+        mentionId: resolvedMentionId,
       })
     }
   }
@@ -1128,6 +1234,7 @@ class MentionsInput<
     const pastedMentions = clipboardData.getData('text/react-mentions')
     const pastedData = clipboardData.getData('text/plain')
     const config = this.getCurrentConfig()
+    const previousSnapshot = this.getCurrentSnapshot(valueText, config)
     const pasteResult = applyPasteToMentionsValue<Extra>(
       valueText,
       config,
@@ -1135,14 +1242,15 @@ class MentionsInput<
       selectionEnd,
       pastedMentions || pastedData
     )
+    this.cacheSnapshot(pasteResult.value, config, pasteResult.snapshot)
 
     this.executeOnChange(
       { type: 'paste', nativeEvent: event },
       pasteResult.value,
-      pasteResult.snapshot.plainText,
-      pasteResult.snapshot.idValue,
-      pasteResult.snapshot.mentions,
-      valueText
+      pasteResult.snapshot,
+      valueText,
+      previousSnapshot,
+      config
     )
     this.setState({
       selectionStart: pasteResult.nextSelectionStart,
@@ -1209,12 +1317,14 @@ class MentionsInput<
     const { value } = this.props
     const valueText = value ?? ''
     const config = this.getCurrentConfig()
+    const previousSnapshot = this.getCurrentSnapshot(valueText, config)
     const cutResult = applyCutToMentionsValue<Extra>(
       valueText,
       config,
       selectionStart,
       selectionEnd
     )
+    this.cacheSnapshot(cutResult.value, config, cutResult.snapshot)
 
     this.setState({
       selectionStart: cutResult.nextSelectionStart,
@@ -1225,10 +1335,10 @@ class MentionsInput<
     this.executeOnChange(
       { type: 'cut', nativeEvent: event },
       cutResult.value,
-      cutResult.snapshot.plainText,
-      cutResult.snapshot.idValue,
-      cutResult.snapshot.mentions,
-      valueText
+      cutResult.snapshot,
+      valueText,
+      previousSnapshot,
+      config
     )
   }
 
@@ -1238,9 +1348,9 @@ class MentionsInput<
     if ('isComposing' in native && typeof native.isComposing === 'boolean') {
       this._isComposing = native.isComposing
     }
-    const value = this.props.value || ''
+    const value = this.props.value ?? ''
 
-    let newPlainTextValue = ev.target.value
+    const newPlainTextValue = ev.target.value
 
     let selectionStartBefore = this.state.selectionStart
     if (selectionStartBefore === null) {
@@ -1257,6 +1367,7 @@ class MentionsInput<
       isComposing?: boolean
     }
     const config = this.getCurrentConfig()
+    const previousSnapshot = this.getCurrentSnapshot(value, config)
     const inputChangeResult = applyInputChangeToMentionsValue<Extra>(
       value,
       newPlainTextValue,
@@ -1267,7 +1378,7 @@ class MentionsInput<
       this.state.selectionEnd,
       nativeEvent.data
     )
-    newPlainTextValue = inputChangeResult.snapshot.plainText
+    this.cacheSnapshot(inputChangeResult.value, config, inputChangeResult.snapshot)
 
     this.setState((prevState) => ({
       selectionStart: inputChangeResult.nextSelectionStart,
@@ -1277,9 +1388,9 @@ class MentionsInput<
     }))
 
     if (
-      nativeEvent.isComposing &&
+      nativeEvent.isComposing === true &&
       inputChangeResult.nextSelectionStart === inputChangeResult.nextSelectionEnd &&
-      this.inputElement
+      this.inputElement !== null
     ) {
       this.updateMentionsQueries(this.inputElement.value, inputChangeResult.nextSelectionStart)
     }
@@ -1288,10 +1399,10 @@ class MentionsInput<
     this.executeOnChange(
       { type: 'input', nativeEvent: ev.nativeEvent },
       inputChangeResult.value,
-      newPlainTextValue,
-      inputChangeResult.snapshot.idValue,
-      inputChangeResult.snapshot.mentions,
-      value
+      inputChangeResult.snapshot,
+      value,
+      previousSnapshot,
+      config
     )
 
     this.props.onChange?.(ev)
@@ -1324,7 +1435,7 @@ class MentionsInput<
     }
 
     if (reason === 'selectionchange') {
-      const ownerDocument = input.ownerDocument ?? document
+      const ownerDocument = input.ownerDocument
       if (ownerDocument.activeElement !== input) {
         return
       }
@@ -1524,15 +1635,13 @@ class MentionsInput<
   }
 
   handleDocumentScroll = (): void => {
-    const shouldMeasureInline = this.isInlineAutocomplete() && isNumber(this.state.selectionStart)
-
-    if (!this.suggestionsElement && !shouldMeasureInline) {
+    if (!this.shouldMeasureSuggestions() && !this.shouldMeasureInline()) {
       return
     }
 
     this.requestViewSync({
       measureSuggestions: true,
-      measureInline: shouldMeasureInline,
+      measureInline: true,
     })
   }
 
@@ -1558,7 +1667,7 @@ class MentionsInput<
       return
     }
     let selectionApplied = false
-    if (el.setSelectionRange) {
+    if (typeof el.setSelectionRange === 'function') {
       el.setSelectionRange(selectionStart, selectionEnd)
       selectionApplied = true
     } else if ('createTextRange' in el) {
@@ -1619,20 +1728,23 @@ class MentionsInput<
       const regex = resolveTriggerRegex(triggerProp)
       const match = substring.match(regex)
 
-      if (match?.[1] === undefined || match[2] === undefined) {
+      if (match === null || match.length < 3) {
         return []
       }
+      const replacementRange = match[1]
+      const query = match[2]
 
       const matchIndex = match.index ?? 0
-      const querySequenceStart = substringStartIndex + substring.indexOf(match[1], matchIndex)
+      const querySequenceStart =
+        substringStartIndex + substring.indexOf(replacementRange, matchIndex)
       return [
         {
           childIndex,
           queryInfo: {
             childIndex,
-            query: match[2],
+            query,
             querySequenceStart,
-            querySequenceEnd: querySequenceStart + match[1].length,
+            querySequenceEnd: querySequenceStart + replacementRange.length,
           },
           mentionChild,
           ignoreAccents: regex.flags.includes('u'),
@@ -1646,9 +1758,12 @@ class MentionsInput<
     nextSuggestions: SuggestionsMap<Extra>
   ): SuggestionQueryStateMap<Extra> {
     return activeQueries.reduce<SuggestionQueryStateMap<Extra>>((queryStates, activeQuery) => {
+      const previousResults = Object.hasOwn(nextSuggestions, activeQuery.childIndex)
+        ? nextSuggestions[activeQuery.childIndex].results
+        : []
       queryStates[activeQuery.childIndex] = {
         ...createLoadingQueryState<Extra>(activeQuery.queryInfo),
-        results: nextSuggestions[activeQuery.childIndex]?.results ?? [],
+        results: previousResults,
       }
       return queryStates
     }, {})
@@ -1659,8 +1774,12 @@ class MentionsInput<
     currentSuggestions: SuggestionsMap<Extra>
   ): SuggestionsMap<Extra> {
     return activeQueries.reduce<SuggestionsMap<Extra>>((nextSuggestions, activeQuery) => {
+      if (!Object.hasOwn(currentSuggestions, activeQuery.childIndex)) {
+        return nextSuggestions
+      }
       const previousSuggestion = currentSuggestions[activeQuery.childIndex]
-      if (!previousSuggestion || previousSuggestion.results.length === 0) {
+
+      if (previousSuggestion.results.length === 0) {
         return nextSuggestions
       }
 
@@ -1826,18 +1945,18 @@ class MentionsInput<
   ): void => {
     const { id, display } = this.getSuggestionData(suggestion)
     // Insert mention in the marked up value at the correct position
-    const value = this.props.value || ''
-    const mentionChildren = this.getMentionChildren()
+    const value = this.props.value ?? ''
     const config = this.getCurrentConfig()
-    const mentionsChild = getMentionChildFromArray<Extra>(mentionChildren, childIndex)
-    if (!mentionsChild) {
+    const previousSnapshot = this.getCurrentSnapshot(value, config)
+    if (childIndex < 0 || childIndex >= config.length) {
       return
     }
+    const childConfig = config[childIndex]
     const {
       serializer,
       appendSpaceOnAdd = DEFAULT_MENTION_PROPS.appendSpaceOnAdd,
       onAdd = DEFAULT_MENTION_PROPS.onAdd,
-    } = config[childIndex]
+    } = childConfig
 
     const start = mapPlainTextIndex(value, config, querySequenceStart, 'START') as number
     const end = start + querySequenceEnd - querySequenceStart
@@ -1853,7 +1972,7 @@ class MentionsInput<
     // Refocus input and set caret position to end of mention
     this.inputElement?.focus()
 
-    let displayValue = config[childIndex].displayTransform(id, mentionDisplay)
+    let displayValue = childConfig.displayTransform(id, mentionDisplay)
     if (appendSpaceOnAdd) {
       displayValue += ' '
     }
@@ -1870,14 +1989,19 @@ class MentionsInput<
       plainText: newPlainTextValue,
       idValue: newIdValue,
     } = getMentionsAndPlainText<Extra>(newValue, config)
+    const nextSnapshot = this.cacheSnapshot(newValue, config, {
+      mentions,
+      plainText: newPlainTextValue,
+      idValue: newIdValue,
+    })
 
     this.executeOnChange(
       { type: 'mention-add' },
       newValue,
-      newPlainTextValue,
-      newIdValue,
-      mentions,
+      nextSnapshot,
       value,
+      previousSnapshot,
+      config,
       id
     )
 

--- a/src/MentionsInputChildren.spec.tsx
+++ b/src/MentionsInputChildren.spec.tsx
@@ -46,7 +46,7 @@ describe('MentionsInputChildren', () => {
     ).toBe(false)
   })
 
-  it('rejects duplicate triggers during validation', () => {
+  it('allows duplicate triggers during validation', () => {
     expect(() =>
       validateMentionChildTree(
         <>
@@ -54,7 +54,7 @@ describe('MentionsInputChildren', () => {
           <Mention trigger="@" data={[]} />
         </>
       )
-    ).toThrow('duplicate triggers')
+    ).not.toThrow()
   })
 
   it('treats regex trigger flags as part of the mention identity', () => {

--- a/src/MentionsInputChildren.ts
+++ b/src/MentionsInputChildren.ts
@@ -1,5 +1,4 @@
 import React from 'react'
-import { DEFAULT_MENTION_PROPS } from './MentionDefaultProps'
 import type { MentionChildConfig, MentionComponentProps } from './types'
 import { isMentionElement } from './utils/isMentionElement'
 import readConfigFromChildren, { collectMentionElements } from './utils/readConfigFromChildren'
@@ -13,44 +12,37 @@ export interface PreparedMentionsInputChildren<
 
 const getTriggerIdentity = (trigger: string | RegExp | undefined): string => {
   if (trigger === undefined) {
-    return `str:${DEFAULT_MENTION_PROPS.trigger}`
-  }
-
-  if (typeof trigger === 'string') {
-    return `str:${trigger}`
-  }
-
-  return `re:${trigger.source}/${trigger.flags.replaceAll('g', '')}`
-}
-
-const getTriggerLabel = (trigger: string | RegExp | undefined): string => {
-  if (trigger === undefined) {
-    return DEFAULT_MENTION_PROPS.trigger
+    return 'default:@'
   }
 
   return typeof trigger === 'string'
-    ? trigger
-    : `/${trigger.source}/${trigger.flags.replaceAll('g', '')}`
+    ? `str:${trigger}`
+    : `re:${trigger.source}/${trigger.flags.replaceAll('g', '')}`
 }
 
 const getInvalidChildLabel = (child: React.ReactNode): string => {
   if (React.isValidElement(child)) {
-    return typeof child.type === 'string' ? child.type : child.type?.name || 'unknown component'
+    if (typeof child.type === 'string') {
+      return child.type
+    }
+
+    return 'name' in child.type && typeof child.type.name === 'string' && child.type.name.length > 0
+      ? child.type.name
+      : 'unknown component'
   }
 
   return 'unknown component'
 }
 
 export const validateMentionChildTree = <Extra extends Record<string, unknown>>(
-  children: React.ReactNode,
-  seenChildren: Set<string> = new Set<string>()
+  children: React.ReactNode
 ): void => {
   React.Children.forEach(children, (child) => {
     if (
       React.isValidElement<{ children?: React.ReactNode }>(child) &&
       child.type === React.Fragment
     ) {
-      validateMentionChildTree<Extra>(child.props.children, seenChildren)
+      validateMentionChildTree<Extra>(child.props.children)
       return
     }
 
@@ -59,17 +51,23 @@ export const validateMentionChildTree = <Extra extends Record<string, unknown>>(
         `MentionsInput only accepts Mention components as children. Found: ${getInvalidChildLabel(child)}`
       )
     }
+  })
+}
 
-    const trigger = getTriggerIdentity(child.props.trigger)
+const validateUniqueSerializerIds = <Extra extends Record<string, unknown>>(
+  config: ReadonlyArray<MentionChildConfig<Extra>>
+): void => {
+  const seenSerializerIds = new Set<string>()
 
-    if (seenChildren.has(trigger)) {
+  for (const childConfig of config) {
+    if (seenSerializerIds.has(childConfig.serializer.id)) {
       throw new Error(
-        `MentionsInput does not support Mention children with duplicate triggers: ${getTriggerLabel(child.props.trigger)}.`
+        `MentionsInput does not support Mention children with duplicate serializer ids: ${childConfig.serializer.id}.`
       )
     }
 
-    seenChildren.add(trigger)
-  })
+    seenSerializerIds.add(childConfig.serializer.id)
+  }
 }
 
 export const prepareMentionsInputChildren = <Extra extends Record<string, unknown>>(
@@ -77,10 +75,12 @@ export const prepareMentionsInputChildren = <Extra extends Record<string, unknow
 ): PreparedMentionsInputChildren<Extra> => {
   validateMentionChildTree<Extra>(children)
   const mentionChildren = collectMentionElements<Extra>(children)
+  const config = readConfigFromChildren<Extra>(mentionChildren)
+  validateUniqueSerializerIds(config)
 
   return {
     mentionChildren,
-    config: readConfigFromChildren<Extra>(mentionChildren),
+    config,
   }
 }
 

--- a/src/MentionsInputLayout.ts
+++ b/src/MentionsInputLayout.ts
@@ -56,6 +56,9 @@ interface TextareaResizePatch {
   overflowY: string
 }
 
+const parseCssNumericValue = (value: string | null | undefined): number =>
+  value === null || value === undefined || value.length === 0 ? 0 : Number.parseFloat(value) || 0
+
 const TYPOGRAPHIC_STYLE_PROPS = [
   'font-family',
   'font-size',
@@ -135,8 +138,16 @@ export const getInputInlineStyle = (singleLine?: boolean): CSSProperties => {
  */
 export const getComputedStyleLengthProp = (forElement: Element, propertyName: string): number => {
   const view = forElement.ownerDocument.defaultView ?? globalThis
+  const getComputedStyle = view.getComputedStyle as
+    | ((element: Element, pseudoElement?: string | null) => CSSStyleDeclaration)
+    | undefined
+
+  if (typeof getComputedStyle !== 'function') {
+    return 0
+  }
+
   const length = Number.parseFloat(
-    view.getComputedStyle(forElement, null).getPropertyValue(propertyName)
+    getComputedStyle(forElement, null).getPropertyValue(propertyName)
   )
   return Number.isFinite(length) ? length : 0
 }
@@ -349,16 +360,15 @@ export const getTextareaResizePatch = (
   const previousOverflowY = element.style.overflowY
   element.style.height = 'auto'
   element.style.overflowY = 'hidden'
-  let borderAdjustment = 0
-
-  if (globalThis.getComputedStyle !== undefined) {
-    const computed = globalThis.getComputedStyle(element)
-    const parse = (value: string | null | undefined) =>
-      value === null || value === undefined || value.length === 0
-        ? 0
-        : Number.parseFloat(value) || 0
-    borderAdjustment = parse(computed.borderTopWidth) + parse(computed.borderBottomWidth)
-  }
+  const getComputedStyle = globalThis.getComputedStyle as
+    | ((inputElement: Element) => CSSStyleDeclaration)
+    | undefined
+  const computed = typeof getComputedStyle === 'function' ? getComputedStyle(element) : null
+  const borderAdjustment =
+    computed === null
+      ? 0
+      : parseCssNumericValue(computed.borderTopWidth) +
+        parseCssNumericValue(computed.borderBottomWidth)
 
   const nextHeight = element.scrollHeight + borderAdjustment
   element.style.height = previousHeight
@@ -374,10 +384,12 @@ export const applyTextareaResizePatch = (
   input: InputElement | null,
   patch: TextareaResizePatch | null
 ): boolean => {
-  const textAreaElementConstructor = globalThis.HTMLTextAreaElement
+  const textAreaElementConstructor = globalThis.HTMLTextAreaElement as
+    | typeof HTMLTextAreaElement
+    | undefined
 
   if (
-    !patch ||
+    patch === null ||
     textAreaElementConstructor === undefined ||
     !(input instanceof textAreaElementConstructor)
   ) {

--- a/src/MentionsInputSelectors.performance.spec.ts
+++ b/src/MentionsInputSelectors.performance.spec.ts
@@ -1,0 +1,33 @@
+import * as selectors from './MentionsInputSelectors'
+import { emitPerformanceMetric } from './test/performance'
+
+describe('MentionsInputSelectors performance', () => {
+  it('reports array-provider scan counts with maxSuggestions early matches', async () => {
+    const items = Array.from({ length: 1000 }, (_, index) => ({
+      id: `user-${index.toString()}`,
+      display: index < 5 ? `Alpha ${index.toString()}` : `User ${index.toString()}`,
+    }))
+    let scanCount = 0
+
+    const provider = selectors.getDataProvider(items, {
+      ignoreAccents: false,
+      maxSuggestions: 5,
+      signal: new AbortController().signal,
+      getSubstringIndex: (haystack, needle, ignoreAccents) => {
+        scanCount += 1
+        return needle.length === 0 ? 0 : haystack.toLowerCase().indexOf(needle.toLowerCase())
+      },
+    })
+
+    const results = await provider('alpha')
+
+    const metrics = {
+      scanCount,
+      resultCount: results.length,
+    }
+    emitPerformanceMetric('array-provider-scan-count', metrics)
+
+    expect(metrics.scanCount).toBe(5)
+    expect(metrics.resultCount).toBe(5)
+  })
+})

--- a/src/MentionsInputSelectors.ts
+++ b/src/MentionsInputSelectors.ts
@@ -34,6 +34,38 @@ export const DEFAULT_EMPTY_SUGGESTIONS_MESSAGE = 'No suggestions found'
 export const DEFAULT_ERROR_SUGGESTIONS_MESSAGE = 'Unable to load suggestions'
 export const INLINE_AUTOCOMPLETE_FALLBACK_ANNOUNCEMENT = 'No inline suggestions available'
 
+interface SearchableSuggestionItem<Extra extends Record<string, unknown>> {
+  item: MentionDataItem<Extra>
+  searchableDisplay: string
+}
+
+type CachedMentionDataItems = ReadonlyArray<MentionDataItem>
+type CachedSearchableSuggestionItems = Array<SearchableSuggestionItem<Record<string, unknown>>>
+
+const plainSearchCache = new WeakMap<CachedMentionDataItems, CachedSearchableSuggestionItems>()
+const accentSearchCache = new WeakMap<CachedMentionDataItems, CachedSearchableSuggestionItems>()
+
+const getCachedSearchableItems = <Extra extends Record<string, unknown>>(
+  items: ReadonlyArray<MentionDataItem<Extra>>,
+  ignoreAccents: boolean
+): Array<SearchableSuggestionItem<Extra>> => {
+  const cache = ignoreAccents ? accentSearchCache : plainSearchCache
+  const cacheKey = items as CachedMentionDataItems
+  const cached = cache.get(cacheKey) as Array<SearchableSuggestionItem<Extra>> | undefined
+
+  if (cached) {
+    return cached
+  }
+
+  const searchableItems = items.map((item) => ({
+    item,
+    searchableDisplay: item.display ?? String(item.id),
+  }))
+  cache.set(cacheKey, searchableItems as CachedSearchableSuggestionItems)
+
+  return searchableItems
+}
+
 export const getMentionChildFromArray = <Extra extends Record<string, unknown>>(
   mentionChildren: ReadonlyArray<React.ReactElement<MentionComponentProps<Extra>>>,
   childIndex: number
@@ -321,28 +353,35 @@ export const getDataProvider = <Extra extends Record<string, unknown>>(
 
   if (Array.isArray(data)) {
     const items = data as ReadonlyArray<MentionDataItem<Extra>>
+    const searchableItems = getCachedSearchableItems(items, ignoreAccents)
 
-    return (query: string) =>
-      Promise.resolve().then(() =>
-        applyMaxSuggestions(
-          items.flatMap((item) => {
-            if (signal.aborted) {
-              return []
-            }
+    return (query: string) => {
+      return Promise.resolve().then(() => {
+        const results: MentionDataItem<Extra>[] = []
 
-            const index = getSubstringIndex(item.display ?? String(item.id), query, ignoreAccents)
+        for (const { item, searchableDisplay } of searchableItems) {
+          if (signal.aborted) {
+            return []
+          }
 
-            return index >= 0
-              ? [
-                  {
-                    ...item,
-                    highlights: [{ start: index, end: index + query.length }],
-                  },
-                ]
-              : []
+          const index = getSubstringIndex(searchableDisplay, query, ignoreAccents)
+          if (index < 0) {
+            continue
+          }
+
+          results.push({
+            ...item,
+            highlights: [{ start: index, end: index + query.length }],
           })
-        )
-      )
+
+          if (maxSuggestions !== undefined && results.length >= maxSuggestions) {
+            break
+          }
+        }
+
+        return applyMaxSuggestions(results)
+      })
+    }
   }
 
   return async (query: string) => {

--- a/src/test/performance.tsx
+++ b/src/test/performance.tsx
@@ -1,0 +1,40 @@
+import React from 'react'
+import type { ReactNode } from 'react'
+import { appendFileSync } from 'node:fs'
+
+export interface RenderCounter {
+  Probe: (props: { label: string; children?: ReactNode }) => React.ReactElement
+  getCount: (label: string) => number
+  reset: () => void
+}
+
+export const createRenderCounter = (): RenderCounter => {
+  const counts = new Map<string, number>()
+
+  const Probe = ({ label, children }: { label: string; children?: ReactNode }) => {
+    counts.set(label, (counts.get(label) ?? 0) + 1)
+    return <>{children}</>
+  }
+
+  return {
+    Probe,
+    getCount: (label) => counts.get(label) ?? 0,
+    reset: () => {
+      counts.clear()
+    },
+  }
+}
+
+export const emitPerformanceMetric = (
+  name: string,
+  metrics: Record<string, number | string>
+): void => {
+  const line = `[perf] ${name} ${JSON.stringify(metrics)}`
+  process.stdout.write(`${line}\n`)
+
+  const outputFile = process.env.PERF_OUTPUT_FILE
+  if (typeof outputFile === 'string' && outputFile.length > 0) {
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- perf tests opt into a specific output file path
+    appendFileSync(outputFile, `${line}\n`, 'utf8')
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -277,9 +277,6 @@ export interface MentionsInputState<
   focusIndex: number
   selectionStart: number | null
   selectionEnd: number | null
-  cachedMentions: MentionOccurrence<Extra>[]
-  cachedPlainText: string
-  cachedIdValue: string
   suggestions: SuggestionsMap<Extra>
   queryStates: SuggestionQueryStateMap<Extra>
   caretPosition: CaretCoordinates | null

--- a/src/utils/applyChangeToValue.spec.ts
+++ b/src/utils/applyChangeToValue.spec.ts
@@ -325,7 +325,7 @@ describe('#applyChangeToValue', () => {
       )
 
       expect(result).toEqual(changed)
-      expect(getPlainTextSpy).toHaveBeenCalledTimes(3)
+      expect(getPlainTextSpy).toHaveBeenCalledTimes(2)
     } finally {
       getPlainTextSpy.mockRestore()
     }

--- a/src/utils/applyChangeToValue.ts
+++ b/src/utils/applyChangeToValue.ts
@@ -122,7 +122,6 @@ const applyChangeToValue = <Extra extends Record<string, unknown> = Record<strin
         value.length
       )
       newValue = spliceString(value, mappedSpliceStart, mappedSpliceEnd, insert)
-      getPlainText<Extra>(newValue, config)
     }
   }
 

--- a/src/utils/readConfigFromChildren.spec.tsx
+++ b/src/utils/readConfigFromChildren.spec.tsx
@@ -90,7 +90,7 @@ describe('readConfigFromChildren', () => {
   })
 
   describe('backward compatibility', () => {
-    it('should use the shared DEFAULT_SERIALIZER when trigger is @ and no markup is provided', () => {
+    it('should generate distinct default serializers for duplicate triggers', () => {
       const children = [
         <Mention key="1" trigger="@" data={[]} />,
         <Mention key="2" trigger="@" data={[]} />,
@@ -98,9 +98,29 @@ describe('readConfigFromChildren', () => {
 
       const config = readConfigFromChildren(children)
 
-      // Both should use the same serializer instance for efficiency
-      expect(config[0].serializer.id).toBe('@[__display__](__id__)')
-      expect(config[1].serializer.id).toBe('@[__display__](__id__)')
+      expect(config[0].serializer.id).toBe('@[__display__](__id__|0)')
+      expect(config[1].serializer.id).toBe('@[__display__](__id__|1)')
+      expect(config[0].serializer.insert({ id: 'first', display: 'First' })).toBe(
+        '@[First](first|0)'
+      )
+      expect(config[1].serializer.insert({ id: 'second', display: 'Second' })).toBe(
+        '@[Second](second|1)'
+      )
+    })
+
+    it('should parse duplicate-trigger markup with the correct serializer', () => {
+      const children = [
+        <Mention key="1" trigger="@" displayTransform={(id) => `user:${id}`} data={[]} />,
+        <Mention key="2" trigger="@" displayTransform={(id) => `team:${id}`} data={[]} />,
+      ]
+
+      const config = readConfigFromChildren(children)
+      const value = [
+        config[0].serializer.insert({ id: 'alice', display: 'Alice' }),
+        config[1].serializer.insert({ id: 'eng', display: 'Engineering' }),
+      ].join(' ')
+
+      expect(getPlainText(value, config)).toBe('user:alice team:eng')
     })
 
     it('should maintain existing behavior when custom markup is provided', () => {

--- a/src/utils/readConfigFromChildren.ts
+++ b/src/utils/readConfigFromChildren.ts
@@ -27,6 +27,10 @@ const generateMarkupForTrigger = (trigger: string | RegExp | undefined): string 
   return `${trigger}[${PLACEHOLDERS.display}](${PLACEHOLDERS.id})`
 }
 
+const appendSerializerMarker = (markup: string, occurrenceIndex: number): string => {
+  return markup.replace(PLACEHOLDERS.id, `${PLACEHOLDERS.id}|${occurrenceIndex.toString()}`)
+}
+
 const isReactFragment = (child: unknown): child is ReactElement<{ children?: ReactNode }> =>
   React.isValidElement(child) && child.type === React.Fragment
 
@@ -47,15 +51,44 @@ export const collectMentionElements = <Extra extends Record<string, unknown>>(
 
 const readConfigFromChildren = <Extra extends Record<string, unknown> = Record<string, unknown>>(
   children: ReactNode
-): MentionChildConfig<Extra>[] =>
-  collectMentionElements<Extra>(children).map((child) => {
+): MentionChildConfig<Extra>[] => {
+  const mentionChildren = collectMentionElements<Extra>(children)
+  const serializerIdCounts = new Map<string, number>()
+
+  for (const child of mentionChildren) {
+    const serializerId =
+      child.props.markup === undefined
+        ? generateMarkupForTrigger(child.props.trigger)
+        : typeof child.props.markup === 'string'
+          ? child.props.markup
+          : child.props.markup.id
+
+    serializerIdCounts.set(serializerId, (serializerIdCounts.get(serializerId) ?? 0) + 1)
+  }
+
+  const autoSerializerOccurrences = new Map<string, number>()
+
+  return mentionChildren.map((child) => {
     const props = child.props
     const trigger = props.trigger ?? DEFAULT_MENTION_PROPS.trigger
     const displayTransform = props.displayTransform ?? DEFAULT_MENTION_PROPS.displayTransform
+    const baseMarkup = generateMarkupForTrigger(trigger)
     const serializer: MentionSerializer =
       props.markup !== undefined && typeof props.markup !== 'string'
         ? props.markup
-        : createMarkupSerializer(props.markup ?? generateMarkupForTrigger(trigger))
+        : createMarkupSerializer(
+            props.markup ??
+              ((serializerIdCounts.get(baseMarkup) ?? 0) > 1
+                ? appendSerializerMarker(baseMarkup, autoSerializerOccurrences.get(baseMarkup) ?? 0)
+                : baseMarkup)
+          )
+
+    if (props.markup === undefined) {
+      autoSerializerOccurrences.set(
+        baseMarkup,
+        (autoSerializerOccurrences.get(baseMarkup) ?? 0) + 1
+      )
+    }
 
     return {
       ...DEFAULT_MENTION_PROPS,
@@ -64,5 +97,6 @@ const readConfigFromChildren = <Extra extends Record<string, unknown> = Record<s
       serializer,
     } satisfies MentionChildConfig<Extra>
   })
+}
 
 export default readConfigFromChildren


### PR DESCRIPTION
runtime now uses a memoized (value, config) snapshot instead of mirrored derived state, componentDidUpdate is split into focused paths, onRemove / mention-remove are live, duplicate triggers are supported via distinct default serializer ids, and local array providers now cache searchable labels and stop scanning at maxSuggestions added deterministic perf coverage in src/MentionsInput.performance.spec.tsx, src/MentionsInputSelectors.performance.spec.ts, plus src/test/performance.tsx.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Support for multiple mention triggers with the same symbol

* **Bug Fixes**
  * Enhanced mention removal handling with improved callback mechanism
  * Improved robustness of selection and trigger parsing logic

* **Performance**
  * Optimized data retrieval with caching for faster suggestion filtering
  * Reduced redundant calculations through snapshot caching

* **Tests**
  * Added comprehensive performance test suites

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reduce controlled-keystroke recomputation and array-provider scans in MentionsInput
> - Introduces snapshot caching in [`MentionsInput`](https://github.com/hbmartin/react-mentions-ts/pull/183/files#diff-5324a6e48c1ed3e0637605dab500fd0e512b7917d46884c35cba8e68698b5473) so mention parsing results are reused across renders instead of recomputed on every keystroke; removes cached values from component state.
> - Adds early-exit to the array data provider in [`MentionsInputSelectors.ts`](https://github.com/hbmartin/react-mentions-ts/pull/183/files#diff-c90f618868bcc692e4549e3767f3a52a01f42df6a8d6d2767a705efbb5cf574b) so scanning stops once `maxSuggestions` matches are found; adds a WeakMap cache for precomputed searchable strings.
> - Duplicate `<Mention>` triggers are now allowed; [`readConfigFromChildren`](https://github.com/hbmartin/react-mentions-ts/pull/183/files#diff-f75f92f372c7d5742998a841b92a5a13383de129b6bd846b49f9f0b9f097b1bd) generates distinct serializer ids per occurrence so each can be parsed independently.
> - Editing or pasting over a mention now emits a `mention-remove` trigger type and calls `onRemove` callbacks via the new `emitOnRemoveCallbacks` helper.
> - Fixes SSR/non-browser environments in [`MeasurementBridge`](https://github.com/hbmartin/react-mentions-ts/pull/183/files#diff-f05f418c2b64673088d3968a6d394b6f13b7dc48a13f8e0a4b7088f5a3635787), [`MentionsInputLayout.ts`](https://github.com/hbmartin/react-mentions-ts/pull/183/files#diff-7d40540d82b40ebe0cf0576049c2f8f73039531f16f648e29f85078d7777a473), and several `MentionsInput` methods by guarding access to `window`, `ResizeObserver`, `getComputedStyle`, and `HTMLTextAreaElement`.
> - Behavioral Change: `trigger.type` in `onMentionsChange` may now be `'mention-remove'` (with `mentionId` set) when an edit removes a mention, where previously only `'change'` was emitted.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 9e0c1c9. 8 files reviewed, 3 issues evaluated, 0 issues filtered, 2 comments posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->