### PR TITLE
Linux IME fixes followups and raising test coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,8 +294,6 @@ Pass the result as the `markup` prop on `Mention`:
 For cases where `createMarkupSerializer` is not flexible enough, you can implement the `MentionSerializer` interface directly:
 
 ```ts
-import type { MentionSerializer } from 'react-mentions-ts'
-
 interface MentionSerializer {
   id: string
   insert: (input: { id: string | number; display: string }) => string

--- a/src/Highlighter.spec.tsx
+++ b/src/Highlighter.spec.tsx
@@ -295,22 +295,26 @@ describe('Highlighter', () => {
   it('measures immediately when requestAnimationFrame is unavailable', async () => {
     const onCaretPositionChange = vi.fn()
     const originalRAF = globalThis.requestAnimationFrame
-    const offsetLeftDescriptor = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'offsetLeft')
+    const offsetLeftDescriptor = Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      'offsetLeft'
+    )
     const offsetTopDescriptor = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'offsetTop')
 
     Object.defineProperty(HTMLElement.prototype, 'offsetLeft', {
       configurable: true,
       get() {
-        return this instanceof HTMLSpanElement && this.hasAttribute('data-mentions-caret') ? 5 : 0
+        return this instanceof HTMLSpanElement && this.dataset.mentionsCaret !== undefined ? 5 : 0
       },
     })
     Object.defineProperty(HTMLElement.prototype, 'offsetTop', {
       configurable: true,
       get() {
-        return this instanceof HTMLSpanElement && this.hasAttribute('data-mentions-caret') ? 9 : 0
+        return this instanceof HTMLSpanElement && this.dataset.mentionsCaret !== undefined ? 9 : 0
       },
     })
-    delete (globalThis as typeof globalThis & { requestAnimationFrame?: unknown }).requestAnimationFrame
+    delete (globalThis as typeof globalThis & { requestAnimationFrame?: unknown })
+      .requestAnimationFrame
 
     try {
       render(
@@ -358,7 +362,7 @@ describe('Highlighter', () => {
       </Highlighter>
     )
 
-    const renderedMentions = Array.from(container.querySelectorAll('span')).filter(
+    const renderedMentions = [...container.querySelectorAll('span')].filter(
       (element) => element.textContent === 'John'
     )
     expect(renderedMentions).toHaveLength(2)

--- a/src/MeasurementBridge.spec.tsx
+++ b/src/MeasurementBridge.spec.tsx
@@ -120,4 +120,81 @@ describe('MeasurementBridge', () => {
         originalResizeObserver
     }
   })
+
+  it('skips optional element observers when ResizeObserver is unavailable', () => {
+    const requestViewSync = vi.fn()
+    const originalResizeObserver = (globalThis as typeof globalThis & { ResizeObserver?: unknown })
+      .ResizeObserver
+
+    ;(globalThis as typeof globalThis & { ResizeObserver?: unknown }).ResizeObserver = undefined
+
+    try {
+      render(
+        <MeasurementBridge
+          container={document.createElement('div')}
+          highlighter={document.createElement('div')}
+          input={null}
+          suggestions={document.createElement('div')}
+          requestViewSync={requestViewSync}
+        />
+      )
+
+      expect(requestViewSync).toHaveBeenCalledTimes(1)
+      expect(requestViewSync).toHaveBeenCalledWith({
+        syncScroll: true,
+        measureSuggestions: true,
+        measureInline: true,
+      })
+    } finally {
+      ;(globalThis as typeof globalThis & { ResizeObserver?: unknown }).ResizeObserver =
+        originalResizeObserver
+    }
+  })
+
+  it('skips viewport listener registration when window lookup is unavailable', () => {
+    const requestViewSync = vi.fn()
+    const container = document.createElement('div')
+    const highlighter = document.createElement('div')
+    const suggestions = document.createElement('div')
+    const addListener = vi.spyOn(globalThis, 'addEventListener')
+    const originalReflectGet = Reflect.get
+    const reflectGetSpy = vi
+      .spyOn(Reflect, 'get')
+      .mockImplementation((target: object, propertyKey: PropertyKey, receiver?: unknown) => {
+        if (target === globalThis && propertyKey === 'window') {
+          return undefined
+        }
+
+        if (target == null) {
+          return undefined
+        }
+
+        return receiver === undefined
+          ? originalReflectGet(target, propertyKey)
+          : originalReflectGet(target, propertyKey, receiver)
+      })
+
+    try {
+      render(
+        <MeasurementBridge
+          container={container}
+          highlighter={highlighter}
+          input={null}
+          suggestions={suggestions}
+          requestViewSync={requestViewSync}
+        />
+      )
+
+      expect(requestViewSync).toHaveBeenCalledWith({
+        syncScroll: true,
+        measureSuggestions: true,
+        measureInline: true,
+      })
+      expect(addListener).not.toHaveBeenCalledWith('resize', expect.any(Function))
+      expect(addListener).not.toHaveBeenCalledWith('orientationchange', expect.any(Function))
+    } finally {
+      addListener.mockRestore()
+      reflectGetSpy.mockRestore()
+    }
+  })
 })

--- a/src/MentionsInput.spec.tsx
+++ b/src/MentionsInput.spec.tsx
@@ -1736,7 +1736,7 @@ describe('MentionsInput', () => {
       )
 
       const instance = ref.current as unknown as any
-      const textarea = screen.getByRole('combobox') as HTMLTextAreaElement
+      const textarea = screen.getByRole<HTMLTextAreaElement>('combobox')
       let scrollHeight = 24
       Object.defineProperty(textarea, 'scrollHeight', {
         configurable: true,
@@ -1768,7 +1768,9 @@ describe('MentionsInput', () => {
         scrollHeight = 60
 
         act(() => {
-          callbacks.splice(0).forEach((callback) => callback(0))
+          for (const callback of callbacks.splice(0)) {
+            callback(0)
+          }
         })
 
         expect(instance._autoResizeFrame).toBeNull()
@@ -3757,7 +3759,7 @@ describe('MentionsInput', () => {
       )
 
       const instance = ref.current as unknown as any
-      const textarea = screen.getByRole('combobox') as HTMLTextAreaElement
+      const textarea = screen.getByRole<HTMLTextAreaElement>('combobox')
       const updateMentionsQueriesSpy = vi
         .spyOn(instance, 'updateMentionsQueries')
         .mockImplementation(() => undefined)
@@ -3885,7 +3887,11 @@ describe('MentionsInput', () => {
       const ref = React.createRef<MentionsInput>()
       const { unmount } = render(
         <MentionsInput ref={ref} value="@a">
-          <Mention trigger="@" data={async () => [{ id: 'alpha', display: 'Alpha' }]} debounceMs={5} />
+          <Mention
+            trigger="@"
+            data={async () => [{ id: 'alpha', display: 'Alpha' }]}
+            debounceMs={5}
+          />
         </MentionsInput>
       )
 
@@ -3927,6 +3933,7 @@ describe('MentionsInput', () => {
           await vi.advanceTimersByTimeAsync(5)
         })
 
+        // eslint-disable-next-line require-atomic-updates -- this test intentionally makes the pending async result stale.
         instance._queryId = 2
 
         await act(async () => {

--- a/src/MentionsInputChildren.spec.tsx
+++ b/src/MentionsInputChildren.spec.tsx
@@ -5,6 +5,7 @@ import {
   prepareMentionsInputChildren,
   validateMentionChildTree,
 } from './MentionsInputChildren'
+import createMarkupSerializer from './utils/createMarkupSerializer'
 
 describe('MentionsInputChildren', () => {
   it('prepares mention children and config from fragments once the tree is validated', () => {
@@ -198,5 +199,29 @@ describe('MentionsInputChildren', () => {
     ).config
 
     expect(areMentionConfigsEqual(globalConfig, nonGlobalConfig)).toBe(true)
+  })
+
+  it('treats raw undefined triggers as the default trigger identity', () => {
+    const serializer = createMarkupSerializer('@[__display__](__id__)')
+    const displayTransform = (id: string | number, display: string | null) => display ?? String(id)
+
+    expect(
+      areMentionConfigsEqual(
+        [
+          {
+            trigger: undefined,
+            serializer,
+            displayTransform,
+          } as never,
+        ],
+        [
+          {
+            trigger: '@',
+            serializer,
+            displayTransform,
+          } as never,
+        ]
+      )
+    ).toBe(true)
   })
 })

--- a/src/MentionsInputLayout.spec.ts
+++ b/src/MentionsInputLayout.spec.ts
@@ -229,6 +229,80 @@ describe('MentionsInputLayout', () => {
     }
   })
 
+  it('supports explicit above placement in a portal and prefers window dimensions when larger', () => {
+    const highlighter = document.createElement('div')
+    const suggestions = document.createElement('div')
+    const container = document.createElement('div')
+    const originalInnerHeight = globalThis.innerHeight
+    const originalInnerWidth = globalThis.innerWidth
+    const originalClientHeight = document.documentElement.clientHeight
+    const originalClientWidth = document.documentElement.clientWidth
+
+    highlighter.style.fontSize = '16px'
+    suggestions.style.marginLeft = '0px'
+    suggestions.style.marginTop = '0px'
+
+    Object.defineProperty(globalThis, 'innerHeight', { value: 220, configurable: true })
+    Object.defineProperty(globalThis, 'innerWidth', { value: 260, configurable: true })
+    Object.defineProperty(document.documentElement, 'clientHeight', {
+      value: 120,
+      configurable: true,
+    })
+    Object.defineProperty(document.documentElement, 'clientWidth', {
+      value: 140,
+      configurable: true,
+    })
+    Object.defineProperty(highlighter, 'getBoundingClientRect', {
+      value: () => ({
+        left: 30,
+        top: 80,
+        right: 0,
+        bottom: 0,
+        width: 0,
+        height: 0,
+      }),
+    })
+    Object.defineProperty(highlighter, 'offsetWidth', { value: 200, configurable: true })
+    Object.defineProperty(suggestions, 'offsetHeight', { value: 40, configurable: true })
+    Object.defineProperty(container, 'offsetWidth', { value: 220, configurable: true })
+
+    try {
+      const position = calculateSuggestionsPosition({
+        caretPosition: { left: 24, top: 30 },
+        suggestionsPlacement: 'above',
+        anchorMode: 'left',
+        resolvedPortalHost: document.body,
+        suggestions,
+        highlighter,
+        container,
+      })
+
+      expect(position).toEqual({
+        left: 30,
+        position: 'fixed',
+        top: 54,
+        width: 200,
+      })
+    } finally {
+      Object.defineProperty(globalThis, 'innerHeight', {
+        value: originalInnerHeight,
+        configurable: true,
+      })
+      Object.defineProperty(globalThis, 'innerWidth', {
+        value: originalInnerWidth,
+        configurable: true,
+      })
+      Object.defineProperty(document.documentElement, 'clientHeight', {
+        value: originalClientHeight,
+        configurable: true,
+      })
+      Object.defineProperty(document.documentElement, 'clientWidth', {
+        value: originalClientWidth,
+        configurable: true,
+      })
+    }
+  })
+
   it('calculates inline suggestion offsets from the caret marker', () => {
     const control = document.createElement('div')
     const highlighter = document.createElement('div')
@@ -379,6 +453,35 @@ describe('MentionsInputLayout', () => {
     expect(getComputedStyleLengthProp(detachedElement, 'font-size')).toBe(0)
   })
 
+  it('falls back to the global computed-style API when a detached document has no view', () => {
+    const detachedDocument = document.implementation.createHTMLDocument('detached')
+    const detachedElement = detachedDocument.createElement('div')
+    const originalGetComputedStyle = globalThis.getComputedStyle
+
+    Object.defineProperty(detachedDocument, 'defaultView', {
+      configurable: true,
+      value: null,
+    })
+    Object.defineProperty(globalThis, 'getComputedStyle', {
+      configurable: true,
+      writable: true,
+      value: () =>
+        ({
+          getPropertyValue: () => '18px',
+        }) as CSSStyleDeclaration,
+    })
+
+    try {
+      expect(getComputedStyleLengthProp(detachedElement, 'font-size')).toBe(18)
+    } finally {
+      Object.defineProperty(globalThis, 'getComputedStyle', {
+        configurable: true,
+        writable: true,
+        value: originalGetComputedStyle,
+      })
+    }
+  })
+
   it('returns zero for non-finite computed style lengths', () => {
     const element = document.createElement('div')
     const originalGetComputedStyle = globalThis.getComputedStyle
@@ -453,6 +556,105 @@ describe('MentionsInputLayout', () => {
       height: '',
       overflowY: '',
     })
+  })
+
+  it('returns the empty textarea resize patch for single-line inputs and ignores blank border widths', () => {
+    const textarea = document.createElement('textarea')
+    const originalGetComputedStyle = globalThis.getComputedStyle
+
+    Object.defineProperty(textarea, 'scrollHeight', { value: 30, configurable: true })
+    Object.defineProperty(globalThis, 'getComputedStyle', {
+      configurable: true,
+      writable: true,
+      value: () =>
+        ({
+          borderTopWidth: '',
+          borderBottomWidth: undefined,
+        }) as unknown as CSSStyleDeclaration,
+    })
+
+    try {
+      expect(
+        getTextareaResizePatch(textarea, {
+          autoResize: true,
+          singleLine: true,
+        })
+      ).toEqual({
+        height: '',
+        overflowY: '',
+      })
+
+      expect(
+        getTextareaResizePatch(textarea, {
+          autoResize: true,
+          singleLine: false,
+        })
+      ).toEqual({
+        height: '30px',
+        overflowY: 'hidden',
+      })
+    } finally {
+      Object.defineProperty(globalThis, 'getComputedStyle', {
+        configurable: true,
+        writable: true,
+        value: originalGetComputedStyle,
+      })
+    }
+  })
+
+  it('adds numeric border widths and treats invalid border widths as zero during auto-resize', () => {
+    const textarea = document.createElement('textarea')
+    const originalGetComputedStyle = globalThis.getComputedStyle
+
+    Object.defineProperty(textarea, 'scrollHeight', { value: 30, configurable: true })
+
+    try {
+      Object.defineProperty(globalThis, 'getComputedStyle', {
+        configurable: true,
+        writable: true,
+        value: () =>
+          ({
+            borderTopWidth: '1px',
+            borderBottomWidth: '2px',
+          }) as unknown as CSSStyleDeclaration,
+      })
+
+      expect(
+        getTextareaResizePatch(textarea, {
+          autoResize: true,
+          singleLine: false,
+        })
+      ).toEqual({
+        height: '33px',
+        overflowY: 'hidden',
+      })
+
+      Object.defineProperty(globalThis, 'getComputedStyle', {
+        configurable: true,
+        writable: true,
+        value: () =>
+          ({
+            borderTopWidth: null,
+            borderBottomWidth: 'not-a-number',
+          }) as unknown as CSSStyleDeclaration,
+      })
+
+      expect(
+        getTextareaResizePatch(textarea, {
+          autoResize: true,
+          singleLine: false,
+        })
+      ).toEqual({
+        height: '30px',
+        overflowY: 'hidden',
+      })
+    } finally {
+      Object.defineProperty(globalThis, 'getComputedStyle', {
+        configurable: true,
+        writable: true,
+        value: originalGetComputedStyle,
+      })
+    }
   })
 
   it('returns a null inline position when the caret marker or control is missing', () => {

--- a/src/MentionsInputQueryState.spec.ts
+++ b/src/MentionsInputQueryState.spec.ts
@@ -3,6 +3,7 @@ import {
   applySuccessfulQueryResult,
   createClearedSuggestionsState,
   createLoadingQueryState,
+  isAbortError,
 } from './MentionsInputQueryState'
 
 const queryInfo = {
@@ -98,5 +99,11 @@ describe('MentionsInputQueryState', () => {
     expect(nextState.suggestions[1]).toBeUndefined()
     expect(nextState.focusIndex).toBe(1)
     expect(nextState.queryStates[1]?.status).toBe('error')
+  })
+
+  it('recognizes abort errors from DOMException instances and plain objects', () => {
+    expect(isAbortError(new DOMException('cancelled', 'AbortError'))).toBe(true)
+    expect(isAbortError({ name: 'AbortError' })).toBe(true)
+    expect(isAbortError(new Error('boom'))).toBe(false)
   })
 })

--- a/src/MentionsInputSelection.spec.tsx
+++ b/src/MentionsInputSelection.spec.tsx
@@ -48,6 +48,42 @@ describe('MentionsInputSelection', () => {
     ).toBe(false)
   })
 
+  it('compares mention snapshots across id, child, plain-text, and display fields', () => {
+    expect(areMentionOccurrencesEqual(mentions, [{ ...mentions[0] }])).toBe(true)
+    expect(
+      areMentionOccurrencesEqual(mentions, [
+        {
+          ...mentions[0],
+          id: 'heisenberg',
+        },
+      ])
+    ).toBe(false)
+    expect(
+      areMentionOccurrencesEqual(mentions, [
+        {
+          ...mentions[0],
+          childIndex: 1,
+        },
+      ])
+    ).toBe(false)
+    expect(
+      areMentionOccurrencesEqual(mentions, [
+        {
+          ...mentions[0],
+          plainTextIndex: 7,
+        },
+      ])
+    ).toBe(false)
+    expect(
+      areMentionOccurrencesEqual(mentions, [
+        {
+          ...mentions[0],
+          display: 'Heisenberg',
+        },
+      ])
+    ).toBe(false)
+  })
+
   it('treats length changes as mention snapshot changes', () => {
     expect(areMentionOccurrencesEqual(mentions, [])).toBe(false)
   })

--- a/src/MentionsInputSelectors.spec.tsx
+++ b/src/MentionsInputSelectors.spec.tsx
@@ -58,9 +58,7 @@ describe('MentionsInputSelectors', () => {
     const children = (
       <>
         {mentionChildren[0]}
-        <>
-          {mentionChildren[1]}
-        </>
+        <>{mentionChildren[1]}</>
       </>
     )
 
@@ -104,9 +102,14 @@ describe('MentionsInputSelectors', () => {
       queryInfo: suggestions[0].queryInfo,
       result: suggestions[0].results[0],
     })
+    expect(getFocusedSuggestionEntryForMentionChildren(mentionChildren, suggestions, 99)).toEqual({
+      queryInfo: suggestions[0].queryInfo,
+      result: suggestions[0].results[0],
+    })
     expect(getFocusedSuggestionEntry(<>{mentionChildren}</>, {}, 0)).toBeNull()
     expect(getFocusedSuggestionEntryForMentionChildren(mentionChildren, {}, 0)).toBeNull()
     expect(getFlattenedSuggestions(<>{mentionChildren}</>, suggestions)).toHaveLength(1)
+    expect(getPreferredQueryState({} as never)).toBeNull()
   })
 
   it('computes inline suggestion remainders and details', () => {
@@ -154,7 +157,13 @@ describe('MentionsInputSelectors', () => {
     expect(
       getInlineSuggestionDetailsForMentionChildren(
         [
-          <Mention key="blank" trigger="@" data={[]} displayTransform={() => ''} appendSpaceOnAdd />,
+          <Mention
+            key="blank"
+            trigger="@"
+            data={[]}
+            displayTransform={() => ''}
+            appendSpaceOnAdd
+          />,
         ],
         {
           0: {
@@ -184,11 +193,7 @@ describe('MentionsInputSelectors', () => {
     expect(
       getInlineSuggestionDetails(
         <>
-          <Mention
-            trigger="@"
-            data={[]}
-            displayTransform={() => 'Al'}
-          />
+          <Mention trigger="@" data={[]} displayTransform={() => 'Al'} />
         </>,
         {
           0: {
@@ -201,12 +206,12 @@ describe('MentionsInputSelectors', () => {
     ).toBeNull()
   })
 
-  it('resolves status content for empty and error states', () => {
+  it('resolves status content for empty states', () => {
     const children = (
       <>
         <Mention trigger="@" data={[]} />
-        <Mention trigger="#" data={[]} renderEmpty={() => undefined} renderError={() => undefined} />
-        <Mention trigger="$" data={[]} renderEmpty={() => false} renderError={() => null} />
+        <Mention trigger="#" data={[]} renderEmpty={() => undefined} />
+        <Mention trigger="$" data={[]} renderEmpty={() => false} />
       </>
     )
     const resolvedChildren = getMentionChildren(children)
@@ -232,120 +237,141 @@ describe('MentionsInputSelectors', () => {
     })
 
     expect(
-      getSuggestionsStatusContentForMentionChildren(
-        resolvedChildren,
-        {},
-        {
-          0: { status: 'success', results: [], queryInfo: suggestions[0].queryInfo },
-        } as never
-      )
+      getSuggestionsStatusContentForMentionChildren(resolvedChildren, {}, {
+        0: { status: 'success', results: [], queryInfo: suggestions[0].queryInfo },
+      } as never)
     ).toEqual({
       statusContent: DEFAULT_EMPTY_SUGGESTIONS_MESSAGE,
       statusType: 'empty',
     })
 
     expect(
-      getSuggestionsStatusContentForMentionChildren(
-        resolvedChildren,
-        {},
-        {
-          1: {
-            status: 'success',
-            results: [],
-            queryInfo: { ...suggestions[0].queryInfo, childIndex: 1 },
-          },
-        } as never
-      )
+      getSuggestionsStatusContentForMentionChildren(resolvedChildren, {}, {
+        1: {
+          status: 'success',
+          results: [],
+          queryInfo: { ...suggestions[0].queryInfo, childIndex: 1 },
+        },
+      } as never)
     ).toEqual({
       statusContent: DEFAULT_EMPTY_SUGGESTIONS_MESSAGE,
       statusType: 'empty',
     })
 
     expect(
-      getSuggestionsStatusContentForMentionChildren(
-        resolvedChildren,
-        {},
-        {
-          2: {
-            status: 'success',
-            results: [],
-            queryInfo: { ...suggestions[0].queryInfo, childIndex: 2 },
-          },
-        } as never
-      )
+      getSuggestionsStatusContentForMentionChildren(resolvedChildren, {}, {
+        2: {
+          status: 'success',
+          results: [],
+          queryInfo: { ...suggestions[0].queryInfo, childIndex: 2 },
+        },
+      } as never)
     ).toEqual({
       statusContent: null,
       statusType: null,
     })
+  })
+
+  it('resolves status content for error states', () => {
+    const children = (
+      <>
+        <Mention trigger="@" data={[]} />
+        <Mention trigger="#" data={[]} renderError={() => undefined} />
+        <Mention trigger="$" data={[]} renderError={() => 'Broken'} />
+        <Mention trigger="%" data={[]} renderError={() => null} />
+      </>
+    )
+    const resolvedChildren = getMentionChildren(children)
 
     expect(
-      getSuggestionsStatusContentForMentionChildren(
-        resolvedChildren,
-        {},
-        {
-          1: {
-            status: 'error',
-            error: new Error('boom'),
-            results: [],
-            queryInfo: { ...suggestions[0].queryInfo, childIndex: 1 },
-          },
-        } as never
-      )
+      getSuggestionsStatusContentForMentionChildren(resolvedChildren, {}, {
+        1: {
+          status: 'error',
+          error: new Error('boom'),
+          results: [],
+          queryInfo: { ...suggestions[0].queryInfo, childIndex: 1 },
+        },
+      } as never)
     ).toEqual({
       statusContent: DEFAULT_ERROR_SUGGESTIONS_MESSAGE,
       statusType: 'error',
     })
 
     expect(
-      getSuggestionsStatusContentForMentionChildren(
-        resolvedChildren,
-        {},
-        {
-          1: {
-            status: 'error',
-            error: new Error('boom'),
-            results: [],
-            queryInfo: { ...suggestions[0].queryInfo, childIndex: 1 },
-          },
-        } as never
-      )
+      getSuggestionsStatusContentForMentionChildren(resolvedChildren, {}, {
+        2: {
+          status: 'error',
+          error: new Error('boom'),
+          results: [],
+          queryInfo: { ...suggestions[0].queryInfo, childIndex: 2 },
+        },
+      } as never)
     ).toEqual({
       statusContent: 'Broken',
       statusType: 'error',
     })
 
     expect(
-      getSuggestionsStatusContentForMentionChildren(
-        resolvedChildren,
-        {},
-        {
-          2: {
-            status: 'error',
-            error: new Error('boom'),
-            results: [],
-            queryInfo: { ...suggestions[0].queryInfo, childIndex: 2 },
-          },
-        } as never
-      )
+      getSuggestionsStatusContentForMentionChildren(resolvedChildren, {}, {
+        3: {
+          status: 'error',
+          error: new Error('boom'),
+          results: [],
+          queryInfo: { ...suggestions[0].queryInfo, childIndex: 3 },
+        },
+      } as never)
     ).toEqual({
       statusContent: null,
       statusType: null,
     })
 
     expect(
-      getSuggestionsStatusContentForMentionChildren(
-        resolvedChildren,
-        {},
-        {
-          1: {
-            status: 'success',
-            results: [],
-            queryInfo: { ...suggestions[0].queryInfo, childIndex: 1 },
-          },
-        } as never
-      )
+      getSuggestionsStatusContentForMentionChildren(resolvedChildren, {}, {
+        99: {
+          status: 'error',
+          error: new Error('boom'),
+          results: [],
+          queryInfo: { ...suggestions[0].queryInfo, childIndex: 99 },
+        },
+      } as never)
+    ).toEqual({
+      statusContent: null,
+      statusType: null,
+    })
+  })
+
+  it('uses custom empty render output and falls back for undefined empty content', () => {
+    const children = (
+      <>
+        <Mention trigger="@" data={[]} renderEmpty={() => 'Nothing here'} />
+        <Mention trigger="#" data={[]} renderEmpty={() => undefined} />
+      </>
+    )
+    const resolvedChildren = getMentionChildren(children)
+
+    expect(
+      getSuggestionsStatusContentForMentionChildren(resolvedChildren, {}, {
+        0: {
+          status: 'success',
+          results: [],
+          queryInfo: { ...suggestions[0].queryInfo, childIndex: 0 },
+        },
+      } as never)
     ).toEqual({
       statusContent: 'Nothing here',
+      statusType: 'empty',
+    })
+
+    expect(
+      getSuggestionsStatusContentForMentionChildren(resolvedChildren, {}, {
+        1: {
+          status: 'success',
+          results: [],
+          queryInfo: { ...suggestions[0].queryInfo, childIndex: 1 },
+        },
+      } as never)
+    ).toEqual({
+      statusContent: DEFAULT_EMPTY_SUGGESTIONS_MESSAGE,
       statusType: 'empty',
     })
   })

--- a/src/Suggestion.spec.tsx
+++ b/src/Suggestion.spec.tsx
@@ -66,6 +66,26 @@ describe('Suggestion', () => {
     expect(container3.textContent).toContain('fallback-id')
   })
 
+  it('falls back to the suggestion id for empty display strings and applies focused classes', () => {
+    const { container } = render(
+      <Suggestion
+        id="suggestion-focused"
+        index={0}
+        query="focus"
+        suggestion={{ id: 'fallback-id', display: '' }}
+        onClick={vi.fn()}
+        onMouseEnter={vi.fn()}
+        focused
+        focusedClassName="ring-2"
+      />
+    )
+
+    const suggestionItem = container.querySelector('li')
+    expect(suggestionItem).toHaveClass('ring-2')
+    expect(suggestionItem).toHaveAttribute('aria-selected', 'true')
+    expect(container.textContent).toContain('fallback-id')
+  })
+
   it('should highlight the part of the display that is matched by the current query.', () => {
     const { container } = render(
       <Suggestion

--- a/src/SuggestionsOverlay.spec.tsx
+++ b/src/SuggestionsOverlay.spec.tsx
@@ -275,7 +275,7 @@ describe('SuggestionsOverlay', () => {
       <SuggestionsOverlay
         id="test-suggestions"
         suggestions={createSuggestionsMap([{ id: '1', display: 'First' }])}
-        focusIndex={4}
+        focusIndex={0}
         isOpened
         scrollFocusedIntoView
       >
@@ -689,6 +689,18 @@ describe('SuggestionsOverlay', () => {
     expect(container.querySelector('[data-slot="suggestions-status"]')).toBeNull()
   })
 
+  it('defaults missing suggestions to an empty map', () => {
+    const { container } = render(
+      <SuggestionsOverlay focusIndex={0} isOpened statusContent="Nothing here">
+        <Mention trigger="@" data={[]} />
+      </SuggestionsOverlay>
+    )
+
+    expect(container.querySelector('[data-slot="suggestions-status"]')).toHaveTextContent(
+      'Nothing here'
+    )
+  })
+
   it('defaults the empty status type when the caller omits it', () => {
     const { container } = render(
       <SuggestionsOverlay
@@ -704,7 +716,7 @@ describe('SuggestionsOverlay', () => {
 
     const status = container.querySelector('[data-slot="suggestions-status"]')
     expect(status).not.toBeNull()
-    expect(status).toHaveAttribute('data-status-type')
+    expect(status).not.toHaveAttribute('data-status-type')
     expect(status).toHaveClass('text-muted-foreground')
   })
 

--- a/src/test/perfNotes.internal.spec.ts
+++ b/src/test/perfNotes.internal.spec.ts
@@ -1,0 +1,57 @@
+describe('perfNotes internal error paths', () => {
+  afterEach(() => {
+    vi.resetModules()
+    vi.doUnmock('node:child_process')
+  })
+
+  it('rethrows spawn errors when recording git notes if git cannot be resolved', async () => {
+    const { recordPerfNote } = await import('./perfNotes')
+    const originalPath = process.env.PATH
+
+    try {
+      process.env.PATH = ''
+      expect(() =>
+        recordPerfNote(process.cwd(), {
+          perfOutput: '[perf] scenario {"count":1}',
+        })
+      ).toThrow(/ENOENT/u)
+    } finally {
+      process.env.PATH = originalPath
+    }
+  })
+
+  it('rethrows spawn errors when reading git notes if git cannot be resolved', async () => {
+    const { readPerfNote } = await import('./perfNotes')
+    const originalPath = process.env.PATH
+
+    try {
+      process.env.PATH = ''
+      expect(() => readPerfNote(process.cwd(), 'HEAD')).toThrow(/ENOENT/u)
+    } finally {
+      process.env.PATH = originalPath
+    }
+  })
+
+  it('wraps perf command failures even when stdout and stderr are absent', async () => {
+    const execError = new Error('perf failed')
+    vi.doMock('node:child_process', async (importOriginal) => {
+      const actual = await importOriginal<Record<string, unknown>>()
+      return {
+        ...actual,
+        spawnSync: vi.fn(() => {
+          return {
+            error: execError,
+          }
+        }),
+      }
+    })
+
+    const { recordPerfNote } = await import('./perfNotes')
+
+    expect(() =>
+      recordPerfNote(process.cwd(), {
+        perfCommand: 'pnpm broken:perf',
+      })
+    ).toThrow('Perf command failed: pnpm broken:perf')
+  })
+})

--- a/src/test/perfNotes.spec.ts
+++ b/src/test/perfNotes.spec.ts
@@ -127,7 +127,7 @@ const addRawPerfNote = (
 
 const createPerfCommand = (output: string): string => {
   const code = `process.stdout.write(${JSON.stringify(output)})`
-  return `${process.execPath} -e ${JSON.stringify(code)}`
+  return `${JSON.stringify(process.execPath)} -e ${JSON.stringify(code)}`
 }
 
 const createPerfCommandScript = (repositoryRoot: string, output = SAMPLE_PERF_OUTPUT): string => {
@@ -141,7 +141,7 @@ const createPerfCommandScript = (repositoryRoot: string, output = SAMPLE_PERF_OU
 
 const createFailingPerfCommand = (stderr = 'perf failed'): string => {
   const code = `process.stderr.write(${JSON.stringify(stderr)}); process.exit(2)`
-  return `${process.execPath} -e ${JSON.stringify(code)}`
+  return `${JSON.stringify(process.execPath)} -e ${JSON.stringify(code)}`
 }
 
 const createMemoryWriteStream = () => {
@@ -485,6 +485,15 @@ describe('perfNotes', () => {
       payload: JSON.stringify({
         ...parsePerfOutput(SAMPLE_PERF_OUTPUT),
         metrics: [],
+      }),
+    },
+    {
+      message: 'metrics.invalid must be an object',
+      payload: JSON.stringify({
+        ...parsePerfOutput(SAMPLE_PERF_OUTPUT),
+        metrics: {
+          invalid: [],
+        },
       }),
     },
     {

--- a/src/test/perfNotes.ts
+++ b/src/test/perfNotes.ts
@@ -1,4 +1,4 @@
-import { execSync, spawnSync } from 'node:child_process'
+import { spawnSync } from 'node:child_process'
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
@@ -61,12 +61,23 @@ interface CommandResult {
   stdout: string
 }
 
+interface ParsedCommandLine {
+  args: string[]
+  command: string
+}
+
 interface RunCommandOptions {
   env?: NodeJS.ProcessEnv
   repositoryRoot: string
 }
 
 const PERF_LINE_PATTERN = /^\[perf] (?<scenario>\S+) (?<metrics>{.+})$/
+
+interface CommandArgumentParseState {
+  args: string[]
+  current: string
+  quote: '"' | "'" | null
+}
 
 export const PERF_COMPARISON_MANIFEST = [
   ['array-provider-scan-count', 'scanCount'],
@@ -166,6 +177,95 @@ const normalizePerfNotePayload = (value: unknown, expectedCommand?: string): Per
   }
 }
 
+const pushCurrentCommandArgument = (state: CommandArgumentParseState): void => {
+  if (state.current.length > 0) {
+    state.args.push(state.current)
+    state.current = ''
+  }
+}
+
+const appendCommandArgumentCharacter = (
+  state: CommandArgumentParseState,
+  commandLine: string,
+  index: number
+): number => {
+  const char = commandLine[index]
+
+  if (char === '\\') {
+    state.current += commandLine[index + 1] ?? '\\'
+    return index + 1
+  }
+
+  if (state.quote !== null) {
+    if (char === state.quote) {
+      state.quote = null
+    } else {
+      state.current += char
+    }
+    return index
+  }
+
+  if (char === '"' || char === "'") {
+    state.quote = char
+    return index
+  }
+
+  if (/\s/u.test(char)) {
+    pushCurrentCommandArgument(state)
+    return index
+  }
+
+  state.current += char
+  return index
+}
+
+const parseCommandArguments = (commandLine: string): string[] => {
+  const state: CommandArgumentParseState = {
+    args: [],
+    current: '',
+    quote: null,
+  }
+
+  let index = 0
+  while (index < commandLine.length) {
+    index = appendCommandArgumentCharacter(state, commandLine, index) + 1
+  }
+
+  if (state.quote !== null) {
+    throw new Error(`Unterminated quoted string in perf command: ${commandLine}`)
+  }
+
+  pushCurrentCommandArgument(state)
+
+  return state.args
+}
+
+const parseCommandLine = (commandLine: string): ParsedCommandLine => {
+  if (commandLine === process.execPath) {
+    return {
+      args: [],
+      command: process.execPath,
+    }
+  }
+
+  if (commandLine.startsWith(`${process.execPath} `)) {
+    return {
+      args: parseCommandArguments(commandLine.slice(process.execPath.length + 1)),
+      command: process.execPath,
+    }
+  }
+
+  const [command, ...args] = parseCommandArguments(commandLine)
+  if (typeof command !== 'string') {
+    throw new TypeError('Perf command must be a non-empty string')
+  }
+
+  return {
+    args,
+    command,
+  }
+}
+
 const runCommand = (command: string, args: string[], options: RunCommandOptions): CommandResult => {
   const result = spawnSync(command, args, {
     // eslint-disable-next-line code-complete/enforce-meaningful-names -- child_process uses the standard cwd option name.
@@ -184,11 +284,13 @@ const runCommand = (command: string, args: string[], options: RunCommandOptions)
 
   if (result.status !== 0) {
     const renderedCommand = [command, ...args].join(' ')
-    throw new Error(
+    const error = new Error(
       [`Command failed: ${renderedCommand}`, stdout.trim(), stderr.trim()]
         .filter(Boolean)
         .join('\n')
     )
+    Object.assign(error, { stderr, stdout })
+    throw error
   }
 
   return {
@@ -238,18 +340,16 @@ const resolvePnpmPerfOutput = (
   env?: NodeJS.ProcessEnv,
   perfCommand = PERF_COMMAND
 ): string => {
+  const { args, command } = parseCommandLine(perfCommand)
+
   try {
-    // eslint-disable-next-line sonarjs/os-command -- perf capture intentionally runs the repository's deterministic perf command.
-    return execSync(perfCommand, {
-      // eslint-disable-next-line code-complete/enforce-meaningful-names -- child_process uses the standard cwd option name.
-      cwd: repositoryRoot,
-      encoding: 'utf8',
+    return runCommand(command, args, {
       env: {
         ...process.env,
         ...env,
       },
-      stdio: ['ignore', 'pipe', 'pipe'],
-    })
+      repositoryRoot,
+    }).stdout
   } catch (error) {
     const commandError = error as {
       stderr?: string | Buffer

--- a/src/test/performance.spec.tsx
+++ b/src/test/performance.spec.tsx
@@ -32,6 +32,7 @@ describe('performance helpers', () => {
 
   it('emits performance metrics to stdout', () => {
     const stdoutWriteSpy = vi.spyOn(process.stdout, 'write').mockReturnValue(true)
+    const originalPerfOutputFile = process.env.PERF_OUTPUT_FILE
 
     try {
       delete process.env.PERF_OUTPUT_FILE
@@ -42,12 +43,18 @@ describe('performance helpers', () => {
 
       expect(stdoutWriteSpy).toHaveBeenCalledWith('[perf] render-pass {"count":2}\n')
     } finally {
+      if (originalPerfOutputFile === undefined) {
+        delete process.env.PERF_OUTPUT_FILE
+      } else {
+        process.env.PERF_OUTPUT_FILE = originalPerfOutputFile
+      }
       stdoutWriteSpy.mockRestore()
     }
   })
 
   it('appends performance metrics to the configured output file', () => {
     const stdoutWriteSpy = vi.spyOn(process.stdout, 'write').mockReturnValue(true)
+    const originalPerfOutputFile = process.env.PERF_OUTPUT_FILE
     const directory = mkdtempSync(path.join(tmpdir(), 'react-mentions-ts-performance-spec-'))
     const outputFile = path.join(directory, 'perf.log')
 
@@ -59,11 +66,16 @@ describe('performance helpers', () => {
         scanCount: 5,
       })
 
+      // eslint-disable-next-line security/detect-non-literal-fs-filename -- test owns this temporary output path.
       expect(readFileSync(outputFile, 'utf8')).toBe(
         '[perf] array-provider-scan-count {"resultCount":5,"scanCount":5}\n'
       )
     } finally {
-      delete process.env.PERF_OUTPUT_FILE
+      if (originalPerfOutputFile === undefined) {
+        delete process.env.PERF_OUTPUT_FILE
+      } else {
+        process.env.PERF_OUTPUT_FILE = originalPerfOutputFile
+      }
       stdoutWriteSpy.mockRestore()
       rmSync(directory, { force: true, recursive: true })
     }

--- a/src/utils/applyChangeToValue.ts
+++ b/src/utils/applyChangeToValue.ts
@@ -103,8 +103,7 @@ const getSpliceRange = (
 
 const getMismatchRecoveryRange = (
   oldPlainTextValue: string,
-  plainTextValue: string,
-  selectionEndAfter: number
+  plainTextValue: string
 ): SpliceRange => {
   let spliceStart = 0
   while (
@@ -129,7 +128,7 @@ const getMismatchRecoveryRange = (
   return {
     insert: plainTextValue.slice(spliceStart, spliceEndOfNew),
     spliceStart,
-    spliceEnd: spliceEndOfOld >= spliceStart ? spliceEndOfOld : selectionEndAfter,
+    spliceEnd: spliceEndOfOld,
   }
 }
 
@@ -195,11 +194,7 @@ const applyChangeToValue = <Extra extends Record<string, unknown> = Record<strin
   }
 
   // some auto-correction is going on
-  const mismatchRecoveryRange = getMismatchRecoveryRange(
-    oldPlainTextValue,
-    plainTextValue,
-    resolvedSelection.selectionEndAfter
-  )
+  const mismatchRecoveryRange = getMismatchRecoveryRange(oldPlainTextValue, plainTextValue)
 
   return applySpliceRange(value, config, mismatchRecoveryRange).newValue
 }

--- a/src/utils/createMarkupSerializer.spec.ts
+++ b/src/utils/createMarkupSerializer.spec.ts
@@ -59,40 +59,47 @@ describe('createMarkupSerializer', () => {
       {
         markup: '@[Ada](1|0)',
         index: 3,
-        id: '1|0',
+        id: '1',
         display: 'Ada',
       },
       {
         markup: '@[Ada](1)|0',
-        index: 18,
+        index: 19,
         id: '1',
         display: 'Ada',
       },
     ])
   })
 
-  it('ignores duplicate suffixes for serializers without id placeholders', () => {
+  it('treats duplicate suffixes as literal markup when no id placeholder exists', () => {
     const serializer = createMarkupSerializer('[[__display__]]|0')
 
-    expect(serializer.findAll('[[Ada]]|0')).toEqual([])
+    expect(serializer.findAll('[[Ada]]|0')).toEqual([
+      {
+        markup: '[[Ada]]|0',
+        index: 0,
+        id: 'Ada',
+        display: 'Ada',
+      },
+    ])
   })
 
   it('sorts overlapping matches by index and longer markup first', () => {
-    const serializer = createMarkupSerializer('[__id__]')
-    const value = 'Nested [abc][de]'
+    const serializer = createMarkupSerializer('@[__display__](__id__)|0')
+    const value = '@[Ada](1|0)|0'
 
     expect(serializer.findAll(value)).toEqual([
       {
-        markup: '[abc]',
-        index: 7,
-        id: 'abc',
-        display: null,
+        markup: '@[Ada](1|0)|0',
+        index: 0,
+        id: '1|0',
+        display: 'Ada',
       },
       {
-        markup: '[de]',
-        index: 12,
-        id: 'de',
-        display: null,
+        markup: '@[Ada](1|0)',
+        index: 0,
+        id: '1',
+        display: 'Ada',
       },
     ])
   })

--- a/src/utils/getSubstringIndex.spec.ts
+++ b/src/utils/getSubstringIndex.spec.ts
@@ -15,6 +15,7 @@ describe('#getSubstringIndex', () => {
     expect(getSubstringIndex('Aurait-Il été ãdOré là-bas ?', 'aurait-il')).toEqual(0)
     expect(getSubstringIndex('Aurait-Il été ãdOré là-bas ?', 'adore')).toEqual(-1)
     expect(getSubstringIndex('Aurait-Il été ãdOré là-bas ?', 'not existing substring')).toEqual(-1)
+    expect(getSubstringIndex('Alpha ALPHA', 'AL', false, false)).toEqual(6)
   })
   it('Should return the index of the substring or -1 ignoring the accents and the case', () => {
     expect(getSubstringIndex('Aurait-Il été ãdOré là-bas ?', 'adore', true)).toEqual(14)
@@ -95,21 +96,24 @@ describe('#getSubstringIndex', () => {
   })
 
   it('skips characters gracefully when String#codePointAt reports undefined', () => {
-    // eslint-disable-next-line sonarjs/no-primitive-wrappers, unicorn/new-for-builtins
-    const haystackWrapper = new String('abc')
-    const codePointAtMock = vi.fn(function (this: string, pos: number) {
-      if (pos === 1) {
-        return undefined
-      }
-      return String.prototype.codePointAt.call(this, pos)
-    })
-    ;(
-      haystackWrapper as unknown as { codePointAt: (pos: number) => number | undefined }
-    ).codePointAt = codePointAtMock
+    const originalCodePointAt = String.prototype.codePointAt
+    const codePointAtMock = vi
+      .spyOn(String.prototype, 'codePointAt')
+      .mockImplementation(function (this: string, pos: number) {
+        if (this.toString() === 'abc' && pos === 1) {
+          return undefined
+        }
 
-    const result = getSubstringIndex(haystackWrapper as unknown as string, 'c', true)
+        return originalCodePointAt.call(this, pos)
+      })
 
-    expect(codePointAtMock).toHaveBeenCalledWith(1)
-    expect(result).toBe(2)
+    try {
+      const result = getSubstringIndex('abc', 'c', true)
+
+      expect(codePointAtMock).toHaveBeenCalledWith(1)
+      expect(result).toBe(2)
+    } finally {
+      codePointAtMock.mockRestore()
+    }
   })
 })

--- a/src/utils/markupToRegex.spec.ts
+++ b/src/utils/markupToRegex.spec.ts
@@ -30,4 +30,12 @@ describe('#markupToRegex', () => {
     const regex = markupToRegex('[tag id=__id__ /]')
     expect(regex.exec('[tag id=italy /]')[1]).toEqual('italy')
   })
+
+  it('should insert custom id patterns literally', () => {
+    const regex = markupToRegex('@[__display__](__id__)', { idPattern: '([^$&]+?)' })
+
+    expect(regex.source).toContain('([^$&]+?)')
+    expect(regex.exec('Hi @[Ada](abc)')?.[2]).toEqual('abc')
+    expect(regex.exec('Hi @[Ada](a&)')).toEqual(null)
+  })
 })

--- a/src/utils/markupToRegex.ts
+++ b/src/utils/markupToRegex.ts
@@ -21,7 +21,7 @@ const markupToRegex = (
   return createInternalRegExp(
     escapedMarkup
       .replace(PLACEHOLDERS.display, `([^${escapeRegex(charAfterDisplay)}]+?)`)
-      .replace(PLACEHOLDERS.id, idPattern ?? `([^${escapeRegex(charAfterId)}]+?)`)
+      .replace(PLACEHOLDERS.id, () => idPattern ?? `([^${escapeRegex(charAfterId)}]+?)`)
   )
 }
 

--- a/src/utils/mergeDeep.spec.ts
+++ b/src/utils/mergeDeep.spec.ts
@@ -54,4 +54,15 @@ describe('mergeDeep', () => {
     const result = mergeDeep(target, source)
     expect(result.meta).toEqual({ nested: true })
   })
+
+  it('returns a shallow copy when the source is not a plain object', () => {
+    const target = {
+      stable: true,
+    }
+
+    const result = mergeDeep(target, null as unknown as Record<string, unknown>)
+
+    expect(result).toEqual(target)
+    expect(result).not.toBe(target)
+  })
 })

--- a/src/utils/readConfigFromChildren.spec.tsx
+++ b/src/utils/readConfigFromChildren.spec.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import Mention from '../Mention'
 import getPlainText from './getPlainText'
-import readConfigFromChildren from './readConfigFromChildren'
+import readConfigFromChildren, { collectMentionElements } from './readConfigFromChildren'
 
 describe('readConfigFromChildren', () => {
   describe('trigger-specific markup generation', () => {
@@ -59,6 +59,13 @@ describe('readConfigFromChildren', () => {
       const children = [<Mention key="1" trigger={/@/} data={[]} />]
 
       const config = readConfigFromChildren(children)
+
+      expect(config).toHaveLength(1)
+      expect(config[0].serializer.id).toBe('@[__display__](__id__)')
+    })
+
+    it('should use the default markup when the trigger is omitted', () => {
+      const config = readConfigFromChildren([<Mention key="1" data={[]} />])
 
       expect(config).toHaveLength(1)
       expect(config[0].serializer.id).toBe('@[__display__](__id__)')
@@ -143,5 +150,18 @@ describe('readConfigFromChildren', () => {
 
       expect(config[0].serializer.id).toBe(customMarkup)
     })
+  })
+
+  it('collects only Mention elements and ignores unrelated children', () => {
+    const mentions = collectMentionElements(
+      <>
+        <span>ignore me</span>
+        Plain text
+        <Mention key="1" trigger="@" data={[]} />
+      </>
+    )
+
+    expect(mentions).toHaveLength(1)
+    expect(mentions[0].props.trigger).toBe('@')
   })
 })

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,6 +14,12 @@ export default defineConfig({
       reportsDirectory: './coverage',
       include: ['src/**/*.{ts,tsx}'],
       exclude: ['src/**/*.spec.{ts,tsx}', 'src/**/__snapshots__/**'],
+      thresholds: {
+        statements: 95,
+        branches: 95,
+        functions: 95,
+        lines: 95,
+      },
     },
   },
 })


### PR DESCRIPTION
Fixed mismatch recovery in applyChangeToValue.ts to keep splice indexes in the old plain-text coordinate space. Fixed custom idPattern insertion in markupToRegex.ts so $ replacement tokens are preserved literally. Replaced perf command shelling with parsed spawnSync execution in perfNotes.ts. Cleaned up the cited tests, env restoration, README duplicate type import, and formatting/lint issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Expanded test coverage across multiple components and utilities, including edge cases for error handling, optional features, and fallback behaviors.

* **Chores**
  * Added minimum code coverage thresholds (95%) to ensure code quality standards.

* **Documentation**
  * Updated README example for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Linux IME mismatch recovery and regex literal handling, raise test coverage to 95%
> - Fixes `getMismatchRecoveryRange` in [applyChangeToValue.ts](https://github.com/hbmartin/react-mentions-ts/pull/186/files#diff-952c56fd7dbc96779d7ad03bda38ea5ee8301c7ea8cc76d3f4b9264b4bc1f1fe) to always use the computed old splice end instead of falling back to `selectionEndAfter`, correcting auto-correction behavior for Linux IME input.
> - Fixes `markupToRegex` in [markupToRegex.ts](https://github.com/hbmartin/react-mentions-ts/pull/186/files#diff-d71471f24c350c47da6967647b34968056690550495e7094d79cc98d9aabffd4) to insert custom `idPattern` strings literally, preventing `$`-based sequences from being misinterpreted as regex replacement tokens.
> - Adds coverage thresholds (95% statements, branches, functions, lines) to [vitest.config.ts](https://github.com/hbmartin/react-mentions-ts/pull/186/files#diff-2ee894bf23aa44ff4ce12a3da8af19ab20180474ebf2176dbe5f2eea3f96dc92) and expands test suites across highlighter, layout, selection, selectors, serializer, and utility modules.
> - Rewrites perf tooling command execution in [perfNotes.ts](https://github.com/hbmartin/react-mentions-ts/pull/186/files#diff-4c0fa0e0bf6df52229830a407eb737331ab74887ffe5b9074c9c50fabc6bf2dc) to use `spawnSync` with a custom argument parser that handles quoted/escaped args, and attaches stdout/stderr to thrown errors on failure.
> - Behavioral Change: mismatch recovery in `getMismatchRecoveryRange` no longer falls back to selection end, which may alter how recovered splices are applied for some IME inputs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b42ce80.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->