### PR TITLE
Count rule violations and upgrade checkout action followup

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,5 +10,5 @@
   "editor.codeActionsOnSave": {
     "source.fixAll.oxc": "explicit"
   },
-  "typescript.tsserver.implicitProjectConfig.types": ["node", "jest", "@testing-library/jest-dom"]
+  "typescript.tsserver.implicitProjectConfig.types": ["node", "vitest", "@testing-library/jest-dom"]
 }

--- a/scripts/write-oxlint-all-rules.mjs
+++ b/scripts/write-oxlint-all-rules.mjs
@@ -5,7 +5,7 @@ import { existsSync, readFileSync, writeFileSync } from 'node:fs'
 import { dirname, relative, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
-const projectRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const projectRoot = resolve(import.meta.dirname, '..')
 const [schemaArgument, configArgument] = process.argv.slice(2)
 const schemaPath = resolve(
   projectRoot,
@@ -118,7 +118,6 @@ function getRegisteredRuleIds(plugins) {
 function getPluginFlags(plugins) {
   const flagsByPlugin = new Map([
     ['import', '--import-plugin'],
-    ['jest', '--jest-plugin'],
     ['jsdoc', '--jsdoc-plugin'],
     ['jsx-a11y', '--jsx-a11y-plugin'],
     ['nextjs', '--nextjs-plugin'],

--- a/scripts/write-oxlint-all-rules.mjs
+++ b/scripts/write-oxlint-all-rules.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { execFileSync } from 'node:child_process'
-import { existsSync, readFileSync, writeFileSync } from 'node:fs'
+import { readFileSync, writeFileSync } from 'node:fs'
 import { dirname, relative, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
@@ -22,7 +22,7 @@ const rules = Object.fromEntries(
   (ruleIds.length > 0 ? ruleIds : getRegisteredRuleIds(plugins)).map((ruleId) => [ruleId, 'error'])
 )
 
-const existingConfig = existsSync(configPath) ? readJson(configPath) : {}
+const existingConfig = readJsonIfExists(configPath)
 const nextConfig = {
   $schema: existingConfig.$schema ?? './node_modules/oxlint/configuration_schema.json',
   plugins,
@@ -38,6 +38,18 @@ console.log(
 
 function readJson(path) {
   return JSON.parse(readFileSync(path, 'utf8'))
+}
+
+function readJsonIfExists(path) {
+  try {
+    return readJson(path)
+  } catch (error) {
+    if (error?.code === 'ENOENT') {
+      return {}
+    }
+
+    throw error
+  }
 }
 
 function omitKeys(object, keys) {


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Remove jest plugin flag from oxlint rule script and update tooling config
- Removes the `--jest-plugin` flag mapping from `getPluginFlags` in [write-oxlint-all-rules.mjs](https://github.com/hbmartin/react-mentions-ts/pull/192/files#diff-daf8d37c2ccf5c81f7db541b4cdbd0b4c14bd3ba34a176e741c2a0aa7a8f30a2), so jest is no longer passed as a CLI flag to oxlint.
- Replaces `existsSync`-based config reading with a new `readJsonIfExists` helper that catches `ENOENT` gracefully.
- Simplifies `projectRoot` derivation using `import.meta.dirname` instead of `fileURLToPath`.
- Replaces `jest` with `vitest` in the TypeScript server implicit project types in [settings.json](https://github.com/hbmartin/react-mentions-ts/pull/192/files#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357).

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 092bb90.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development tooling configuration from jest to vitest for improved type checking support.
  * Improved internal configuration management and error handling in build scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->