### PR TITLE
Restored process.execPath handling in perfNotes.ts (line 261), with a…

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 - never run publint with pnpm, instead always use `npx publint --pack npm`
 - use `pnpm` for all commands except `pack`
-- always run `pnpm test` after completing the todo list to make sure there are no breaking changes
+- always run `pnpm format && pnpm lint && pnpm test` after completing work and fix findings
 
 ## Relevant best-practice guidance for this library
 

--- a/src/test/perfNotes.spec.ts
+++ b/src/test/perfNotes.spec.ts
@@ -7,6 +7,7 @@ import {
   checkPerfAgainstBaseline,
   comparePerfNotes,
   findNearestBaselineNote,
+  parseCommandLine,
   parsePerfOutput,
   recordPerfNote,
   readPerfNote,
@@ -154,6 +155,24 @@ const createArgvCheckingPerfCommand = (expectedArgs: string[], commandTail: stri
   ].join(';')
 
   return `${JSON.stringify(process.execPath)} -e ${JSON.stringify(code)} -- ${commandTail}`
+}
+
+const withProcessExecPath = <Result>(execPath: string, callback: () => Result): Result => {
+  const originalExecPathDescriptor = Object.getOwnPropertyDescriptor(process, 'execPath')
+  Object.defineProperty(process, 'execPath', {
+    configurable: true,
+    enumerable: originalExecPathDescriptor?.enumerable ?? true,
+    value: execPath,
+    writable: true,
+  })
+
+  try {
+    return callback()
+  } finally {
+    if (originalExecPathDescriptor) {
+      Object.defineProperty(process, 'execPath', originalExecPathDescriptor)
+    }
+  }
 }
 
 const createMemoryWriteStream = () => {
@@ -462,6 +481,17 @@ describe('perfNotes', () => {
 
     expect(payload.command).toBe(perfCommand)
     expect(readPerfNote(cwd, headCommit, 'refs/notes/test-perf', perfCommand)).toEqual(payload)
+  })
+
+  it('preserves unquoted process.execPath commands that contain spaces', () => {
+    const execPathWithSpaces = path.join(tmpdir(), 'runtime with spaces', 'node')
+    const code = 'process.stdout.write("ok")'
+    const commandLine = `${execPathWithSpaces} -e ${JSON.stringify(code)} --label escaped\\ value`
+
+    expect(withProcessExecPath(execPathWithSpaces, () => parseCommandLine(commandLine))).toEqual({
+      args: ['-e', code, '--label', 'escaped value'],
+      command: execPathWithSpaces,
+    })
   })
 
   it('records a perf note on HEAD without touching the default notes ref', () => {

--- a/src/test/perfNotes.ts
+++ b/src/test/perfNotes.ts
@@ -258,7 +258,21 @@ const parseCommandArguments = (commandLine: string): string[] => {
   return state.args
 }
 
-const parseCommandLine = (commandLine: string): ParsedCommandLine => {
+export const parseCommandLine = (commandLine: string): ParsedCommandLine => {
+  if (commandLine === process.execPath) {
+    return {
+      args: [],
+      command: process.execPath,
+    }
+  }
+
+  if (commandLine.startsWith(`${process.execPath} `)) {
+    return {
+      args: parseCommandArguments(commandLine.slice(process.execPath.length)),
+      command: process.execPath,
+    }
+  }
+
   const [command, ...args] = parseCommandArguments(commandLine)
   if (typeof command !== 'string' || command.length === 0) {
     throw new TypeError('Perf command must be a non-empty string')

--- a/src/utils/getSubstringIndex.spec.ts
+++ b/src/utils/getSubstringIndex.spec.ts
@@ -99,14 +99,16 @@ describe('#getSubstringIndex', () => {
     const originalCodePointAt = Object.getOwnPropertyDescriptor(String.prototype, 'codePointAt')
       ?.value as (this: string, pos: number) => number | undefined
     const codePointAtMock = vi.spyOn(String.prototype, 'codePointAt').mockImplementation(function (
-      this: string,
+      this: unknown,
       pos: number
     ) {
-      if (this === 'abc' && pos === 1) {
+      const receiver = String(this)
+
+      if (receiver === 'abc' && pos === 1) {
         return undefined
       }
 
-      return originalCodePointAt.call(this, pos)
+      return originalCodePointAt.call(receiver, pos)
     })
 
     try {


### PR DESCRIPTION
… regression test for unquoted executable paths containing spaces in perfNotes.spec.ts (line 483).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `parseCommandLine` in `perfNotes.ts` to handle unquoted `process.execPath` with spaces
> - Exports `parseCommandLine` from [perfNotes.ts](https://github.com/hbmartin/react-mentions-ts/pull/188/files#diff-4c0fa0e0bf6df52229830a407eb737331ab74887ffe5b9074c9c50fabc6bf2dc) and adds two early-return branches: one for when the command line exactly equals `process.execPath` (returns empty args), and one for when it starts with `process.execPath` followed by a space (parses remaining tokens as args).
> - Adds a test helper `withProcessExecPath` in [perfNotes.spec.ts](https://github.com/hbmartin/react-mentions-ts/pull/188/files#diff-d5e130040357603f8ba52824c35fe27425ced99534f2539f88787cb9471df952) to temporarily override `process.execPath` during tests, enabling coverage of paths that contain spaces.
> - Fixes a spy receiver issue in [getSubstringIndex.spec.ts](https://github.com/hbmartin/react-mentions-ts/pull/188/files#diff-4a34e03ee68bfb6e218621f767d6421ccd5dee0f0a16350e43c72655f44ed0b6) by coercing `this` to `String(this)` to avoid brittle binding assumptions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8306c1f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for command-line argument parsing with edge cases.
  * Improved test robustness for string operation handling.

* **Documentation**
  * Updated development process guidance for comprehensive code quality checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->