### PR TITLE
Add insertText(text: string) method on the MentionsInput class - closes #132

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,17 @@ The `MentionsInput` component supports the following props:
 - `mentionId`: the identifier of the mention that triggered the change when the `trigger.type` is mention-specific (e.g. `'mention-add'`); otherwise `undefined`
 - `mentions`: the mention occurrences extracted from the new value
 - `previousValue`: the markup string before the change
-- `trigger`: metadata about what caused the change. `trigger.type` is one of `'input'`, `'paste'`, `'cut'`, `'mention-add'`, or `'mention-remove'`, and, when available, `trigger.nativeEvent` references the originating DOM event (optional; do not rely on its exact shape). Regular text edits (typing, Backspace/Delete) use `trigger.type: 'input'`.
+- `trigger`: metadata about what caused the change. `trigger.type` is one of `'input'`, `'paste'`, `'cut'`, `'mention-add'`, `'mention-remove'`, or `'insert-text'`, and, when available, `trigger.nativeEvent` references the originating DOM event (optional; do not rely on its exact shape). Regular text edits (typing, Backspace/Delete) use `trigger.type: 'input'`.
+
+#### Imperative API
+
+Attach a ref to `MentionsInput` when you need to programmatically insert text at the current caret position or replace the current selection:
+
+```tsx
+const mentionsRef = useRef<MentionsInput>(null)
+
+mentionsRef.current?.insertText('anything')
+```
 
 #### onMentionSelectionChange payload
 

--- a/scripts/write-oxlint-all-rules.mjs
+++ b/scripts/write-oxlint-all-rules.mjs
@@ -2,8 +2,6 @@
 
 import { execFileSync } from 'node:child_process'
 import { readFileSync, writeFileSync } from 'node:fs'
-import { dirname, relative, resolve } from 'node:path'
-import { fileURLToPath } from 'node:url'
 
 const projectRoot = resolve(import.meta.dirname, '..')
 const [schemaArgument, configArgument] = process.argv.slice(2)

--- a/src/MentionsInput.spec.tsx
+++ b/src/MentionsInput.spec.tsx
@@ -2234,6 +2234,130 @@ describe('MentionsInput', () => {
     })
   })
 
+  describe('insertText', () => {
+    it('inserts plain text at the current caret position', async () => {
+      const ref = React.createRef<MentionsInput>()
+
+      function ControlledMentionsInput() {
+        const [value, setValue] = React.useState('Hello world')
+
+        return (
+          <MentionsInput
+            ref={ref}
+            value={value}
+            onMentionsChange={({ value: nextValue }) => setValue(nextValue)}
+          >
+            <Mention trigger="@" data={data} />
+          </MentionsInput>
+        )
+      }
+
+      render(<ControlledMentionsInput />)
+
+      const textarea = screen.getByRole<HTMLTextAreaElement>('combobox')
+      textarea.setSelectionRange('Hello'.length, 'Hello'.length)
+
+      act(() => {
+        ref.current?.insertText(', typed')
+      })
+
+      await waitFor(() => {
+        expect(textarea).toHaveValue('Hello, typed world')
+        expect(textarea.selectionStart).toBe('Hello, typed'.length)
+        expect(textarea.selectionEnd).toBe('Hello, typed'.length)
+      })
+    })
+
+    it('replaces the current selection', async () => {
+      const ref = React.createRef<MentionsInput>()
+
+      function ControlledMentionsInput() {
+        const [value, setValue] = React.useState('Hello world')
+
+        return (
+          <MentionsInput
+            ref={ref}
+            value={value}
+            onMentionsChange={({ value: nextValue }) => setValue(nextValue)}
+          >
+            <Mention trigger="@" data={data} />
+          </MentionsInput>
+        )
+      }
+
+      render(<ControlledMentionsInput />)
+
+      const textarea = screen.getByRole<HTMLTextAreaElement>('combobox')
+      const selectionStart = 'Hello '.length
+      const selectionEnd = 'Hello world'.length
+      textarea.setSelectionRange(selectionStart, selectionEnd)
+
+      act(() => {
+        ref.current?.insertText('there')
+      })
+
+      await waitFor(() => {
+        expect(textarea).toHaveValue('Hello there')
+        expect(textarea.selectionStart).toBe('Hello there'.length)
+        expect(textarea.selectionEnd).toBe('Hello there'.length)
+      })
+    })
+
+    it('emits mention-remove when inserted text replaces a mention', () => {
+      const ref = React.createRef<MentionsInput>()
+      const onMentionsChange = vi.fn()
+      const onRemove = vi.fn()
+
+      render(
+        <MentionsInput ref={ref} value="Hello @[First](first)" onMentionsChange={onMentionsChange}>
+          <Mention trigger="@[__display__](__id__)" data={data} onRemove={onRemove} />
+        </MentionsInput>
+      )
+
+      const textarea = screen.getByRole<HTMLTextAreaElement>('combobox')
+      const selectionStart = 'Hello '.length
+      const selectionEnd = 'Hello First'.length
+      textarea.setSelectionRange(selectionStart, selectionEnd)
+
+      act(() => {
+        ref.current?.insertText('replacement')
+      })
+
+      const payload = getLastMentionsChange(onMentionsChange)
+      expect(payload.trigger.type).toBe('mention-remove')
+      expect(payload.mentionId).toBe('first')
+      expect(payload.value).toBe('Hello replacement')
+      expect(onRemove).toHaveBeenCalledWith('first')
+    })
+
+    it('emits insert-text changes, refreshes suggestions, and supports typed refs', async () => {
+      const ref = React.createRef<MentionsInput>()
+      const onMentionsChange = vi.fn()
+
+      render(
+        <MentionsInput ref={ref} value="Hello" onMentionsChange={onMentionsChange}>
+          <Mention trigger="@" data={data} />
+        </MentionsInput>
+      )
+
+      const textarea = screen.getByRole<HTMLTextAreaElement>('combobox')
+      textarea.setSelectionRange('Hello'.length, 'Hello'.length)
+
+      act(() => {
+        ref.current?.insertText(' @')
+      })
+
+      const payload = getLastMentionsChange(onMentionsChange)
+      expect(payload.trigger.type).toBe('insert-text')
+      expect(payload.value).toBe('Hello @')
+      expect(payload.plainTextValue).toBe('Hello @')
+
+      await waitFor(() => {
+        expect(screen.getAllByRole('option', { hidden: true })).toHaveLength(data.length)
+      })
+    })
+  })
+
   describe('mention selection change', () => {
     const mentionMarkup = '@[First](first)'
     const mentionDisplay = 'First'

--- a/src/MentionsInput.tsx
+++ b/src/MentionsInput.tsx
@@ -44,6 +44,7 @@ import SuggestionsOverlay from './SuggestionsOverlay'
 import {
   applyCutToMentionsValue,
   applyInputChangeToMentionsValue,
+  applyInsertTextToMentionsValue,
   applyPasteToMentionsValue,
   getMarkupSelectionRange,
 } from './MentionsInputEditing'
@@ -1218,6 +1219,46 @@ class MentionsInput<
     }
   }
 
+  insertText = (text: string): void => {
+    const input = this.inputElement
+    const selectionStart = input?.selectionStart ?? this.state.selectionStart
+    const selectionEnd = input?.selectionEnd ?? this.state.selectionEnd
+    const value = this.props.value ?? ''
+    const config = this.getCurrentConfig()
+    const previousSnapshot = this.getCurrentSnapshot(value, config)
+    const insertResult = applyInsertTextToMentionsValue<Extra>(
+      value,
+      config,
+      selectionStart,
+      selectionEnd,
+      text
+    )
+
+    this.cacheSnapshot(insertResult.value, config, insertResult.snapshot)
+    input?.focus()
+    this.setState({
+      selectionStart: insertResult.nextSelectionStart,
+      selectionEnd: insertResult.nextSelectionStart,
+      pendingSelectionUpdate: true,
+    })
+
+    this.executeOnChange(
+      { type: 'insert-text' },
+      insertResult.value,
+      insertResult.snapshot,
+      value,
+      previousSnapshot,
+      config
+    )
+
+    this.updateMentionsQueries(
+      insertResult.snapshot.plainText,
+      insertResult.nextSelectionStart,
+      insertResult.value
+    )
+    this.requestHighlighterScrollSync()
+  }
+
   handlePaste = (event: ClipboardEvent): void => {
     if (event.target !== this.inputElement) {
       return
@@ -1706,9 +1747,9 @@ class MentionsInput<
 
   private getActiveSuggestionQueries(
     plainTextValue: string,
-    caretPosition: number
+    caretPosition: number,
+    value: string = this.props.value ?? ''
   ): ActiveSuggestionQuery<Extra>[] {
-    const value = this.props.value ?? ''
     const mentionChildren = this.getMentionChildren()
     const config = this.getCurrentConfig()
     const positionInValue = mapPlainTextIndex(value, config, caretPosition, 'NULL')
@@ -1847,8 +1888,8 @@ class MentionsInput<
     executeQuery()
   }
 
-  updateMentionsQueries = (plainTextValue: string, caretPosition: number): void => {
-    const activeQueries = this.getActiveSuggestionQueries(plainTextValue, caretPosition)
+  updateMentionsQueries = (plainTextValue: string, caretPosition: number, value?: string): void => {
+    const activeQueries = this.getActiveSuggestionQueries(plainTextValue, caretPosition, value)
 
     // Invalidate previous queries. Async results for previous queries will be neglected.
     const queryId = this._queryId + 1

--- a/src/MentionsInputEditing.spec.tsx
+++ b/src/MentionsInputEditing.spec.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { Mention } from './index'
 import {
   applyInputChangeToMentionsValue,
+  applyInsertTextToMentionsValue,
   applyCutToMentionsValue,
   applyPasteToMentionsValue,
   getMarkupSelectionRange,
@@ -27,6 +28,20 @@ describe('MentionsInputEditing', () => {
     expect(result.snapshot.plainText).toBe('Walter White')
     expect(result.snapshot.mentions[0]?.id).toBe('user:walter')
     expect(result.nextSelectionStart).toBe('Walter White'.length)
+  })
+
+  it('derives the next snapshot when inserting text', () => {
+    const result = applyInsertTextToMentionsValue(
+      'Hello ',
+      config,
+      6,
+      6,
+      '@[Walter White](user:walter)'
+    )
+
+    expect(result.value).toBe('Hello @[Walter White](user:walter)')
+    expect(result.snapshot.plainText).toBe('Hello Walter White')
+    expect(result.nextSelectionStart).toBe('Hello Walter White'.length)
   })
 
   it('normalizes only the pasted payload when removing carriage returns', () => {

--- a/src/MentionsInputEditing.ts
+++ b/src/MentionsInputEditing.ts
@@ -28,6 +28,9 @@ export interface CutResult<Extra extends Record<string, unknown> = Record<string
   nextSelectionStart: number
 }
 
+export type InsertTextResult<Extra extends Record<string, unknown> = Record<string, unknown>> =
+  PasteResult<Extra>
+
 export interface InputChangeResult<
   Extra extends Record<string, unknown> = Record<string, unknown>,
 > extends PasteResult<Extra> {
@@ -52,21 +55,21 @@ export const getMarkupSelectionRange = <Extra extends Record<string, unknown>>(
   }
 }
 
-export const applyPasteToMentionsValue = <Extra extends Record<string, unknown>>(
+export const applyInsertTextToMentionsValue = <Extra extends Record<string, unknown>>(
   value: string,
   config: ReadonlyArray<MentionChildConfig<Extra>>,
   selectionStart: number | null,
   selectionEnd: number | null,
-  pastedText: string
-): PasteResult<Extra> => {
+  text: string
+): InsertTextResult<Extra> => {
   const { safeSelectionStart, markupStartIndex, markupEndIndex } = getMarkupSelectionRange(
     value,
     config,
     selectionStart,
     selectionEnd
   )
-  const normalizedPastedText = pastedText.replaceAll('\r', '')
-  const nextValue = spliceString(value, markupStartIndex, markupEndIndex, normalizedPastedText)
+  const normalizedText = text.replaceAll('\r', '')
+  const nextValue = spliceString(value, markupStartIndex, markupEndIndex, normalizedText)
   const snapshot = deriveMentionValueSnapshot<Extra>(nextValue, config)
   const startOfMention =
     selectionStart === null
@@ -77,8 +80,18 @@ export const applyPasteToMentionsValue = <Extra extends Record<string, unknown>>
     value: nextValue,
     snapshot,
     nextSelectionStart:
-      (startOfMention ?? safeSelectionStart) + getPlainText(normalizedPastedText, config).length,
+      (startOfMention ?? safeSelectionStart) + getPlainText(normalizedText, config).length,
   }
+}
+
+export const applyPasteToMentionsValue = <Extra extends Record<string, unknown>>(
+  value: string,
+  config: ReadonlyArray<MentionChildConfig<Extra>>,
+  selectionStart: number | null,
+  selectionEnd: number | null,
+  pastedText: string
+): PasteResult<Extra> => {
+  return applyInsertTextToMentionsValue(value, config, selectionStart, selectionEnd, pastedText)
 }
 
 export const applyCutToMentionsValue = <Extra extends Record<string, unknown>>(

--- a/src/types.ts
+++ b/src/types.ts
@@ -136,6 +136,7 @@ export type MentionsInputChangeTriggerType =
   | 'cut'
   | 'mention-add'
   | 'mention-remove'
+  | 'insert-text'
 
 export interface MentionsInputChangeTrigger {
   type: MentionsInputChangeTriggerType


### PR DESCRIPTION
Consumers can call mentionRef.current?.insertText("anything") to replace the current selection or insert at the current caret position.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `insertText(text)` imperative method to `MentionsInput`
> - Adds a public `insertText(text)` method on the `MentionsInput` class, accessible via a typed ref, that inserts or replaces text at the current selection.
> - Introduces `applyInsertTextToMentionsValue` in [MentionsInputEditing.ts](https://github.com/hbmartin/react-mentions-ts/pull/193/files#diff-b3df56b82bd73708ab9a02bc16bbc028e36890ace15abeb4293a47d4a6bf55c9) as the core insertion primitive; `applyPasteToMentionsValue` is refactored to delegate to it.
> - After insertion, the input is focused, the caret moves to the end of the inserted text, suggestions are refreshed against the new value, and `onMentionsChange` fires with `trigger.type: 'insert-text'`.
> - Extends the `MentionsInputChangeTriggerType` union in [types.ts](https://github.com/hbmartin/react-mentions-ts/pull/193/files#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410a) with the new `'insert-text'` discriminator.
> - Risk: `scripts/write-oxlint-all-rules.mjs` removes imports for `resolve` but still references it, causing a `ReferenceError` at runtime when that script is run.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 493de9a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added imperative API allowing programmatic text insertion/replacement at the current caret position via a ref method.
  * Extended change event triggers to include `'insert-text'` type for distinguishing programmatic text operations.

* **Documentation**
  * Updated payload documentation for change events to reflect new trigger type and new imperative API capabilities.

* **Tests**
  * Added comprehensive test coverage for text insertion, including caret positioning, selection replacement, and mention handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->