### PR TITLE
Fixes Linux IME issue via dead-key/IME fix

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -1,0 +1,68 @@
+name: Performance Notes
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  perf-check:
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v5
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22.x
+          cache: 'pnpm'
+          cache-dependency-path: pnpm-lock.yaml
+      - run: corepack enable
+      - run: pnpm install --frozen-lockfile
+      - name: Fetch master history
+        run: git fetch origin master:refs/remotes/origin/master
+      - name: Fetch perf notes
+        run: |
+          if git ls-remote --exit-code origin refs/notes/perf >/dev/null 2>&1; then
+            git fetch origin +refs/notes/perf:refs/notes/perf
+          fi
+      - run: pnpm perf:check
+
+  perf-record:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v5
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22.x
+          cache: 'pnpm'
+          cache-dependency-path: pnpm-lock.yaml
+      - run: corepack enable
+      - run: pnpm install --frozen-lockfile
+      - name: Fetch perf notes
+        run: |
+          if git ls-remote --exit-code origin refs/notes/perf >/dev/null 2>&1; then
+            git fetch origin +refs/notes/perf:refs/notes/perf
+          fi
+      - name: Configure git identity
+        run: |
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+      - run: pnpm perf:record
+      - name: Push perf notes
+        run: git push origin refs/notes/perf:refs/notes/perf

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,17 @@
 - never run publint with pnpm, instead always use `npx publint --pack npm`
 - use `pnpm` for all commands except `pack`
 - always run `pnpm test` after completing the todo list to make sure there are no breaking changes
+
+## Relevant best-practice guidance for this library
+
+- keep `MentionsInput` as the orchestration shell; prefer extracting helpers or leaf components before considering a full hooks rewrite
+- preserve render locality: move state and derived work into the smallest branch that consumes it, and do not reparse mention children/config in hot render paths
+- prefer composition and the existing extension points (`children`, `inputComponent`, `customSuggestionsContainer`, targeted render callbacks) over adding boolean props, prop explosions, HOCs, or broad context layers
+- measure before memoizing; only add `useMemo`, `useCallback`, or `memo` when referential stability or a measured bottleneck requires it, and keep simple primitive derivations inline
+- never define components inside components; preserve stable keys and element identity across suggestions, highlighter output, and other dynamic lists
+- derive values during render when possible; avoid prop-to-state syncing in effects, and keep interaction-driven side effects in event handlers instead of `useEffect`
+- use refs and stable callback helpers for transient values, subscriptions, and stale-closure avoidance; keep user-visible data in state and preserve imperative/ref compatibility
+- keep async suggestion flows race-safe: debounce side effects rather than controlled input updates, abort or ignore stale requests, and preserve existing suggestions while a same-trigger refresh is loading
+- keep paint-sensitive measurement and overlay math inside `MentionsInputLayout`, `MeasurementBridge`, and minimal `useLayoutEffect` usage; preserve portal, scroll, and auto-resize behavior
+- keep the published surface small and analyzable: avoid unnecessary exports, overly dynamic import/path patterns, and dependency choices that bloat the library bundle
+- verify render-locality, async, and layout changes with focused tests and the demo harness before treating a refactor as safe

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,3 +20,20 @@ Pull requests are encouraged. If you want to add a feature or fix a bug:
 5. Run `pnpm build` and then run tests with `pnpm test`
 6. If coding a new feature, please add the examples to the example app (`/demo/src/examples`) and add the docs to the `README.md` file.
 7. Push your branch and open a PR 🚀
+
+## Performance Notes
+
+The repository tracks deterministic perf results in Git notes under `refs/notes/perf`.
+
+- Run `pnpm perf:check` to compare your current branch against the nearest recorded baseline on `origin/master`.
+- Run `pnpm perf:record` only when you intend to attach a perf note to the current `HEAD` commit.
+
+Optional local Git setup for maintainers:
+
+```bash
+git config --add remote.origin.fetch +refs/notes/perf:refs/notes/perf
+git config --add notes.displayRef refs/notes/perf
+git config --add notes.rewriteRef refs/notes/perf
+```
+
+With that config in place, `git log --notes=perf` and `git show --notes=perf <commit>` will display recorded perf notes locally.

--- a/package.json
+++ b/package.json
@@ -43,6 +43,8 @@
 		"dev": "node ./scripts/dev-with-wdyr.mjs",
 		"demo": "vite --config demo/vite.config.ts",
 		"preview": "vite preview --config demo/vite.config.ts",
+		"perf:check": "node ./scripts/perf-notes.mjs check",
+		"perf:record": "node ./scripts/perf-notes.mjs record",
 		"test": "BROWSERSLIST_IGNORE_OLD_DATA=true vitest run",
 		"test:perf": "BROWSERSLIST_IGNORE_OLD_DATA=true vitest run src/MentionsInput.performance.spec.tsx src/MentionsInputSelectors.performance.spec.ts",
 		"test:watch": "BROWSERSLIST_IGNORE_OLD_DATA=true vitest",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1607,8 +1607,8 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
-  baseline-browser-mapping@2.10.19:
-    resolution: {integrity: sha512-qCkNLi2sfBOn8XhZQ0FXsT1Ki/Yo5P90hrkRamVFRS7/KV9hpfA4HkoWNU152+8w0zPjnxo5psx5NL3PSGgv5g==}
+  baseline-browser-mapping@2.10.20:
+    resolution: {integrity: sha512-1AaXxEPfXT+GvTBJFuy4yXVHWJBXa4OdbIebGN/wX5DlsIkU0+wzGnd2lOzokSk51d5LUmqjgBLRLlypLUqInQ==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -2284,6 +2284,9 @@ packages:
 
   get-tsconfig@4.13.7:
     resolution: {integrity: sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==}
+
+  get-tsconfig@4.14.0:
+    resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
 
   git-hooks-list@4.2.1:
     resolution: {integrity: sha512-WNvqJjOxxs/8ZP9+DWdwWJ7cDsd60NHf39XnD82pDVrKO5q7xfPqpkK6hwEAmBa/ZSEE4IOoR75EzbbIuwGlMw==}
@@ -4932,7 +4935,7 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
-  baseline-browser-mapping@2.10.19: {}
+  baseline-browser-mapping@2.10.20: {}
 
   bidi-js@1.0.3:
     dependencies:
@@ -4955,7 +4958,7 @@ snapshots:
 
   browserslist@4.28.2:
     dependencies:
-      baseline-browser-mapping: 2.10.19
+      baseline-browser-mapping: 2.10.20
       caniuse-lite: 1.0.30001788
       electron-to-chromium: 1.5.340
       node-releases: 2.0.37
@@ -5322,7 +5325,7 @@ snapshots:
 
   eslint-import-context@0.1.9(unrs-resolver@1.11.1):
     dependencies:
-      get-tsconfig: 4.13.7
+      get-tsconfig: 4.14.0
       stable-hash-x: 0.2.0
     optionalDependencies:
       unrs-resolver: 1.11.1
@@ -5341,7 +5344,7 @@ snapshots:
       debug: 4.4.3
       eslint: 10.2.1(jiti@2.6.1)
       eslint-import-context: 0.1.9(unrs-resolver@1.11.1)
-      get-tsconfig: 4.13.7
+      get-tsconfig: 4.14.0
       is-bun-module: 2.0.0
       stable-hash-x: 0.2.0
       tinyglobby: 0.2.16
@@ -5754,6 +5757,10 @@ snapshots:
       get-intrinsic: 1.3.0
 
   get-tsconfig@4.13.7:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
+  get-tsconfig@4.14.0:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
@@ -6571,7 +6578,7 @@ snapshots:
       ast-kit: 3.0.0-beta.1
       birpc: 4.0.0
       dts-resolver: 2.1.3(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))
-      get-tsconfig: 4.13.7
+      get-tsconfig: 4.14.0
       obug: 2.1.1
       picomatch: 4.0.4
       rolldown: 1.0.0-rc.16

--- a/src/MentionsInput.performance.spec.tsx
+++ b/src/MentionsInput.performance.spec.tsx
@@ -125,6 +125,10 @@ describe('MentionsInput performance', () => {
       expect(combobox.selectionStart).toBe(2)
     })
 
+    await waitFor(() => {
+      expect(screen.getByRole('status')).toHaveTextContent('Alice')
+    })
+
     fireEvent.keyDown(combobox, { key: 'ArrowRight' })
 
     await waitFor(() => {

--- a/src/MentionsInput.spec.tsx
+++ b/src/MentionsInput.spec.tsx
@@ -1134,6 +1134,46 @@ describe('MentionsInput', () => {
     })
   })
 
+  it('falls back to counter-based generated ids when crypto.randomUUID is unavailable', async () => {
+    const cryptoDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'crypto')
+
+    Object.defineProperty(globalThis, 'crypto', {
+      value: undefined,
+      configurable: true,
+    })
+
+    try {
+      render(
+        <MentionsInput value="@f" suggestionsDisplay="inline">
+          <Mention
+            trigger="@"
+            data={[
+              { id: 'first', display: 'First' },
+              { id: 'second', display: 'Second' },
+            ]}
+          />
+        </MentionsInput>
+      )
+
+      const textarea = screen.getByRole('combobox')
+      fireEvent.focus(textarea)
+      textarea.setSelectionRange(2, 2)
+      fireEvent.select(textarea)
+
+      await waitFor(() => {
+        const status = screen.getByRole('status')
+        expect(status.id).toMatch(/^mentions-\d+-inline-live$/)
+        expect(textarea).toHaveAttribute('aria-describedby', status.id)
+      })
+    } finally {
+      if (cryptoDescriptor) {
+        Object.defineProperty(globalThis, 'crypto', cryptoDescriptor)
+      } else {
+        delete (globalThis as { crypto?: unknown }).crypto
+      }
+    }
+  })
+
   it('should accept a Document instance as the suggestionsPortalHost.', async () => {
     render(
       <MentionsInput value="@" suggestionsPortalHost={document}>
@@ -1205,6 +1245,32 @@ describe('MentionsInput', () => {
     expect(textarea.value).toEqual('@A and @B and :invalidId')
   })
 
+  it('updates the rendered plain text when displayTransform changes', () => {
+    const mentionData = [{ id: 'user', display: 'User' }]
+    const atDisplayTransform = (id: string | number, display?: string | null) =>
+      `@${display ?? String(id)}`
+    const hashDisplayTransform = (id: string | number) => `#${String(id)}`
+    const value = '@[User](user)'
+
+    const { rerender } = render(
+      <MentionsInput value={value}>
+        <Mention trigger="@" data={mentionData} displayTransform={atDisplayTransform} />
+      </MentionsInput>
+    )
+
+    const textarea = screen.getByRole('combobox')
+    fireEvent.focus(textarea)
+    expect(textarea).toHaveValue('@User')
+
+    rerender(
+      <MentionsInput value={value}>
+        <Mention trigger="@" data={mentionData} displayTransform={hashDisplayTransform} />
+      </MentionsInput>
+    )
+
+    expect(textarea).toHaveValue('#user')
+  })
+
   it('should forward the `inputRef` prop to become the `ref` of the input', () => {
     const inputRef = React.createRef()
 
@@ -1230,6 +1296,19 @@ describe('MentionsInput', () => {
 
     const textarea = screen.getByRole('combobox')
     expect(inputRef).toHaveBeenCalledWith(textarea)
+  })
+
+  it('should ignore a null inputRef object without throwing', () => {
+    render(
+      <MentionsInput
+        value="test"
+        inputRef={null as unknown as React.RefObject<HTMLInputElement | HTMLTextAreaElement>}
+      >
+        <Mention trigger="@" data={data} />
+      </MentionsInput>
+    )
+
+    expect(screen.getByRole('combobox')).toBeInTheDocument()
   })
 
   it('should render a custom input when supplied.', () => {
@@ -1295,6 +1374,28 @@ describe('MentionsInput', () => {
       const suggestions = screen.getAllByRole('option', { hidden: true })
       expect(suggestions.length).toBeGreaterThan(0)
     })
+  })
+
+  it('ignores custom regular expression matches without a replacement range capture', async () => {
+    const mentionData = vi.fn(() => [{ id: 'first', display: 'First' }])
+
+    render(
+      <MentionsInput value="hello">
+        <Mention trigger={/(#)?(\S*)$/} data={mentionData} />
+      </MentionsInput>
+    )
+
+    const textarea = screen.getByRole('combobox')
+    fireEvent.focus(textarea)
+    textarea.setSelectionRange(5, 5)
+    fireEvent.select(textarea)
+
+    await waitFor(() => {
+      expect(textarea.selectionStart).toBe(5)
+    })
+
+    expect(mentionData).not.toHaveBeenCalled()
+    expect(screen.queryByRole('option', { hidden: true })).toBeNull()
   })
 
   describe('autoResize', () => {
@@ -1950,6 +2051,46 @@ describe('MentionsInput', () => {
       expect(payload.trigger.type).toBe('mention-remove')
       expect(payload.mentionId).toBe('first')
       expect(onRemove).toHaveBeenCalledWith('first')
+    })
+
+    it('emits mention-remove when replacement mentions would collide under colon-joined keys.', () => {
+      const onMentionsChange = vi.fn()
+      const onRemove = vi.fn()
+
+      render(
+        <MentionsInput value="@[c](a:b)" onMentionsChange={onMentionsChange}>
+          <Mention trigger="@[__display__](__id__)" data={data} onRemove={onRemove} />
+        </MentionsInput>
+      )
+
+      const textarea = screen.getByRole('combobox')
+      textarea.setSelectionRange(0, 1)
+      fireEvent.select(textarea, {
+        target: { selectionStart: 0, selectionEnd: 1 },
+      })
+
+      const event = new Event('paste', { bubbles: true })
+      event.clipboardData = {
+        getData: vi.fn((type) => {
+          if (type === 'text/react-mentions') {
+            return '@[b:c](a)'
+          }
+
+          if (type === 'text/plain') {
+            return 'b:c'
+          }
+
+          return ''
+        }),
+      }
+
+      fireEvent(textarea, event)
+
+      const payload = getLastMentionsChange(onMentionsChange)
+      expect(payload.trigger.type).toBe('mention-remove')
+      expect(payload.mentionId).toBe('a:b')
+      expect(payload.value).toBe('@[b:c](a)')
+      expect(onRemove).toHaveBeenCalledWith('a:b')
     })
 
     it('should remove carriage returns from pasted values', () => {
@@ -2995,6 +3136,84 @@ describe('MentionsInput', () => {
       expect(instance._isComposing).toBe(false)
 
       unmount()
+    })
+
+    it('preserves composing diacritics when controlled reconciliation re-runs mismatch recovery', async () => {
+      const ref = React.createRef<MentionsInput>()
+      const onMentionsChange = vi.fn()
+
+      function ControlledInput() {
+        const [value, setValue] = React.useState('Cafe')
+
+        return (
+          <MentionsInput
+            ref={ref}
+            value={value}
+            onMentionsChange={(change) => {
+              setValue(change.value)
+              onMentionsChange(change)
+            }}
+          >
+            <Mention trigger="@" data={data} />
+          </MentionsInput>
+        )
+      }
+
+      const { unmount } = render(<ControlledInput />)
+
+      try {
+        await waitFor(() => {
+          expect(ref.current).not.toBeNull()
+        })
+
+        const instance = ref.current as unknown as any
+        const combobox = screen.getByRole('combobox') as HTMLTextAreaElement
+
+        act(() => {
+          instance.setState({ selectionStart: 4, selectionEnd: 4 })
+        })
+
+        const actualGetPlainText = utils.getPlainText
+        const getPlainTextSpy = vi
+          .spyOn(utils, 'getPlainText')
+          .mockImplementationOnce((inputValue, inputConfig) =>
+            actualGetPlainText(inputValue, inputConfig)
+          )
+          .mockImplementationOnce(() => 'intermediate mismatch')
+          .mockImplementation((inputValue, inputConfig) =>
+            actualGetPlainText(inputValue, inputConfig)
+          )
+
+        try {
+          combobox.value = 'Cafe\u0301'
+          combobox.setSelectionRange('Cafe\u0301'.length, 'Cafe\u0301'.length)
+
+          act(() => {
+            instance.handleChange({
+              target: combobox,
+              currentTarget: combobox,
+              nativeEvent: {
+                isComposing: true,
+                data: '\u0301',
+              },
+            } as React.ChangeEvent<HTMLTextAreaElement>)
+          })
+
+          await waitFor(() => {
+            expect(onMentionsChange).toHaveBeenCalled()
+            expect(combobox).toHaveValue('Cafe\u0301')
+          })
+
+          const payload = getLastMentionsChange(onMentionsChange)
+          expect(payload.value).toBe('Cafe\u0301')
+          expect(payload.plainTextValue).toBe('Cafe\u0301')
+          expect(payload.trigger.type).toBe('input')
+        } finally {
+          getPlainTextSpy.mockRestore()
+        }
+      } finally {
+        unmount()
+      }
     })
 
     it('processes queued highlighter recompute requests sequentially.', async () => {

--- a/src/MentionsInput.tsx
+++ b/src/MentionsInput.tsx
@@ -97,8 +97,10 @@ import type {
 let generatedIdCounter = 0
 
 const createGeneratedId = (): string => {
-  if (typeof globalThis.crypto.randomUUID === 'function') {
-    return `mentions-${globalThis.crypto.randomUUID()}`
+  const cryptoObject = globalThis.crypto
+
+  if (cryptoObject && typeof cryptoObject.randomUUID === 'function') {
+    return `mentions-${cryptoObject.randomUUID()}`
   }
 
   generatedIdCounter += 1
@@ -159,7 +161,7 @@ interface ActiveSuggestionQuery<Extra extends Record<string, unknown>> {
 const getMentionDiffKey = <Extra extends Record<string, unknown>>(
   mention: MentionOccurrence<Extra>
 ): string => {
-  return `${mention.childIndex}:${String(mention.id)}:${mention.display}`
+  return JSON.stringify([mention.childIndex, String(mention.id), mention.display])
 }
 
 const getRemovedMentions = <Extra extends Record<string, unknown>>(
@@ -821,7 +823,7 @@ class MentionsInput<
     const { inputRef } = this.props
     if (typeof inputRef === 'function') {
       inputRef(el)
-    } else if (inputRef !== undefined) {
+    } else if (inputRef !== null && inputRef !== undefined) {
       ;(inputRef as React.RefObject<InputElement | null>).current = el
     }
   }
@@ -1728,11 +1730,15 @@ class MentionsInput<
       const regex = resolveTriggerRegex(triggerProp)
       const match = substring.match(regex)
 
-      if (match === null || match.length < 3) {
+      if (match === null) {
         return []
       }
       const replacementRange = match[1]
       const query = match[2]
+
+      if (typeof replacementRange !== 'string' || typeof query !== 'string') {
+        return []
+      }
 
       const matchIndex = match.index ?? 0
       const querySequenceStart =

--- a/src/MentionsInputChildren.spec.tsx
+++ b/src/MentionsInputChildren.spec.tsx
@@ -57,6 +57,44 @@ describe('MentionsInputChildren', () => {
     ).not.toThrow()
   })
 
+  it('treats omitted and default string triggers as the same mention identity', () => {
+    const defaultedConfig = prepareMentionsInputChildren(
+      <>
+        <Mention data={[]} />
+      </>
+    ).config
+    const explicitConfig = prepareMentionsInputChildren(
+      <>
+        <Mention trigger="@" data={[]} />
+      </>
+    ).config
+
+    expect(areMentionConfigsEqual(defaultedConfig, explicitConfig)).toBe(true)
+  })
+
+  it('treats displayTransform identity as part of the mention equality check', () => {
+    const sharedDisplayTransform = (id: string | number) => `@${String(id)}`
+
+    const baseConfig = prepareMentionsInputChildren(
+      <>
+        <Mention trigger="@" data={[]} displayTransform={sharedDisplayTransform} />
+      </>
+    ).config
+    const sameConfig = prepareMentionsInputChildren(
+      <>
+        <Mention trigger="@" data={[]} displayTransform={sharedDisplayTransform} />
+      </>
+    ).config
+    const differentDisplayTransformConfig = prepareMentionsInputChildren(
+      <>
+        <Mention trigger="@" data={[]} displayTransform={(id) => `#${String(id)}`} />
+      </>
+    ).config
+
+    expect(areMentionConfigsEqual(baseConfig, sameConfig)).toBe(true)
+    expect(areMentionConfigsEqual(baseConfig, differentDisplayTransformConfig)).toBe(false)
+  })
+
   it('treats regex trigger flags as part of the mention identity', () => {
     expect(() =>
       validateMentionChildTree(

--- a/src/MentionsInputChildren.ts
+++ b/src/MentionsInputChildren.ts
@@ -1,4 +1,5 @@
 import React from 'react'
+import { DEFAULT_MENTION_PROPS } from './MentionDefaultProps'
 import type { MentionChildConfig, MentionComponentProps } from './types'
 import { isMentionElement } from './utils/isMentionElement'
 import readConfigFromChildren, { collectMentionElements } from './utils/readConfigFromChildren'
@@ -11,13 +12,11 @@ export interface PreparedMentionsInputChildren<
 }
 
 const getTriggerIdentity = (trigger: string | RegExp | undefined): string => {
-  if (trigger === undefined) {
-    return 'default:@'
-  }
+  const normalizedTrigger = trigger ?? DEFAULT_MENTION_PROPS.trigger
 
-  return typeof trigger === 'string'
-    ? `str:${trigger}`
-    : `re:${trigger.source}/${trigger.flags.replaceAll('g', '')}`
+  return typeof normalizedTrigger === 'string'
+    ? `str:${normalizedTrigger}`
+    : `re:${normalizedTrigger.source}/${normalizedTrigger.flags.replaceAll('g', '')}`
 }
 
 const getInvalidChildLabel = (child: React.ReactNode): string => {
@@ -97,7 +96,8 @@ export const areMentionConfigsEqual = <Extra extends Record<string, unknown>>(
 
     return (
       getTriggerIdentity(leftConfig.trigger) === getTriggerIdentity(rightConfig.trigger) &&
-      leftConfig.serializer.id === rightConfig.serializer.id
+      leftConfig.serializer.id === rightConfig.serializer.id &&
+      leftConfig.displayTransform === rightConfig.displayTransform
     )
   })
 }

--- a/src/test/perfNotes.spec.ts
+++ b/src/test/perfNotes.spec.ts
@@ -1,0 +1,239 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { spawnSync } from 'node:child_process'
+import path from 'node:path'
+import {
+  checkPerfAgainstBaseline,
+  comparePerfNotes,
+  findNearestBaselineNote,
+  parsePerfOutput,
+  recordPerfNote,
+  readPerfNote,
+  writePerfNote,
+} from './perfNotes'
+
+const SAMPLE_PERF_OUTPUT = `
+[perf] array-provider-scan-count {"scanCount":5,"resultCount":5}
+[perf] controlled-keystroke {"getPlainTextCalls":0,"deriveMentionValueSnapshotCalls":1,"prepareMentionsInputChildrenCalls":1}
+[perf] selection-only {"deriveMentionValueSnapshotCalls":0}
+[perf] inline-layout {"calculateSuggestionsPositionCalls":0,"calculateInlineSuggestionPositionCalls":1}
+[perf] overlay-layout {"calculateSuggestionsPositionCalls":2,"calculateInlineSuggestionPositionCalls":0}
+[perf] locality-render-counts {"stableSiblingRendersDuringInteraction":0,"activeBranchRendersDuringInteraction":1}
+`.trim()
+
+const runGit = (repositoryRoot: string, args: string[]): string => {
+  // eslint-disable-next-line sonarjs/no-os-command-from-path -- temp-repo integration tests intentionally exercise the local git binary.
+  const result = spawnSync('git', args, {
+    cwd: repositoryRoot,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+
+  if (result.error) {
+    throw result.error
+  }
+
+  if (result.status !== 0) {
+    throw new Error(
+      [`git ${args.join(' ')}`, result.stdout, result.stderr]
+        .map((value) => value.trim())
+        .filter(Boolean)
+        .join('\n')
+    )
+  }
+
+  return result.stdout.trim()
+}
+
+const tempDirectories: string[] = []
+
+const createTempRepository = (): string => {
+  const directory = mkdtempSync(path.join(tmpdir(), 'react-mentions-ts-perf-notes-spec-'))
+  tempDirectories.push(directory)
+
+  runGit(directory, ['init', '--initial-branch=master'])
+  runGit(directory, ['config', 'user.name', 'Perf Notes Test'])
+  runGit(directory, ['config', 'user.email', 'perf-notes@example.com'])
+
+  return directory
+}
+
+const commitFile = (
+  repositoryRoot: string,
+  name: string,
+  content: string,
+  message: string
+): string => {
+  // eslint-disable-next-line security/detect-non-literal-fs-filename -- temp-repo tests intentionally write fixture files by computed path.
+  writeFileSync(path.join(repositoryRoot, name), content, 'utf8')
+  runGit(repositoryRoot, ['add', name])
+  runGit(repositoryRoot, ['commit', '-m', message])
+  return runGit(repositoryRoot, ['rev-parse', 'HEAD'])
+}
+
+const createFeatureRepository = (): {
+  commits: { feature: string; first: string; mergeBase: string; masterHead: string }
+  cwd: string
+} => {
+  const repositoryRoot = createTempRepository()
+  const first = commitFile(repositoryRoot, 'fixture.txt', 'one\n', 'first')
+  const mergeBase = commitFile(repositoryRoot, 'fixture.txt', 'two\n', 'second')
+  const masterHead = commitFile(repositoryRoot, 'fixture.txt', 'three\n', 'third')
+  runGit(repositoryRoot, ['update-ref', 'refs/remotes/origin/master', masterHead])
+  runGit(repositoryRoot, ['checkout', '-b', 'feature', mergeBase])
+  const feature = commitFile(repositoryRoot, 'feature.txt', 'feature\n', 'feature')
+
+  return {
+    commits: {
+      feature,
+      first,
+      masterHead,
+      mergeBase,
+    },
+    cwd: repositoryRoot,
+  }
+}
+
+afterEach(() => {
+  while (tempDirectories.length > 0) {
+    const directory = tempDirectories.pop()
+    if (typeof directory === 'string') {
+      rmSync(directory, { force: true, recursive: true })
+    }
+  }
+})
+
+describe('perfNotes', () => {
+  it('parses [perf] lines into a stable note payload', () => {
+    const payload = parsePerfOutput(`ignored line\n${SAMPLE_PERF_OUTPUT}\ntrailing line`)
+
+    expect(payload).toEqual({
+      command: 'pnpm test:perf',
+      metrics: {
+        'array-provider-scan-count': {
+          resultCount: 5,
+          scanCount: 5,
+        },
+        'controlled-keystroke': {
+          deriveMentionValueSnapshotCalls: 1,
+          getPlainTextCalls: 0,
+          prepareMentionsInputChildrenCalls: 1,
+        },
+        'inline-layout': {
+          calculateInlineSuggestionPositionCalls: 1,
+          calculateSuggestionsPositionCalls: 0,
+        },
+        'locality-render-counts': {
+          activeBranchRendersDuringInteraction: 1,
+          stableSiblingRendersDuringInteraction: 0,
+        },
+        'overlay-layout': {
+          calculateInlineSuggestionPositionCalls: 0,
+          calculateSuggestionsPositionCalls: 2,
+        },
+        'selection-only': {
+          deriveMentionValueSnapshotCalls: 0,
+        },
+      },
+      schemaVersion: 1,
+      suite: 'react-mentions-ts/perf',
+    })
+  })
+
+  it('ignores informational metrics and only flags tracked regressions', () => {
+    const baseline = parsePerfOutput(SAMPLE_PERF_OUTPUT)
+    const candidate = parsePerfOutput(
+      SAMPLE_PERF_OUTPUT.replace('"resultCount":5', '"resultCount":999').replace(
+        '"scanCount":5',
+        '"scanCount":6'
+      )
+    )
+
+    const result = comparePerfNotes(baseline, candidate)
+
+    expect(result.errors).toEqual([])
+    expect(result.skipped).toEqual([])
+    expect(result.regressions).toEqual([
+      {
+        baseline: 5,
+        candidate: 6,
+        metric: 'scanCount',
+        scenario: 'array-provider-scan-count',
+      },
+    ])
+  })
+
+  it('writes and reads perf notes through a custom notes ref', () => {
+    const cwd = createTempRepository()
+    const headCommit = commitFile(cwd, 'fixture.txt', 'hello\n', 'initial')
+    const payload = parsePerfOutput(SAMPLE_PERF_OUTPUT)
+
+    writePerfNote(cwd, headCommit, payload, 'refs/notes/test-perf')
+
+    expect(readPerfNote(cwd, headCommit, 'refs/notes/test-perf')).toEqual(payload)
+  })
+
+  it('records a perf note on HEAD without touching the default notes ref', () => {
+    const cwd = createTempRepository()
+    const headCommit = commitFile(cwd, 'fixture.txt', 'hello\n', 'initial')
+
+    const payload = recordPerfNote(cwd, {
+      notesRef: 'refs/notes/test-perf',
+      perfOutput: SAMPLE_PERF_OUTPUT,
+    })
+
+    expect(payload).toEqual(readPerfNote(cwd, headCommit, 'refs/notes/test-perf'))
+    expect(readPerfNote(cwd, headCommit)).toBeNull()
+  })
+
+  it('prefers an exact merge-base note when one exists', () => {
+    const { commits, cwd } = createFeatureRepository()
+    writePerfNote(
+      cwd,
+      commits.mergeBase,
+      parsePerfOutput(SAMPLE_PERF_OUTPUT),
+      'refs/notes/test-perf'
+    )
+
+    const result = findNearestBaselineNote(cwd, {
+      head: commits.feature,
+      notesRef: 'refs/notes/test-perf',
+      targetRef: 'origin/master',
+    })
+
+    expect(result.mergeBase).toBe(commits.mergeBase)
+    expect(result.baselineCommit).toBe(commits.mergeBase)
+    expect(result.note?.metrics['array-provider-scan-count'].scanCount).toBe(5)
+  })
+
+  it('falls back to an earlier master note when the exact merge-base note is missing', () => {
+    const { commits, cwd } = createFeatureRepository()
+    writePerfNote(cwd, commits.first, parsePerfOutput(SAMPLE_PERF_OUTPUT), 'refs/notes/test-perf')
+
+    const result = findNearestBaselineNote(cwd, {
+      head: commits.feature,
+      notesRef: 'refs/notes/test-perf',
+      targetRef: 'origin/master',
+    })
+
+    expect(result.mergeBase).toBe(commits.mergeBase)
+    expect(result.baselineCommit).toBe(commits.first)
+    expect(result.note?.metrics['overlay-layout'].calculateSuggestionsPositionCalls).toBe(2)
+  })
+
+  it('returns a neutral result when no baseline note exists on master ancestry', () => {
+    const { commits, cwd } = createFeatureRepository()
+
+    const result = checkPerfAgainstBaseline(cwd, {
+      head: commits.feature,
+      notesRef: 'refs/notes/test-perf',
+      perfOutput: SAMPLE_PERF_OUTPUT,
+      targetRef: 'origin/master',
+    })
+
+    expect(result.status).toBe('missing-baseline')
+    expect(result.mergeBase).toBe(commits.mergeBase)
+    expect(result.baselineCommit).toBeNull()
+    expect(result.baselineNote).toBeNull()
+  })
+})

--- a/src/test/perfNotes.ts
+++ b/src/test/perfNotes.ts
@@ -1,0 +1,604 @@
+import { execSync, spawnSync } from 'node:child_process'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+
+export const PERF_NOTES_REF = 'refs/notes/perf'
+export const PERF_TARGET_REF = 'origin/master'
+export const PERF_COMMAND = 'pnpm test:perf'
+export const PERF_SCHEMA_VERSION = 1
+export const PERF_SUITE = 'react-mentions-ts/perf'
+
+export interface PerfNotePayload {
+  command: string
+  metrics: Record<string, Record<string, number | string>>
+  schemaVersion: number
+  suite: string
+}
+
+export interface PerfRegression {
+  baseline: number
+  candidate: number
+  metric: string
+  scenario: string
+}
+
+export interface PerfComparisonSkippedMetric {
+  metric: string
+  reason: 'baseline-missing-or-non-numeric'
+  scenario: string
+}
+
+export interface PerfComparisonError {
+  metric: string
+  reason: 'candidate-missing-or-non-numeric'
+  scenario: string
+}
+
+export interface PerfComparisonResult {
+  errors: PerfComparisonError[]
+  regressions: PerfRegression[]
+  skipped: PerfComparisonSkippedMetric[]
+}
+
+export interface BaselineLookupResult {
+  baselineCommit: string | null
+  mergeBase: string
+  note: PerfNotePayload | null
+}
+
+export interface CheckPerfAgainstBaselineResult {
+  baselineCommit: string | null
+  baselineNote: PerfNotePayload | null
+  candidateNote: PerfNotePayload
+  comparison: PerfComparisonResult
+  mergeBase: string
+  status: 'failed' | 'missing-baseline' | 'passed'
+}
+
+interface CommandResult {
+  stderr: string
+  stdout: string
+}
+
+interface RunCommandOptions {
+  env?: NodeJS.ProcessEnv
+  repositoryRoot: string
+}
+
+const PERF_LINE_PATTERN = /^\[perf] (?<scenario>\S+) (?<metrics>{.+})$/
+
+export const PERF_COMPARISON_MANIFEST = [
+  ['array-provider-scan-count', 'scanCount'],
+  ['controlled-keystroke', 'getPlainTextCalls'],
+  ['controlled-keystroke', 'deriveMentionValueSnapshotCalls'],
+  ['controlled-keystroke', 'prepareMentionsInputChildrenCalls'],
+  ['selection-only', 'deriveMentionValueSnapshotCalls'],
+  ['inline-layout', 'calculateSuggestionsPositionCalls'],
+  ['inline-layout', 'calculateInlineSuggestionPositionCalls'],
+  ['overlay-layout', 'calculateSuggestionsPositionCalls'],
+  ['overlay-layout', 'calculateInlineSuggestionPositionCalls'],
+  ['locality-render-counts', 'stableSiblingRendersDuringInteraction'],
+  ['locality-render-counts', 'activeBranchRendersDuringInteraction'],
+] as const
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+const normalizeMetricRecord = (
+  value: unknown,
+  context: string
+): Record<string, number | string> => {
+  if (!isRecord(value)) {
+    throw new TypeError(`${context} must be an object`)
+  }
+
+  const normalizedMetrics: Record<string, number | string> = {}
+  for (const [key, metricValue] of Object.entries(value)) {
+    if (typeof metricValue !== 'number' && typeof metricValue !== 'string') {
+      throw new TypeError(`${context}.${key} must be a string or number`)
+    }
+
+    normalizedMetrics[key] = metricValue
+  }
+
+  return normalizedMetrics
+}
+
+const normalizePerfNotePayload = (value: unknown): PerfNotePayload => {
+  if (!isRecord(value)) {
+    throw new TypeError('Perf note payload must be an object')
+  }
+
+  const { command, metrics, schemaVersion, suite } = value
+
+  if (schemaVersion !== PERF_SCHEMA_VERSION) {
+    throw new Error(`Unsupported perf note schema version: ${String(schemaVersion)}`)
+  }
+
+  if (command !== PERF_COMMAND) {
+    throw new Error(`Unsupported perf note command: ${String(command)}`)
+  }
+
+  if (suite !== PERF_SUITE) {
+    throw new Error(`Unsupported perf note suite: ${String(suite)}`)
+  }
+
+  if (!isRecord(metrics)) {
+    throw new TypeError('Perf note metrics must be an object')
+  }
+
+  const normalizedMetrics: Record<string, Record<string, number | string>> = {}
+  for (const [scenario, scenarioMetrics] of Object.entries(metrics)) {
+    normalizedMetrics[scenario] = normalizeMetricRecord(scenarioMetrics, `metrics.${scenario}`)
+  }
+
+  return {
+    command,
+    metrics: normalizedMetrics,
+    schemaVersion,
+    suite,
+  }
+}
+
+const runCommand = (command: string, args: string[], options: RunCommandOptions): CommandResult => {
+  const result = spawnSync(command, args, {
+    // eslint-disable-next-line code-complete/enforce-meaningful-names -- child_process uses the standard cwd option name.
+    cwd: options.repositoryRoot,
+    encoding: 'utf8',
+    env: options.env ?? process.env,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+
+  if (result.error) {
+    throw result.error
+  }
+
+  const stderr = result.stderr
+  const stdout = result.stdout
+
+  if (result.status !== 0) {
+    const renderedCommand = [command, ...args].join(' ')
+    throw new Error(
+      [`Command failed: ${renderedCommand}`, stdout.trim(), stderr.trim()]
+        .filter(Boolean)
+        .join('\n')
+    )
+  }
+
+  return {
+    stderr,
+    stdout,
+  }
+}
+
+const runGit = (repositoryRoot: string, args: string[]): CommandResult =>
+  runCommand('git', args, { repositoryRoot })
+
+const tryShowPerfNote = (
+  repositoryRoot: string,
+  commit: string,
+  notesRef: string
+): string | null => {
+  // eslint-disable-next-line sonarjs/no-os-command-from-path -- git notes are the canonical storage for perf metadata in this repository.
+  const result = spawnSync('git', ['notes', `--ref=${notesRef}`, 'show', commit], {
+    // eslint-disable-next-line code-complete/enforce-meaningful-names -- child_process uses the standard cwd option name.
+    cwd: repositoryRoot,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+
+  if (result.error) {
+    throw result.error
+  }
+
+  if (result.status === 0) {
+    return result.stdout
+  }
+
+  const stderr = result.stderr
+  if (stderr.includes('no note found') || stderr.includes('cannot read note data')) {
+    return null
+  }
+
+  throw new Error(
+    [`Failed to read git note for ${commit} from ${notesRef}`, result.stdout.trim(), stderr.trim()]
+      .filter(Boolean)
+      .join('\n')
+  )
+}
+
+const resolvePnpmPerfOutput = (
+  repositoryRoot: string,
+  env?: NodeJS.ProcessEnv,
+  perfCommand = PERF_COMMAND
+): string => {
+  try {
+    // eslint-disable-next-line sonarjs/os-command -- perf capture intentionally runs the repository's deterministic perf command.
+    return execSync(perfCommand, {
+      // eslint-disable-next-line code-complete/enforce-meaningful-names -- child_process uses the standard cwd option name.
+      cwd: repositoryRoot,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        ...env,
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+  } catch (error) {
+    const commandError = error as {
+      stderr?: string | Buffer
+      stdout?: string | Buffer
+    }
+    const stderr = String(commandError.stderr ?? '').trim()
+    const stdout = String(commandError.stdout ?? '').trim()
+    throw new Error(
+      [`Perf command failed: ${perfCommand}`, stdout, stderr].filter(Boolean).join('\n'),
+      {
+        cause: error,
+      }
+    )
+  }
+}
+
+const resolveBaselineStartCommit = (
+  repositoryRoot: string,
+  head: string,
+  targetRef: string,
+  explicitBaselineCommit?: string
+): { mergeBase: string; startCommit: string } => {
+  if (typeof explicitBaselineCommit === 'string' && explicitBaselineCommit.length > 0) {
+    return {
+      mergeBase: explicitBaselineCommit,
+      startCommit: explicitBaselineCommit,
+    }
+  }
+
+  const mergeBase = runGit(repositoryRoot, ['merge-base', head, targetRef]).stdout.trim()
+
+  return {
+    mergeBase,
+    startCommit: mergeBase,
+  }
+}
+
+export const parsePerfOutput = (output: string): PerfNotePayload => {
+  const metricsByScenario = new Map<string, Record<string, number | string>>()
+
+  for (const line of output.split(/\r?\n/u)) {
+    const match = line.match(PERF_LINE_PATTERN)
+    if (!match?.groups) {
+      continue
+    }
+
+    const { metrics: rawMetrics, scenario } = match.groups
+
+    if (metricsByScenario.has(scenario)) {
+      throw new Error(`Duplicate perf scenario emitted: ${scenario}`)
+    }
+
+    metricsByScenario.set(scenario, normalizeMetricRecord(JSON.parse(rawMetrics), scenario))
+  }
+
+  if (metricsByScenario.size === 0) {
+    throw new Error('No perf metrics were emitted by the perf command')
+  }
+
+  const normalizedMetrics: Record<string, Record<string, number | string>> = {}
+  for (const [scenario, scenarioMetrics] of metricsByScenario) {
+    normalizedMetrics[scenario] = scenarioMetrics
+  }
+
+  return {
+    command: PERF_COMMAND,
+    metrics: normalizedMetrics,
+    schemaVersion: PERF_SCHEMA_VERSION,
+    suite: PERF_SUITE,
+  }
+}
+
+export const stringifyPerfNote = (payload: PerfNotePayload): string =>
+  `${JSON.stringify(payload, null, 2)}\n`
+
+export const readPerfNote = (
+  repositoryRoot: string,
+  commit: string,
+  notesRef = PERF_NOTES_REF
+): PerfNotePayload | null => {
+  const rawNote = tryShowPerfNote(repositoryRoot, commit, notesRef)
+  if (rawNote === null) {
+    return null
+  }
+
+  return normalizePerfNotePayload(JSON.parse(rawNote))
+}
+
+export const writePerfNote = (
+  repositoryRoot: string,
+  commit: string,
+  payload: PerfNotePayload,
+  notesRef = PERF_NOTES_REF
+): void => {
+  const tempDirectory = mkdtempSync(path.join(tmpdir(), 'react-mentions-ts-perf-note-'))
+  const tempFile = path.join(tempDirectory, 'note.json')
+
+  try {
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- perf notes intentionally use a temporary file path for git notes input.
+    writeFileSync(tempFile, stringifyPerfNote(payload), 'utf8')
+    runGit(repositoryRoot, [
+      'notes',
+      `--ref=${notesRef}`,
+      'add',
+      '--force',
+      '--file',
+      tempFile,
+      commit,
+    ])
+  } finally {
+    rmSync(tempDirectory, { force: true, recursive: true })
+  }
+}
+
+export const comparePerfNotes = (
+  baseline: PerfNotePayload,
+  candidate: PerfNotePayload
+): PerfComparisonResult => {
+  const errors: PerfComparisonError[] = []
+  const regressions: PerfRegression[] = []
+  const skipped: PerfComparisonSkippedMetric[] = []
+
+  for (const [scenario, metric] of PERF_COMPARISON_MANIFEST) {
+    const baselineValue = baseline.metrics[scenario][metric]
+    const candidateValue = candidate.metrics[scenario][metric]
+
+    if (typeof candidateValue !== 'number') {
+      errors.push({
+        metric,
+        reason: 'candidate-missing-or-non-numeric',
+        scenario,
+      })
+      continue
+    }
+
+    if (typeof baselineValue !== 'number') {
+      skipped.push({
+        metric,
+        reason: 'baseline-missing-or-non-numeric',
+        scenario,
+      })
+      continue
+    }
+
+    if (candidateValue > baselineValue) {
+      regressions.push({
+        baseline: baselineValue,
+        candidate: candidateValue,
+        metric,
+        scenario,
+      })
+    }
+  }
+
+  return {
+    errors,
+    regressions,
+    skipped,
+  }
+}
+
+export const findNearestBaselineNote = (
+  repositoryRoot: string,
+  {
+    baselineCommit,
+    head = 'HEAD',
+    notesRef = PERF_NOTES_REF,
+    targetRef = PERF_TARGET_REF,
+  }: {
+    baselineCommit?: string
+    head?: string
+    notesRef?: string
+    targetRef?: string
+  } = {}
+): BaselineLookupResult => {
+  const resolvedBaseline = resolveBaselineStartCommit(
+    repositoryRoot,
+    head,
+    targetRef,
+    baselineCommit
+  )
+  const commits = runGit(repositoryRoot, [
+    'rev-list',
+    '--first-parent',
+    resolvedBaseline.startCommit,
+  ])
+    .stdout.split(/\r?\n/u)
+    .filter(Boolean)
+
+  for (const commit of commits) {
+    const note = readPerfNote(repositoryRoot, commit, notesRef)
+    if (note !== null) {
+      return {
+        baselineCommit: commit,
+        mergeBase: resolvedBaseline.mergeBase,
+        note,
+      }
+    }
+  }
+
+  return {
+    baselineCommit: null,
+    mergeBase: resolvedBaseline.mergeBase,
+    note: null,
+  }
+}
+
+export const recordPerfNote = (
+  repositoryRoot: string,
+  {
+    commit = 'HEAD',
+    env,
+    notesRef = PERF_NOTES_REF,
+    perfCommand = PERF_COMMAND,
+    perfOutput,
+  }: {
+    commit?: string
+    env?: NodeJS.ProcessEnv
+    notesRef?: string
+    perfCommand?: string
+    perfOutput?: string
+  } = {}
+): PerfNotePayload => {
+  const payload = parsePerfOutput(
+    perfOutput ?? resolvePnpmPerfOutput(repositoryRoot, env, perfCommand)
+  )
+  writePerfNote(repositoryRoot, commit, payload, notesRef)
+  return payload
+}
+
+export const checkPerfAgainstBaseline = (
+  repositoryRoot: string,
+  {
+    baselineCommit,
+    env,
+    head = 'HEAD',
+    notesRef = PERF_NOTES_REF,
+    perfCommand = PERF_COMMAND,
+    perfOutput,
+    targetRef = PERF_TARGET_REF,
+  }: {
+    baselineCommit?: string
+    env?: NodeJS.ProcessEnv
+    head?: string
+    notesRef?: string
+    perfCommand?: string
+    perfOutput?: string
+    targetRef?: string
+  } = {}
+): CheckPerfAgainstBaselineResult => {
+  const candidateNote = parsePerfOutput(
+    perfOutput ?? resolvePnpmPerfOutput(repositoryRoot, env, perfCommand)
+  )
+  const baseline = findNearestBaselineNote(repositoryRoot, {
+    baselineCommit,
+    head,
+    notesRef,
+    targetRef,
+  })
+
+  if (baseline.note === null) {
+    return {
+      baselineCommit: null,
+      baselineNote: null,
+      candidateNote,
+      comparison: {
+        errors: [],
+        regressions: [],
+        skipped: [],
+      },
+      mergeBase: baseline.mergeBase,
+      status: 'missing-baseline',
+    }
+  }
+
+  const comparison = comparePerfNotes(baseline.note, candidateNote)
+
+  return {
+    baselineCommit: baseline.baselineCommit,
+    baselineNote: baseline.note,
+    candidateNote,
+    comparison,
+    mergeBase: baseline.mergeBase,
+    status: comparison.errors.length > 0 || comparison.regressions.length > 0 ? 'failed' : 'passed',
+  }
+}
+
+const formatMetricList = (items: Array<{ metric: string; scenario: string }>): string =>
+  items.map(({ metric, scenario }) => `- ${scenario}.${metric}`).join('\n')
+
+const formatRegressions = (regressions: PerfRegression[]): string =>
+  regressions
+    .map(
+      ({ baseline, candidate, metric, scenario }) =>
+        `- ${scenario}.${metric}: candidate=${candidate} baseline=${baseline}`
+    )
+    .join('\n')
+
+export const runPerfNotesCli = (
+  argv: string[],
+  {
+    repositoryRoot = process.cwd(),
+    env = process.env,
+    stderr = process.stderr,
+    stdout = process.stdout,
+  }: {
+    repositoryRoot?: string
+    env?: NodeJS.ProcessEnv
+    stderr?: NodeJS.WriteStream
+    stdout?: NodeJS.WriteStream
+  } = {}
+): number => {
+  const [subcommand] = argv
+  const baselineCommit = env.PERF_BASELINE_COMMIT
+  const notesRef = env.PERF_NOTES_REF ?? PERF_NOTES_REF
+  const perfCommand = env.PERF_COMMAND ?? PERF_COMMAND
+  const targetRef = env.PERF_TARGET_REF ?? PERF_TARGET_REF
+
+  if (subcommand === 'record') {
+    const payload = recordPerfNote(repositoryRoot, {
+      commit: 'HEAD',
+      env,
+      notesRef,
+      perfCommand,
+    })
+    const headCommit = runGit(repositoryRoot, ['rev-parse', '--short', 'HEAD']).stdout.trim()
+
+    stdout.write(
+      `Recorded perf note for ${headCommit} in ${notesRef} with ${Object.keys(payload.metrics).length} scenarios.\n`
+    )
+    return 0
+  }
+
+  if (subcommand === 'check') {
+    const result = checkPerfAgainstBaseline(repositoryRoot, {
+      baselineCommit,
+      env,
+      head: 'HEAD',
+      notesRef,
+      perfCommand,
+      targetRef,
+    })
+
+    if (result.status === 'missing-baseline') {
+      stdout.write(
+        `No perf baseline note found from ${result.mergeBase} back on ${targetRef}; skipping regression check.\n`
+      )
+      return 0
+    }
+
+    if (result.comparison.errors.length > 0) {
+      stderr.write(
+        `Perf check could not compare required candidate metrics:\n${formatMetricList(result.comparison.errors)}\n`
+      )
+      return 1
+    }
+
+    if (result.comparison.regressions.length > 0) {
+      stderr.write(
+        `Perf regressions detected against ${result.baselineCommit}:\n${formatRegressions(result.comparison.regressions)}\n`
+      )
+      if (result.comparison.skipped.length > 0) {
+        stderr.write(`Skipped baseline metrics:\n${formatMetricList(result.comparison.skipped)}\n`)
+      }
+      return 1
+    }
+
+    stdout.write(`Perf check passed against ${result.baselineCommit}.\n`)
+    if (result.comparison.skipped.length > 0) {
+      stdout.write(`Skipped baseline metrics:\n${formatMetricList(result.comparison.skipped)}\n`)
+    }
+    return 0
+  }
+
+  stderr.write('Usage: node scripts/perf-notes.mjs <record|check>\n')
+  return 1
+}

--- a/src/utils/applyChangeToValue.spec.ts
+++ b/src/utils/applyChangeToValue.spec.ts
@@ -70,6 +70,25 @@ describe('#applyChangeToValue', () => {
     )
   })
 
+  it('recovers full IME hint insertions when the caret stays inside the inserted text', () => {
+    const changed = "Hi John Doe, \n\nlet's M[mid]add joe@smoe.com to this conversation..."
+
+    const result = applyChangeToValue(
+      value,
+      changed,
+      {
+        selectionStartBefore: 21,
+        selectionEndBefore: 21,
+        selectionEndAfter: 22,
+      },
+      config
+    )
+
+    expect(result).toEqual(
+      "Hi @[John Doe](user:johndoe), \n\nlet's M[mid]add @[joe@smoe.com](email:joe@smoe.com) to this conversation..."
+    )
+  })
+
   it('should correctly delete single characters and ranges of selected text', () => {
     // delete "i"
     let changed = "H John Doe, \n\nlet's add joe@smoe.com to this conversation..."
@@ -132,6 +151,23 @@ describe('#applyChangeToValue', () => {
       config
     )
     expect(result).toEqual(value.replace('add', 'remove'))
+  })
+
+  it('recovers replacement text when selectionEndAfter reflects the caret instead of the full replacement', () => {
+    const changed = plainText.replace('add', 'remove[remove]')
+
+    const result = applyChangeToValue(
+      value,
+      changed,
+      {
+        selectionStartBefore: plainText.indexOf('add'),
+        selectionEndBefore: plainText.indexOf('add') + 'add'.length,
+        selectionEndAfter: plainText.indexOf('add') + 'remove'.length,
+      },
+      config
+    )
+
+    expect(result).toEqual(value.replace('add', 'remove[remove]'))
   })
 
   it('should remove mentions markup contained in deleted text ranges', () => {
@@ -287,7 +323,7 @@ describe('#applyChangeToValue', () => {
   })
 
   it('should correctly handle text auto-correction', () => {
-    const result = applyChangeToValue(
+    let result = applyChangeToValue(
       'ill',
       "I'll",
       {
@@ -298,6 +334,73 @@ describe('#applyChangeToValue', () => {
       config
     )
     expect(result).toEqual("I'll")
+
+    result = applyChangeToValue(
+      "s'a[sa'a]",
+      'sad[sad]',
+      {
+        selectionStartBefore: 2,
+        selectionEndBefore: 2,
+        selectionEndAfter: 3,
+      },
+      config
+    )
+    expect(result).toEqual('sad[sad]')
+  })
+
+  it('preserves decomposed dead-key input during mismatch recovery', () => {
+    const baseValue = 'Cafe'
+    const changed = 'Cafe\u0301[dead]'
+
+    const result = applyChangeToValue(
+      baseValue,
+      changed,
+      {
+        selectionStartBefore: baseValue.length,
+        selectionEndBefore: baseValue.length,
+        selectionEndAfter: 'Cafe\u0301'.length,
+      },
+      config
+    )
+
+    expect(result).toEqual(changed)
+  })
+
+  it('preserves composed accented characters during mismatch recovery', () => {
+    const baseValue = 'Caf'
+    const changed = 'Café[end]'
+
+    const result = applyChangeToValue(
+      baseValue,
+      changed,
+      {
+        selectionStartBefore: baseValue.length,
+        selectionEndBefore: baseValue.length,
+        selectionEndAfter: 'Café'.length,
+      },
+      config
+    )
+
+    expect(result).toEqual(changed)
+  })
+
+  it('preserves mention markup when dead-key recovery appends text next to a mention', () => {
+    const valueWithMention = 'Hi @[John Doe](user:johndoe) cafe'
+    const changed = 'Hi John Doe cafe\u0301[dead]'
+    const caretPosition = 'Hi John Doe cafe\u0301'.length
+
+    const result = applyChangeToValue(
+      valueWithMention,
+      changed,
+      {
+        selectionStartBefore: 'Hi John Doe cafe'.length,
+        selectionEndBefore: 'Hi John Doe cafe'.length,
+        selectionEndAfter: caretPosition,
+      },
+      config
+    )
+
+    expect(result).toEqual('Hi @[John Doe](user:johndoe) cafe\u0301[dead]')
   })
 
   it('re-runs splice logic when the reconstructed plain text differs from the target plain text', () => {

--- a/src/utils/applyChangeToValue.ts
+++ b/src/utils/applyChangeToValue.ts
@@ -100,17 +100,30 @@ const applyChangeToValue = <Extra extends Record<string, unknown> = Record<strin
 
       // find start of diff
       spliceStart = 0
-      while (plainTextValue[spliceStart] === controlPlainTextValue[spliceStart]) {
+      while (
+        spliceStart < plainTextValue.length &&
+        spliceStart < oldPlainTextValue.length &&
+        plainTextValue[spliceStart] === oldPlainTextValue[spliceStart]
+      ) {
         spliceStart++
       }
 
+      let spliceEndOfNew = plainTextValue.length
+      let spliceEndOfOld = oldPlainTextValue.length
+      while (
+        spliceEndOfNew > spliceStart &&
+        spliceEndOfOld > spliceStart &&
+        plainTextValue[spliceEndOfNew - 1] === oldPlainTextValue[spliceEndOfOld - 1]
+      ) {
+        spliceEndOfNew--
+        spliceEndOfOld--
+      }
+
       // extract auto-corrected insertion
-      insert = plainTextValue.slice(spliceStart, selectionEndAfter)
+      insert = plainTextValue.slice(spliceStart, spliceEndOfNew)
 
       // find index of the unchanged remainder
-      spliceEnd = oldPlainTextValue.lastIndexOf(
-        plainTextValue.slice(Math.max(0, selectionEndAfter))
-      )
+      spliceEnd = spliceEndOfOld >= spliceStart ? spliceEndOfOld : selectionEndAfter
 
       // re-map the corrected indices
       mappedSpliceStart = ensureNumber(

--- a/src/utils/readConfigFromChildren.spec.tsx
+++ b/src/utils/readConfigFromChildren.spec.tsx
@@ -98,17 +98,17 @@ describe('readConfigFromChildren', () => {
 
       const config = readConfigFromChildren(children)
 
-      expect(config[0].serializer.id).toBe('@[__display__](__id__|0)')
-      expect(config[1].serializer.id).toBe('@[__display__](__id__|1)')
+      expect(config[0].serializer.id).toBe('@[__display__](__id__)|0')
+      expect(config[1].serializer.id).toBe('@[__display__](__id__)|1')
       expect(config[0].serializer.insert({ id: 'first', display: 'First' })).toBe(
-        '@[First](first|0)'
+        '@[First](first)|0'
       )
       expect(config[1].serializer.insert({ id: 'second', display: 'Second' })).toBe(
-        '@[Second](second|1)'
+        '@[Second](second)|1'
       )
     })
 
-    it('should parse duplicate-trigger markup with the correct serializer', () => {
+    it('should parse duplicate-trigger markup with the correct serializer when ids contain pipes', () => {
       const children = [
         <Mention key="1" trigger="@" displayTransform={(id) => `user:${id}`} data={[]} />,
         <Mention key="2" trigger="@" displayTransform={(id) => `team:${id}`} data={[]} />,
@@ -116,11 +116,11 @@ describe('readConfigFromChildren', () => {
 
       const config = readConfigFromChildren(children)
       const value = [
-        config[0].serializer.insert({ id: 'alice', display: 'Alice' }),
-        config[1].serializer.insert({ id: 'eng', display: 'Engineering' }),
+        config[0].serializer.insert({ id: 'alice|ops', display: 'Alice' }),
+        config[1].serializer.insert({ id: 'eng|platform', display: 'Engineering' }),
       ].join(' ')
 
-      expect(getPlainText(value, config)).toBe('user:alice team:eng')
+      expect(getPlainText(value, config)).toBe('user:alice|ops team:eng|platform')
     })
 
     it('should maintain existing behavior when custom markup is provided', () => {

--- a/src/utils/readConfigFromChildren.ts
+++ b/src/utils/readConfigFromChildren.ts
@@ -28,7 +28,7 @@ const generateMarkupForTrigger = (trigger: string | RegExp | undefined): string 
 }
 
 const appendSerializerMarker = (markup: string, occurrenceIndex: number): string => {
-  return markup.replace(PLACEHOLDERS.id, `${PLACEHOLDERS.id}|${occurrenceIndex.toString()}`)
+  return `${markup}|${occurrenceIndex.toString()}`
 }
 
 const isReactFragment = (child: unknown): child is ReactElement<{ children?: ReactNode }> =>
@@ -93,6 +93,7 @@ const readConfigFromChildren = <Extra extends Record<string, unknown> = Record<s
     return {
       ...DEFAULT_MENTION_PROPS,
       ...props,
+      trigger,
       displayTransform,
       serializer,
     } satisfies MentionChildConfig<Extra>


### PR DESCRIPTION
In applyChangeToValue.ts (line 95)  replacied the fallback mismatch recovery with a bounded diff against the old plain text from both ends Also guards globalThis.crypto, uses a collision-safe removed-mention diff key, invalidates cached snapshots when displayTransform changes, normalizes default trigger identity, moves duplicate-trigger serializer markers outside the ID capture, rejects regex matches with missing capture groups, and null-guards object refs Added perf tracking via git notes

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Linux IME and dead-key input handling in `applyChangeToValue`
> - Reworks the mismatch-recovery branch in [`applyChangeToValue`](https://github.com/hbmartin/react-mentions-ts/pull/184/files#diff-952c56fd7dbc96779d7ad03bda38ea5ee8301c7ea8cc76d3f4b9264b4bc1f1fe) to correctly compute splice boundaries via head/tail comparison, fixing IME composition and dead-key (accent) inputs on Linux.
> - Fixes diff key collisions in `getMentionDiffKey` when mention `id` or `display` values contain `:` by switching to `JSON.stringify`.
> - Fixes `areMentionConfigsEqual` to include `displayTransform` in equality checks, and normalises omitted `trigger` to the default `@` trigger in config identity.
> - Fixes `appendSerializerMarker` to append `|index` to the full markup string rather than injecting into `__id__`, avoiding conflicts when ids contain `|`.
> - Behavioral Change: mismatch recovery now inserts the full differing segment rather than slicing to `selectionEndAfter`, which changes behavior for replacements where the caret does not reach the end of the replacement.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 2873bc5. 7 files reviewed, 2 issues evaluated, 1 issue filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>src/utils/readConfigFromChildren.ts — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 31](https://github.com/hbmartin/react-mentions-ts/blob/2873bc5358b0e1deada2d46df21a60ce30944be3/src/utils/readConfigFromChildren.ts#L31): The change to `appendSerializerMarker` places the occurrence marker outside the markup structure instead of inside the `__id__` placeholder. The old code `markup.replace(PLACEHOLDERS.id, `${PLACEHOLDERS.id}|${occurrenceIndex.toString()}`)` would produce markup like `@[__display__](__id__|0)`, embedding the marker in the ID. The new code produces `@[__display__](__id__)|0`, placing `|0` as literal text after the closing parenthesis. This breaks mention serialization because: (1) when `createMarkupSerializer` generates a regex from this markup, it will expect to find `|0` literally in the text, and (2) when inserting mentions, `makeMentionsMarkup` will include `|0` outside the mention structure. Multiple Mention components with the same trigger will have broken parsing and serialization. <b>[ Out of scope (triage) ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added performance tracking system with Git notes integration and new performance testing commands (`pnpm perf:check`, `pnpm perf:record`)

* **Bug Fixes**
  * Fixed crypto API fallback for ID generation
  * Improved mention tracking and diff comparison logic
  * Enhanced regex trigger matching with proper type validation
  * Fixed IME composition and dead-key input recovery

* **Documentation**
  * Added performance testing guidelines and architectural best-practices to contributing documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->