### PR TITLE
Normalized CRLF and lone CR inserted text to `\n`

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,15 @@ Attach a ref to `MentionsInput` when you need to programmatically insert text at
 
 ```tsx
 const mentionsRef = useRef<MentionsInput>(null)
+const [value, setValue] = useState('')
+
+<MentionsInput
+  ref={mentionsRef}
+  value={value}
+  onMentionsChange={({ value: nextValue }) => setValue(nextValue)}
+>
+  <Mention trigger="@" data={users} />
+</MentionsInput>
 
 mentionsRef.current?.insertText('anything')
 ```

--- a/scripts/write-oxlint-all-rules.mjs
+++ b/scripts/write-oxlint-all-rules.mjs
@@ -2,6 +2,7 @@
 
 import { execFileSync } from 'node:child_process'
 import { readFileSync, writeFileSync } from 'node:fs'
+import { relative, resolve } from 'node:path'
 
 const projectRoot = resolve(import.meta.dirname, '..')
 const [schemaArgument, configArgument] = process.argv.slice(2)

--- a/src/MentionsInput.spec.tsx
+++ b/src/MentionsInput.spec.tsx
@@ -2334,11 +2334,24 @@ describe('MentionsInput', () => {
       const ref = React.createRef<MentionsInput>()
       const onMentionsChange = vi.fn()
 
-      render(
-        <MentionsInput ref={ref} value="Hello" onMentionsChange={onMentionsChange}>
-          <Mention trigger="@" data={data} />
-        </MentionsInput>
-      )
+      function ControlledMentionsInput() {
+        const [value, setValue] = React.useState('Hello')
+
+        return (
+          <MentionsInput
+            ref={ref}
+            value={value}
+            onMentionsChange={(change) => {
+              onMentionsChange(change)
+              setValue(change.value)
+            }}
+          >
+            <Mention trigger="@" data={data} />
+          </MentionsInput>
+        )
+      }
+
+      render(<ControlledMentionsInput />)
 
       const textarea = screen.getByRole<HTMLTextAreaElement>('combobox')
       textarea.setSelectionRange('Hello'.length, 'Hello'.length)
@@ -2351,6 +2364,10 @@ describe('MentionsInput', () => {
       expect(payload.trigger.type).toBe('insert-text')
       expect(payload.value).toBe('Hello @')
       expect(payload.plainTextValue).toBe('Hello @')
+
+      await waitFor(() => {
+        expect(textarea).toHaveValue('Hello @')
+      })
 
       await waitFor(() => {
         expect(screen.getAllByRole('option', { hidden: true })).toHaveLength(data.length)

--- a/src/MentionsInputEditing.spec.tsx
+++ b/src/MentionsInputEditing.spec.tsx
@@ -44,13 +44,21 @@ describe('MentionsInputEditing', () => {
     expect(result.nextSelectionStart).toBe('Hello Walter White'.length)
   })
 
-  it('normalizes only the pasted payload when removing carriage returns', () => {
+  it('normalizes only the pasted payload when converting CRLF to LF', () => {
     const value = 'Keep\r\nline'
     const result = applyPasteToMentionsValue(value, config, value.length, value.length, '\r\nnext')
 
     expect(result.value).toBe('Keep\r\nline\nnext')
     expect(result.snapshot.plainText).toBe('Keep\r\nline\nnext')
     expect(result.nextSelectionStart).toBe('Keep\r\nline\nnext'.length)
+  })
+
+  it('normalizes lone carriage returns in inserted text', () => {
+    const result = applyInsertTextToMentionsValue('Hello', config, 5, 5, '\rthere')
+
+    expect(result.value).toBe('Hello\nthere')
+    expect(result.snapshot.plainText).toBe('Hello\nthere')
+    expect(result.nextSelectionStart).toBe('Hello\nthere'.length)
   })
 
   it('cuts mention markup while restoring the caret to the selection start', () => {

--- a/src/MentionsInputEditing.ts
+++ b/src/MentionsInputEditing.ts
@@ -68,7 +68,7 @@ export const applyInsertTextToMentionsValue = <Extra extends Record<string, unkn
     selectionStart,
     selectionEnd
   )
-  const normalizedText = text.replaceAll('\r', '')
+  const normalizedText = text.replaceAll(/\r\n?/g, '\n')
   const nextValue = spliceString(value, markupStartIndex, markupEndIndex, normalizedText)
   const snapshot = deriveMentionValueSnapshot<Extra>(nextValue, config)
   const startOfMention =


### PR DESCRIPTION
Made the README insertText ref example runnable.
Updated the suggestion-refresh test to apply the controlled value before asserting suggestions. Restored relative/resolve imports in scripts/write-oxlint-all-rules.mjs.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Normalize CRLF and lone CR to `\n` in `applyInsertTextToMentionsValue`
> Changes the inserted text normalization in [MentionsInputEditing.ts](https://github.com/hbmartin/react-mentions-ts/pull/195/files#diff-b3df56b82bd73708ab9a02bc16bbc028e36890ace15abeb4293a47d4a6bf55c9) from stripping all `\r` characters to replacing both `\r\n` and lone `\r` with `\n`. This fixes lone carriage returns being silently dropped instead of treated as newlines.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3795586.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated example demonstrating controlled component usage with MentionsInput.

* **Bug Fixes**
  * Fixed line ending handling to normalize CRLF and CR sequences to LF in inserted text.

* **Tests**
  * Enhanced test coverage for controlled component pattern and line ending normalization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->