### PR TITLE
Pagination and mouseover key nav fixes

### DIFF
--- a/src/MentionsInput.spec.tsx
+++ b/src/MentionsInput.spec.tsx
@@ -343,6 +343,46 @@ describe('MentionsInput', () => {
     expect(activeDescendant).toBe(refreshedSuggestions[1].id)
   })
 
+  it('keeps arrow-key navigation ahead of a stationary hovered suggestion.', async () => {
+    render(
+      <MentionsInput value="@">
+        <Mention trigger="@" data={data} />
+      </MentionsInput>
+    )
+
+    const combobox = screen.getByRole('combobox')
+    fireEvent.focus(combobox)
+    combobox.setSelectionRange(1, 1)
+    fireEvent.select(combobox)
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('option', { hidden: true })).toHaveLength(data.length)
+    })
+
+    let suggestions = screen.getAllByRole('option', { hidden: true })
+    fireEvent.mouseEnter(suggestions[1], { clientX: 20, clientY: 20 })
+
+    await waitFor(() => {
+      suggestions = screen.getAllByRole('option', { hidden: true })
+      expect(suggestions[1]).toHaveAttribute('aria-selected', 'true')
+    })
+
+    fireEvent.keyDown(combobox, { key: 'ArrowDown', keyCode: 40 })
+
+    suggestions = screen.getAllByRole('option', { hidden: true })
+    expect(suggestions[2]).toHaveAttribute('aria-selected', 'true')
+
+    fireEvent.mouseEnter(suggestions[1], { clientX: 20, clientY: 20 })
+
+    suggestions = screen.getAllByRole('option', { hidden: true })
+    expect(suggestions[2]).toHaveAttribute('aria-selected', 'true')
+
+    fireEvent.keyDown(combobox, { key: 'ArrowDown', keyCode: 40 })
+
+    suggestions = screen.getAllByRole('option', { hidden: true })
+    expect(suggestions[0]).toHaveAttribute('aria-selected', 'true')
+  })
+
   it('should be possible to select a suggestion with enter.', async () => {
     const onMentionsChange = vi.fn()
 
@@ -935,17 +975,19 @@ describe('MentionsInput', () => {
     scrollSuggestionsNearBottom()
 
     await waitFor(() => {
+      expect(firstAsyncData).toHaveBeenCalledWith(
+        'a',
+        expect.objectContaining({ cursor: 'first-cursor-2', reason: 'page' })
+      )
+      expect(secondAsyncData).toHaveBeenCalledWith(
+        'a',
+        expect.objectContaining({ cursor: 'second-cursor-2', reason: 'page' })
+      )
+    })
+    await waitFor(() => {
       expect(screen.getByText('First Page 2')).toBeInTheDocument()
       expect(screen.getByText('Second Page 2')).toBeInTheDocument()
     })
-    expect(firstAsyncData).toHaveBeenCalledWith(
-      'a',
-      expect.objectContaining({ cursor: 'first-cursor-2', reason: 'page' })
-    )
-    expect(secondAsyncData).toHaveBeenCalledWith(
-      'a',
-      expect.objectContaining({ cursor: 'second-cursor-2', reason: 'page' })
-    )
   })
 
   it('replaces the latest query range when selecting a preserved async suggestion.', async () => {

--- a/src/MentionsInput.tsx
+++ b/src/MentionsInput.tsx
@@ -89,6 +89,7 @@ import type {
   MentionsInputState,
   MentionsInputClassNames,
   MentionsInputChangeTrigger,
+  MentionPageCursor,
   NormalizedMentionDataPage,
   QueryInfo,
   SuggestionDataItem,
@@ -1907,7 +1908,7 @@ class MentionsInput<
     queryInfo: QueryInfo,
     mentionChild: React.ReactElement<MentionComponentProps<Extra>>,
     ignoreAccents: boolean,
-    cursor: unknown
+    cursor: MentionPageCursor
   ): void {
     if (this._loadingPageChildren.has(childIndex)) {
       return
@@ -1958,18 +1959,16 @@ class MentionsInput<
     for (const [childIndex, queryState] of getSuggestionQueryStateEntries(this.state.queryStates)) {
       const { pagination } = queryState
 
-      if (
-        queryState.status !== 'success' ||
-        !pagination?.hasMore ||
-        pagination.isLoading ||
-        pagination.nextCursor === null ||
-        pagination.nextCursor === undefined
-      ) {
+      if (queryState.status !== 'success' || pagination === undefined) {
         continue
       }
 
-      const mentionChild = mentionChildren[childIndex]
-      if (!mentionChild) {
+      if (!pagination.hasMore || pagination.isLoading || pagination.nextCursor === null) {
+        continue
+      }
+
+      const mentionChild = mentionChildren.at(childIndex)
+      if (mentionChild === undefined) {
         continue
       }
 
@@ -2089,13 +2088,15 @@ class MentionsInput<
     results: NormalizedMentionDataPage<Extra> | Promise<NormalizedMentionDataPage<Extra>>,
     controller: AbortController
   ): Promise<void> => {
+    const isStaleRequest = () => queryId !== this._queryId || controller.signal.aborted
+
     try {
-      if (queryId !== this._queryId || controller.signal.aborted) {
+      if (isStaleRequest()) {
         return
       }
 
       const page = await Promise.resolve(results)
-      if (queryId !== this._queryId || controller.signal.aborted) {
+      if (isStaleRequest()) {
         return
       }
 
@@ -2110,7 +2111,7 @@ class MentionsInput<
         )
       )
     } catch (error) {
-      if (queryId !== this._queryId || controller.signal.aborted || isAbortError(error)) {
+      if (isStaleRequest() || isAbortError(error)) {
         return
       }
 

--- a/src/MentionsInputQueryState.ts
+++ b/src/MentionsInputQueryState.ts
@@ -89,9 +89,17 @@ export const applyLoadingPageResult = <Extra extends Record<string, unknown>>(
   childIndex: number,
   focusIndex: number
 ): SuggestionsLifecycleState<Extra> => {
+  if (!Object.hasOwn(currentQueryStates, childIndex)) {
+    return {
+      suggestions: currentSuggestions,
+      queryStates: currentQueryStates,
+      focusIndex,
+    }
+  }
+
   const currentQueryState = currentQueryStates[childIndex]
 
-  if (!currentQueryState?.pagination) {
+  if (currentQueryState.pagination === undefined) {
     return {
       suggestions: currentSuggestions,
       queryStates: currentQueryStates,
@@ -124,7 +132,9 @@ export const applySuccessfulPageResult = <Extra extends Record<string, unknown>>
   page: NormalizedMentionDataPage<Extra>,
   focusIndex: number
 ): SuggestionsLifecycleState<Extra> => {
-  const previousResults = currentSuggestions[childIndex]?.results ?? []
+  const previousResults = Object.hasOwn(currentSuggestions, childIndex)
+    ? currentSuggestions[childIndex].results
+    : []
   const results = [...previousResults, ...page.items]
   const suggestions: SuggestionsMap<Extra> = {
     ...currentSuggestions,
@@ -141,7 +151,7 @@ export const applySuccessfulPageResult = <Extra extends Record<string, unknown>>
     queryStates: {
       ...currentQueryStates,
       [childIndex]: {
-        ...(currentQueryStates[childIndex] ?? {}),
+        ...currentQueryStates[childIndex],
         queryInfo,
         results,
         status: 'success',
@@ -162,9 +172,17 @@ export const applyErroredPageResult = <Extra extends Record<string, unknown>>(
   error: unknown,
   focusIndex: number
 ): SuggestionsLifecycleState<Extra> => {
+  if (!Object.hasOwn(currentQueryStates, childIndex)) {
+    return {
+      suggestions: currentSuggestions,
+      queryStates: currentQueryStates,
+      focusIndex,
+    }
+  }
+
   const currentQueryState = currentQueryStates[childIndex]
 
-  if (!currentQueryState?.pagination) {
+  if (currentQueryState.pagination === undefined) {
     return {
       suggestions: currentSuggestions,
       queryStates: currentQueryStates,

--- a/src/Suggestion.tsx
+++ b/src/Suggestion.tsx
@@ -7,7 +7,7 @@ interface SuggestionProps<Extra extends Record<string, unknown> = Record<string,
   readonly focused?: boolean
   readonly index: number
   readonly onClick: () => void
-  readonly onMouseEnter: () => void
+  readonly onMouseEnter: React.MouseEventHandler<HTMLLIElement>
   readonly query: string
   readonly renderSuggestion?: MentionRenderSuggestion<Extra> | null
   readonly suggestion: SuggestionDataItem<Extra>

--- a/src/SuggestionsOverlay.spec.tsx
+++ b/src/SuggestionsOverlay.spec.tsx
@@ -724,13 +724,13 @@ describe('SuggestionsOverlay', () => {
 
     const listItems = container.querySelectorAll('li[role="option"]')
 
-    fireEvent.mouseEnter(listItems[0])
+    fireEvent.mouseEnter(listItems[0], { clientX: 10, clientY: 10 })
     expect(onMouseEnter).toHaveBeenCalledWith(0)
 
-    fireEvent.mouseEnter(listItems[1])
+    fireEvent.mouseEnter(listItems[1], { clientX: 10, clientY: 30 })
     expect(onMouseEnter).toHaveBeenCalledWith(1)
 
-    fireEvent.mouseEnter(listItems[2])
+    fireEvent.mouseEnter(listItems[2], { clientX: 10, clientY: 50 })
     expect(onMouseEnter).toHaveBeenCalledWith(2)
   })
 

--- a/src/SuggestionsOverlay.tsx
+++ b/src/SuggestionsOverlay.tsx
@@ -1,4 +1,4 @@
-import React, { useLayoutEffect, useMemo, useState } from 'react'
+import React, { useLayoutEffect, useMemo, useRef, useState } from 'react'
 import type { CSSProperties } from 'react'
 import { cva } from 'class-variance-authority'
 import LoadingIndicator from './LoadingIndicator'
@@ -58,6 +58,20 @@ const overlayStyles = cva(
 const listStyles =
   'm-0 max-h-64 list-none divide-y divide-border overflow-y-auto scroll-py-1 p-0 focus:outline-none'
 const loadMoreThresholdPx = 48
+
+interface MousePosition {
+  readonly clientX: number
+  readonly clientY: number
+}
+
+const didMousePositionChange = (
+  previousPosition: MousePosition | null,
+  nextPosition: MousePosition
+): boolean =>
+  previousPosition === null ||
+  previousPosition.clientX !== nextPosition.clientX ||
+  previousPosition.clientY !== nextPosition.clientY
+
 const statusStyles = cva('px-4 py-2.5 text-left text-sm leading-relaxed', {
   variants: {
     type: {
@@ -106,6 +120,7 @@ function SuggestionsOverlay<Extra extends Record<string, unknown> = Record<strin
   statusType,
 }: SuggestionsOverlayProps<Extra>) {
   const [ulElement, setUlElement] = useState<HTMLUListElement | null>(null)
+  const lastMouseEnterPosition = useRef<MousePosition | null>(null)
   const mentionChildren = useMemo(
     () => mentionChildrenProp ?? collectMentionElements(children),
     [children, mentionChildrenProp]
@@ -153,8 +168,27 @@ function SuggestionsOverlay<Extra extends Record<string, unknown> = Record<strin
     }
   )
 
-  const handleMouseEnter = useEventCallback((index: number) => {
-    onMouseEnter?.(index)
+  const handleMouseEnter = useEventCallback(
+    (index: number, event: React.MouseEvent<HTMLLIElement>) => {
+      const nextMousePosition = { clientX: event.clientX, clientY: event.clientY }
+
+      if (!didMousePositionChange(lastMouseEnterPosition.current, nextMousePosition)) {
+        return
+      }
+
+      lastMouseEnterPosition.current = nextMousePosition
+      onMouseEnter?.(index)
+    }
+  )
+
+  const handleMouseEnterAtIndex = useEventCallback((index: number) => {
+    return (event: React.MouseEvent<HTMLLIElement>) => {
+      handleMouseEnter(index, event)
+    }
+  })
+
+  const handleListMouseLeave = useEventCallback<React.MouseEventHandler<HTMLUListElement>>(() => {
+    lastMouseEnterPosition.current = null
   })
 
   const flattenedSuggestions = useMemo<FlattenedSuggestion<Extra>[]>(() => {
@@ -174,12 +208,18 @@ function SuggestionsOverlay<Extra extends Record<string, unknown> = Record<strin
         isFocused,
         renderSuggestionFromChild,
         onClick: () => selectSuggestion(suggestionItem, queryInfo),
-        onMouseEnterHandler: () => handleMouseEnter(index),
+        onMouseEnterHandler: handleMouseEnterAtIndex(index),
         query,
         index,
       }
     })
-  }, [childRenderSuggestions, focusIndex, flattenedSuggestions, handleMouseEnter, selectSuggestion])
+  }, [
+    childRenderSuggestions,
+    focusIndex,
+    flattenedSuggestions,
+    handleMouseEnterAtIndex,
+    selectSuggestion,
+  ])
 
   const handleListMouseDown = useEventCallback<React.MouseEventHandler<HTMLUListElement>>(
     (event) => {
@@ -206,6 +246,7 @@ function SuggestionsOverlay<Extra extends Record<string, unknown> = Record<strin
         className={listClassNameResolved}
         data-slot="suggestions-list"
         onMouseDown={handleListMouseDown}
+        onMouseLeave={handleListMouseLeave}
         onScroll={handleListScroll}
       >
         {suggestionEntries.map(


### PR DESCRIPTION
src/types.ts: real non-nullish MentionPageCursor, optional reason.
src/MentionsInputSelectors.ts: abort checks before provider invocation and after async resolution.
src/SuggestionsOverlay.tsx: no repeated load-more calls while loading.
src/MentionsInput.tsx: reuses query-local ignoreAccents for pagination instead of resolving the trigger again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added mouse movement tracking to optimize suggestion hover interactions.

* **Bug Fixes**
  * Fixed arrow key navigation to continue properly when suggestions are hovered.
  * Improved pagination state and error handling with stronger defensive guards.

* **Tests**
  * Enhanced test coverage for keyboard navigation and async pagination behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix keyboard navigation in suggestions overlay being overridden by stationary mouse hover
> - Adds a `didMousePositionChange` helper in [SuggestionsOverlay.tsx](https://github.com/hbmartin/react-mentions-ts/pull/198/files#diff-8d2b85b42eafe864e1f94902263195848ee9436d546b75c7baae1384f02e7f8a) that compares `clientX`/`clientY` coordinates; `handleMouseEnter` now only triggers focus changes when the pointer actually moves, preventing stationary hover from overriding keyboard-driven selection.
> - Resets the tracked mouse position via `onMouseLeave` on the suggestions `<ul>` so suppression clears when the pointer leaves the list.
> - Fixes pagination query guards in [MentionsInput.tsx](https://github.com/hbmartin/react-mentions-ts/pull/198/files#diff-5324a6e48c1ed3e0637605dab500fd0e512b7917d46884c35cba8e68698b5473) to check `queryState.status`, `pagination.hasMore`, `pagination.isLoading`, and `pagination.nextCursor` independently, and uses `.at(childIndex)` with a defined-check before scheduling page queries.
> - Adds explicit `Object.hasOwn` guards in [MentionsInputQueryState.ts](https://github.com/hbmartin/react-mentions-ts/pull/198/files#diff-b59066a5e0773121a0ecf23c7947c70804bec622891e97a9b8eb924188ee5a16) across `applyLoadingPageResult`, `applySuccessfulPageResult`, and `applyErroredPageResult` to avoid accessing undefined query states.
> - Behavioral Change: `onMouseEnter` on suggestion items now receives a `React.MouseEvent<HTMLLIElement>` instead of no arguments, matching the updated `SuggestionProps` interface.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 8226e08. 4 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->