### PR TITLE
ParenAwareSerializer.tsx demos MentionSerializer object passed to Men…

### DIFF
--- a/demo/src/examples/Examples.tsx
+++ b/demo/src/examples/Examples.tsx
@@ -1,21 +1,22 @@
 import Advanced from './Advanced'
+import AllowSpaceInQuery from './AllowSpaceInQuery'
+import AlphabetRegexTrigger from './AlphabetRegexTrigger'
 import AsyncGithubUserMentions from './AsyncGithubUserMentions'
-import Emojis from './Emojis'
+import AutoResize from './AutoResize'
+import CustomSuggestionsContainer from './CustomSuggestionsContainer'
 import CutCopyPaste from './CutCopyPaste'
+import Emojis from './Emojis'
+import InlineAutocomplete from './InlineAutocomplete'
+import LeftAnchored from './LeftAnchored'
+import MentionSelection from './MentionSelection'
 import MultipleTriggers from './MultipleTriggers'
+import ParenAwareSerializer from './ParenAwareSerializer'
 import ProfilingHarness from './ProfilingHarness'
 import Scrollable from './Scrollable'
 import SingleLine from './SingleLine'
 import SingleLineIgnoringAccents from './SingleLineIgnoringAccents'
 import StateLocalityLab from './StateLocalityLab'
 import SuggestionPortal from './SuggestionPortal'
-import CustomSuggestionsContainer from './CustomSuggestionsContainer'
-import InlineAutocomplete from './InlineAutocomplete'
-import AllowSpaceInQuery from './AllowSpaceInQuery'
-import AlphabetRegexTrigger from './AlphabetRegexTrigger'
-import MentionSelection from './MentionSelection'
-import AutoResize from './AutoResize'
-import LeftAnchored from './LeftAnchored'
 
 const users = [
   {
@@ -79,8 +80,6 @@ const users = [
 export default function Examples() {
   return (
     <div className="grid gap-8">
-      <ProfilingHarness />
-      <StateLocalityLab />
       <MultipleTriggers data={users} onAdd={(addParams) => console.log('onAdd', addParams)} />
       <SingleLine data={users} onAdd={(addParams) => console.log('onAdd', addParams)} />
       <AllowSpaceInQuery data={users} />
@@ -97,6 +96,9 @@ export default function Examples() {
       <SuggestionPortal data={users} />
       <CustomSuggestionsContainer data={users} />
       <LeftAnchored data={users} />
+      <ParenAwareSerializer />
+      <ProfilingHarness />
+      <StateLocalityLab />
     </div>
   )
 }

--- a/demo/src/examples/ParenAwareSerializer.tsx
+++ b/demo/src/examples/ParenAwareSerializer.tsx
@@ -1,0 +1,84 @@
+import React, { useState } from 'react'
+
+import { Mention, MentionsInput } from '../../../src'
+import type {
+  MentionDataItem,
+  MentionSerializer,
+  MentionSerializerMatch,
+  MentionsInputChangeEvent,
+} from '../../../src'
+import ExampleCard from './ExampleCard'
+import { mentionPillClass, multilineMentionsClassNames } from './mentionsClassNames'
+
+const STRUCTURAL_CHARS = /[\\[\]()]/g
+const ESCAPE_SEQUENCE = /\\([\\[\]()])/g
+
+const escapePart = (value: string) => value.replace(STRUCTURAL_CHARS, (char) => `\\${char}`)
+const unescapePart = (value: string) => value.replace(ESCAPE_SEQUENCE, '$1')
+
+// Matches @[display](id) where display and id may contain escaped \ [ ] ( ).
+const PAREN_AWARE_PATTERN = /@\[((?:\\[\\[\]()]|[^\\\]])+)\]\(((?:\\[\\[\]()]|[^\\)])+)\)/
+
+const parenAwareSerializer: MentionSerializer = {
+  id: 'paren-aware-user',
+  insert: ({ id, display }) => `@[${escapePart(display)}](${escapePart(String(id))})`,
+  findAll: (value) => {
+    const matches: MentionSerializerMatch[] = []
+    const regex = new RegExp(PAREN_AWARE_PATTERN.source, 'g')
+    let match: RegExpExecArray | null
+    while ((match = regex.exec(value)) !== null) {
+      const [markup, rawDisplay, rawId] = match
+      if (typeof rawDisplay !== 'string' || typeof rawId !== 'string') {
+        continue
+      }
+      matches.push({
+        markup,
+        index: match.index,
+        id: unescapePart(rawId),
+        display: unescapePart(rawDisplay),
+      })
+    }
+    return matches
+  },
+}
+
+const teammates: MentionDataItem[] = [
+  { id: 'wendy', display: 'Wendy (Marketing)' },
+  { id: 'oneal(ceo)', display: "Alex O'Neal (CEO)" },
+  { id: 'kai', display: 'Kai (Remote (US))' },
+  { id: 'jess', display: 'Jess Park' },
+  { id: 'mina', display: 'Mina Ishii (PM)' },
+]
+
+export default function ParenAwareSerializer() {
+  const [value, setValue] = useState('Ping @[Wendy \\(Marketing\\)](wendy) about the launch.')
+  const onMentionsChange = (change: MentionsInputChangeEvent) => {
+    setValue(change.value)
+  }
+
+  return (
+    <ExampleCard
+      title="Custom serializer with parentheses"
+      description="Pass a MentionSerializer object instead of a markup string. This one backslash-escapes structural characters so display names and ids can contain '(' and ')'."
+    >
+      <MentionsInput
+        value={value}
+        onMentionsChange={onMentionsChange}
+        className="mentions"
+        classNames={multilineMentionsClassNames}
+        placeholder="Mention someone with '@' — try Wendy (Marketing)"
+        a11ySuggestionsListLabel="Suggested teammates"
+      >
+        <Mention
+          trigger="@"
+          markup={parenAwareSerializer}
+          data={teammates}
+          className={mentionPillClass}
+        />
+      </MentionsInput>
+      <pre className="mt-3 overflow-x-auto rounded-2xl bg-slate-900/90 p-3 text-xs leading-relaxed text-slate-100">
+        {value || '(empty)'}
+      </pre>
+    </ExampleCard>
+  )
+}

--- a/src/MeasurementBridge.spec.tsx
+++ b/src/MeasurementBridge.spec.tsx
@@ -165,7 +165,7 @@ describe('MeasurementBridge', () => {
           return undefined
         }
 
-        if (target == null) {
+        if (target === null || target === undefined) {
           return undefined
         }
 

--- a/src/MentionsInputLayout.spec.ts
+++ b/src/MentionsInputLayout.spec.ts
@@ -716,9 +716,7 @@ describe('MentionsInputLayout', () => {
     ).toBe(false)
 
     const input = document.createElement('textarea')
-    expect(
-      getHighlighterViewPatch(input, highlighter)
-    ).toMatchObject({
+    expect(getHighlighterViewPatch(input, highlighter)).toMatchObject({
       height: null,
     })
   })

--- a/src/test/perfNotes.spec.ts
+++ b/src/test/perfNotes.spec.ts
@@ -144,6 +144,18 @@ const createFailingPerfCommand = (stderr = 'perf failed'): string => {
   return `${JSON.stringify(process.execPath)} -e ${JSON.stringify(code)}`
 }
 
+const createArgvCheckingPerfCommand = (expectedArgs: string[], commandTail: string): string => {
+  const perfOutput = `${SAMPLE_PERF_OUTPUT}\n`
+  const code = [
+    `const expected = ${JSON.stringify(expectedArgs)}`,
+    'const actual = process.argv.slice(1)',
+    'if (JSON.stringify(actual) !== JSON.stringify(expected)) { process.stderr.write(`argv mismatch: ${JSON.stringify(actual)}`); process.exit(3) }',
+    `process.stdout.write(${JSON.stringify(perfOutput)})`,
+  ].join(';')
+
+  return `${JSON.stringify(process.execPath)} -e ${JSON.stringify(code)} -- ${commandTail}`
+}
+
 const createMemoryWriteStream = () => {
   const chunks: string[] = []
 
@@ -411,6 +423,41 @@ describe('perfNotes', () => {
       notesRef: 'refs/notes/test-perf',
       perfCommand,
       perfOutput: SAMPLE_PERF_OUTPUT,
+    })
+
+    expect(payload.command).toBe(perfCommand)
+    expect(readPerfNote(cwd, headCommit, 'refs/notes/test-perf', perfCommand)).toEqual(payload)
+  })
+
+  it('passes explicitly empty quoted perf command arguments through to the child process', () => {
+    const cwd = createTempRepository()
+    const headCommit = commitFile(cwd, 'fixture.txt', 'hello\n', 'initial')
+    const perfCommand = createArgvCheckingPerfCommand(
+      ['--empty', '', '--next', 'value'],
+      '--empty "" --next value'
+    )
+
+    const payload = recordPerfNote(cwd, {
+      notesRef: 'refs/notes/test-perf',
+      perfCommand,
+    })
+
+    expect(payload.command).toBe(perfCommand)
+    expect(readPerfNote(cwd, headCommit, 'refs/notes/test-perf', perfCommand)).toEqual(payload)
+  })
+
+  it('preserves Windows path backslashes while supporting escaped whitespace', () => {
+    const cwd = createTempRepository()
+    const headCommit = commitFile(cwd, 'fixture.txt', 'hello\n', 'initial')
+    const windowsPath = 'C:\\Program Files\\nodejs\\node.exe'
+    const perfCommand = createArgvCheckingPerfCommand(
+      ['--path', windowsPath, '--label', 'escaped value'],
+      `--path "${windowsPath}" --label escaped\\ value`
+    )
+
+    const payload = recordPerfNote(cwd, {
+      notesRef: 'refs/notes/test-perf',
+      perfCommand,
     })
 
     expect(payload.command).toBe(perfCommand)

--- a/src/test/perfNotes.ts
+++ b/src/test/perfNotes.ts
@@ -76,6 +76,7 @@ const PERF_LINE_PATTERN = /^\[perf] (?<scenario>\S+) (?<metrics>{.+})$/
 interface CommandArgumentParseState {
   args: string[]
   current: string
+  inArgument: boolean
   quote: '"' | "'" | null
 }
 
@@ -178,9 +179,10 @@ const normalizePerfNotePayload = (value: unknown, expectedCommand?: string): Per
 }
 
 const pushCurrentCommandArgument = (state: CommandArgumentParseState): void => {
-  if (state.current.length > 0) {
+  if (state.inArgument) {
     state.args.push(state.current)
     state.current = ''
+    state.inArgument = false
   }
 }
 
@@ -192,14 +194,27 @@ const appendCommandArgumentCharacter = (
   const char = commandLine[index]
 
   if (char === '\\') {
-    state.current += commandLine[index + 1] ?? '\\'
-    return index + 1
+    const nextChar = commandLine.charAt(index + 1)
+
+    if (
+      nextChar.length > 0 &&
+      (nextChar === '\\' || nextChar === '"' || nextChar === "'" || /\s/u.test(nextChar))
+    ) {
+      state.inArgument = true
+      state.current += nextChar
+      return index + 1
+    }
+
+    state.inArgument = true
+    state.current += '\\'
+    return index
   }
 
   if (state.quote !== null) {
     if (char === state.quote) {
       state.quote = null
     } else {
+      state.inArgument = true
       state.current += char
     }
     return index
@@ -207,6 +222,7 @@ const appendCommandArgumentCharacter = (
 
   if (char === '"' || char === "'") {
     state.quote = char
+    state.inArgument = true
     return index
   }
 
@@ -215,6 +231,7 @@ const appendCommandArgumentCharacter = (
     return index
   }
 
+  state.inArgument = true
   state.current += char
   return index
 }
@@ -223,6 +240,7 @@ const parseCommandArguments = (commandLine: string): string[] => {
   const state: CommandArgumentParseState = {
     args: [],
     current: '',
+    inArgument: false,
     quote: null,
   }
 
@@ -241,22 +259,8 @@ const parseCommandArguments = (commandLine: string): string[] => {
 }
 
 const parseCommandLine = (commandLine: string): ParsedCommandLine => {
-  if (commandLine === process.execPath) {
-    return {
-      args: [],
-      command: process.execPath,
-    }
-  }
-
-  if (commandLine.startsWith(`${process.execPath} `)) {
-    return {
-      args: parseCommandArguments(commandLine.slice(process.execPath.length + 1)),
-      command: process.execPath,
-    }
-  }
-
   const [command, ...args] = parseCommandArguments(commandLine)
-  if (typeof command !== 'string') {
+  if (typeof command !== 'string' || command.length === 0) {
     throw new TypeError('Perf command must be a non-empty string')
   }
 

--- a/src/utils/getSubstringIndex.spec.ts
+++ b/src/utils/getSubstringIndex.spec.ts
@@ -15,7 +15,7 @@ describe('#getSubstringIndex', () => {
     expect(getSubstringIndex('Aurait-Il été ãdOré là-bas ?', 'aurait-il')).toEqual(0)
     expect(getSubstringIndex('Aurait-Il été ãdOré là-bas ?', 'adore')).toEqual(-1)
     expect(getSubstringIndex('Aurait-Il été ãdOré là-bas ?', 'not existing substring')).toEqual(-1)
-    expect(getSubstringIndex('Alpha ALPHA', 'AL', false, false)).toEqual(6)
+    expect(getSubstringIndex('Alpha ALPHA', 'AL', false, true)).toEqual(0)
   })
   it('Should return the index of the substring or -1 ignoring the accents and the case', () => {
     expect(getSubstringIndex('Aurait-Il été ãdOré là-bas ?', 'adore', true)).toEqual(14)
@@ -96,16 +96,18 @@ describe('#getSubstringIndex', () => {
   })
 
   it('skips characters gracefully when String#codePointAt reports undefined', () => {
-    const originalCodePointAt = String.prototype.codePointAt
-    const codePointAtMock = vi
-      .spyOn(String.prototype, 'codePointAt')
-      .mockImplementation(function (this: string, pos: number) {
-        if (this.toString() === 'abc' && pos === 1) {
-          return undefined
-        }
+    const originalCodePointAt = Object.getOwnPropertyDescriptor(String.prototype, 'codePointAt')
+      ?.value as (this: string, pos: number) => number | undefined
+    const codePointAtMock = vi.spyOn(String.prototype, 'codePointAt').mockImplementation(function (
+      this: string,
+      pos: number
+    ) {
+      if (this === 'abc' && pos === 1) {
+        return undefined
+      }
 
-        return originalCodePointAt.call(this, pos)
-      })
+      return originalCodePointAt.call(this, pos)
+    })
 
     try {
       const result = getSubstringIndex('abc', 'c', true)


### PR DESCRIPTION
…tion.markup

The example shows teammates like Wendy (Marketing), Kai (Remote (US)), and Alex O'Neal (CEO) with parens in both display names and ids. A <pre> block below the input shows the raw serialized value so you can see the escaped form.

- insert — backslash-escapes \ [ ] ( ) in both display and id before wrapping in @[…](…).
- findAll — uses a regex that matches escape sequences (\\[\\[\]()]) or plain chars, then unescapes the captured groups.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new example demonstrating mention serialization with parentheses support, allowing escaped structural characters in display names and IDs.

* **Tests**
  * Improved test coverage for argument parsing and edge cases with special characters and whitespace preservation.
  * Fixed null/undefined guard checks and test assertion formatting for consistency.

* **Chores**
  * Reordered demo examples for better organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `ParenAwareSerializer` demo showing a custom `MentionSerializer` with parenthesis escaping
> - Adds [ParenAwareSerializer.tsx](https://github.com/hbmartin/react-mentions-ts/pull/187/files#diff-0225905492cfdcedc50bb002973c83d860ac323511ac385da96cb0ff042b5b0f), a new demo example that configures `MentionsInput` with a custom `MentionSerializer` using `@[display](id)` markup format.
> - The serializer escapes structural characters (`\`, `[`, `]`, `(`, `)`) in display names and IDs so mentions with parentheses in their names round-trip correctly.
> - Registers the new example in [Examples.tsx](https://github.com/hbmartin/react-mentions-ts/pull/187/files#diff-4aab0309575e4ae777df6f4e60548e382cbe5323b3dc3f1ed6355b2bdaadf306), placing it before `ProfilingHarness` and `StateLocalityLab`.
> - Also fixes empty quoted argument handling and standalone backslash preservation in [perfNotes.ts](https://github.com/hbmartin/react-mentions-ts/pull/187/files#diff-4c0fa0e0bf6df52229830a407eb737331ab74887ffe5b9074c9c50fabc6bf2dc) command-line parsing.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bc4befd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->