### PR TITLE
data loading race and staleness fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,20 +12,39 @@ A React component that enables Facebook/Twitter-style @mentions and tagging in t
 
 ### [Try out the live demos now!](https://hbmartin.github.io/react-mentions-ts/)
 
-## 🎯 Features
+## Table of Contents
 
-- ✅ **Flexible Triggers** - Use any character or pattern to trigger mentions (@, #, :, or custom)
-- 🎨 **Tailwind v4 Ready** - First-class support for Tailwind CSS v4 utility styling
-- ⚡ **Async Data Loading** - Load suggestions dynamically from APIs
-- 🔍 **Smart Suggestions** - Real-time filtering and matching
-- 🪄 **Caret Aware** - Detect when the caret overlaps mentions and style them via data attributes
-- ♿ **Accessible** - Built with ARIA labels and keyboard navigation
-- 🎯 **TypeScript First** - Written in TypeScript with complete type definitions
-- 🧪 **Well Tested** - Comprehensive test suite with Testing Library
-- 🌐 **SSR Compatible** - Works with Next.js and other SSR frameworks
-- 📱 **Mobile Friendly** - Touch-optimized for mobile devices
+- [Features](#features)
+- [Installation](#installation)
+- [Quick Start](#quick-start)
+- [How It Works](#how-it-works)
+- [Configuration](#configuration)
+  - [MentionsInput Props](#mentionsinput-props)
+  - [Mention Props](#mention-props)
+  - [Async Data Loading](#async-data-loading)
+- [More Examples](#more-examples)
+- [Advanced Usage](#advanced-usage)
+- [Styling](#styling)
+- [Testing](#testing)
+- [FAQ & Gotchas](#faq--gotchas)
+- [Migrating from react-mentions](#migrating-from-react-mentions)
+- [Contributing](#contributing)
+- [License](#license)
+- [Acknowledgments](#acknowledgments)
 
-## 📦 Installation
+## Features
+
+- **Flexible Triggers** — any character, string, or custom `RegExp` (`@`, `#`, `:`, or your own)
+- **Async Data Loading** — real-time filtering with debouncing, `AbortSignal` cancellation, and cursor pagination
+- **Caret Aware** — detect when the caret overlaps mentions and style them via `data-mention-selection`
+- **Inline Autocomplete** — ghost-text hints accepted with Tab, Enter, or arrow keys
+- **Tailwind v4 Ready** — first-class support for Tailwind CSS v4 utility styling
+- **TypeScript First** — written in TypeScript with complete type definitions
+- **Accessible** — built with ARIA labels and keyboard navigation
+- **SSR Compatible** — works with Next.js and other SSR frameworks
+- **Mobile Friendly** — touch-optimized for mobile devices
+
+## Installation
 
 ```bash
 # npm

--- a/src/MentionsInput.tsx
+++ b/src/MentionsInput.tsx
@@ -1816,7 +1816,7 @@ class MentionsInput<
         ? nextSuggestions[activeQuery.childIndex].results
         : []
       queryStates[activeQuery.childIndex] = {
-        ...createLoadingQueryState<Extra>(activeQuery.queryInfo),
+        ...createLoadingQueryState<Extra>(activeQuery.queryInfo, activeQuery.ignoreAccents),
         results: previousResults,
       }
       return queryStates
@@ -1844,13 +1844,6 @@ class MentionsInput<
 
       return nextSuggestions
     }, {})
-  }
-
-  private getIgnoreAccentsForMentionChild(
-    mentionChild: React.ReactElement<MentionComponentProps<Extra>>
-  ): boolean {
-    const triggerProp = mentionChild.props.trigger ?? '@'
-    return resolveTriggerRegex(triggerProp).flags.includes('u')
   }
 
   private scheduleSuggestionQuery(
@@ -1977,7 +1970,7 @@ class MentionsInput<
         childIndex,
         queryState.queryInfo,
         mentionChild,
-        this.getIgnoreAccentsForMentionChild(mentionChild),
+        queryState.ignoreAccents,
         pagination.nextCursor
       )
     }
@@ -2170,10 +2163,16 @@ class MentionsInput<
       displayValue += ' '
     }
     const newCaretPosition = querySequenceStart + displayValue.length
+    const clearedState = createClearedSuggestionsState<Extra>()
+    this._queryId++
+    this.clearPendingSuggestionRequests()
     this.setState({
       selectionStart: newCaretPosition,
       selectionEnd: newCaretPosition,
       pendingSelectionUpdate: true,
+      suggestions: clearedState.suggestions,
+      queryStates: clearedState.queryStates,
+      focusIndex: clearedState.focusIndex,
     })
 
     // Propagate change
@@ -2207,9 +2206,6 @@ class MentionsInput<
         serializerId: serializer.id,
       })
     }
-
-    // Make sure the suggestions overlay is closed
-    this.clearSuggestions()
   }
 
   isLoading = (): boolean => {

--- a/src/MentionsInputQueryState.spec.ts
+++ b/src/MentionsInputQueryState.spec.ts
@@ -18,10 +18,11 @@ const queryInfo = {
 
 describe('MentionsInputQueryState', () => {
   it('creates loading state with empty results by default', () => {
-    expect(createLoadingQueryState(queryInfo)).toEqual({
+    expect(createLoadingQueryState(queryInfo, true)).toEqual({
       queryInfo,
       results: [],
       status: 'loading',
+      ignoreAccents: true,
     })
   })
 
@@ -44,7 +45,14 @@ describe('MentionsInputQueryState', () => {
           ],
         },
       },
-      {},
+      {
+        0: {
+          queryInfo,
+          results: [],
+          status: 'loading',
+          ignoreAccents: true,
+        },
+      },
       0,
       queryInfo,
       {
@@ -60,6 +68,7 @@ describe('MentionsInputQueryState', () => {
     expect(nextState.focusIndex).toBe(0)
     expect(nextState.suggestions[0]?.results).toHaveLength(1)
     expect(nextState.queryStates[0]?.status).toBe('success')
+    expect(nextState.queryStates[0]?.ignoreAccents).toBe(true)
   })
 
   it('removes failed suggestions while keeping the latest error state', () => {
@@ -70,7 +79,14 @@ describe('MentionsInputQueryState', () => {
           results: [{ id: 'first', display: 'First' }],
         },
       },
-      {},
+      {
+        0: {
+          queryInfo,
+          results: [{ id: 'first', display: 'First' }],
+          status: 'loading',
+          ignoreAccents: true,
+        },
+      },
       0,
       queryInfo,
       new Error('boom'),
@@ -80,6 +96,7 @@ describe('MentionsInputQueryState', () => {
     expect(nextState.suggestions[0]).toBeUndefined()
     expect(nextState.focusIndex).toBe(0)
     expect(nextState.queryStates[0]?.status).toBe('error')
+    expect(nextState.queryStates[0]?.ignoreAccents).toBe(true)
   })
 
   it('clamps focus when an errored query removes the focused preserved results', () => {
@@ -97,7 +114,14 @@ describe('MentionsInputQueryState', () => {
           results: [{ id: 'third', display: 'Third' }],
         },
       },
-      {},
+      {
+        1: {
+          queryInfo: { ...queryInfo, childIndex: 1 },
+          results: [{ id: 'third', display: 'Third' }],
+          status: 'loading',
+          ignoreAccents: false,
+        },
+      },
       1,
       { ...queryInfo, childIndex: 1 },
       new Error('boom'),
@@ -151,6 +175,7 @@ describe('MentionsInputQueryState', () => {
           queryInfo,
           results: [{ id: 'first', display: 'First' }],
           status: 'success',
+          ignoreAccents: false,
           pagination: {
             nextCursor: 'cursor-2',
             hasMore: true,
@@ -179,6 +204,7 @@ describe('MentionsInputQueryState', () => {
           queryInfo,
           results: [{ id: 'first', display: 'First' }],
           status: 'success',
+          ignoreAccents: false,
           pagination: {
             nextCursor: 'cursor-2',
             hasMore: true,
@@ -208,6 +234,63 @@ describe('MentionsInputQueryState', () => {
     })
   })
 
+  it('ignores stale successful page results without current pagination state', () => {
+    const suggestions = {
+      0: {
+        queryInfo,
+        results: [{ id: 'first', display: 'First' }],
+      },
+    }
+    const queryStates = {
+      1: {
+        queryInfo: { ...queryInfo, childIndex: 1 },
+        results: [],
+        status: 'loading' as const,
+        ignoreAccents: false,
+      },
+    }
+
+    expect(
+      applySuccessfulPageResult(
+        suggestions,
+        queryStates,
+        0,
+        queryInfo,
+        {
+          items: [{ id: 'stale', display: 'Stale' }],
+          nextCursor: null,
+          hasMore: false,
+          paginated: true,
+        },
+        2
+      )
+    ).toEqual({
+      suggestions,
+      queryStates,
+      focusIndex: 2,
+    })
+
+    expect(
+      applySuccessfulPageResult(
+        suggestions,
+        queryStates,
+        1,
+        { ...queryInfo, childIndex: 1 },
+        {
+          items: [{ id: 'stale', display: 'Stale' }],
+          nextCursor: null,
+          hasMore: false,
+          paginated: true,
+        },
+        2
+      )
+    ).toEqual({
+      suggestions,
+      queryStates,
+      focusIndex: 2,
+    })
+  })
+
   it('keeps successful suggestions when a next page fails', () => {
     const error = new Error('boom')
     const nextState = applyErroredPageResult(
@@ -222,6 +305,7 @@ describe('MentionsInputQueryState', () => {
           queryInfo,
           results: [{ id: 'first', display: 'First' }],
           status: 'success',
+          ignoreAccents: false,
           pagination: {
             nextCursor: 'cursor-2',
             hasMore: true,

--- a/src/MentionsInputQueryState.ts
+++ b/src/MentionsInputQueryState.ts
@@ -24,11 +24,13 @@ export const createClearedSuggestionsState = <
 })
 
 export const createLoadingQueryState = <Extra extends Record<string, unknown>>(
-  queryInfo: QueryInfo
+  queryInfo: QueryInfo,
+  ignoreAccents: boolean
 ): SuggestionQueryState<Extra> => ({
   queryInfo,
   results: [],
   status: 'loading',
+  ignoreAccents,
 })
 
 export const isAbortError = (error: unknown): boolean =>
@@ -49,6 +51,9 @@ export const applySuccessfulQueryResult = <Extra extends Record<string, unknown>
   inlineAutocomplete: boolean
 ): SuggestionsLifecycleState<Extra> => {
   const results = page.items
+  const ignoreAccents = Object.hasOwn(currentQueryStates, childIndex)
+    ? currentQueryStates[childIndex].ignoreAccents
+    : false
   const suggestions: SuggestionsMap<Extra> = {
     ...currentSuggestions,
     [childIndex]: {
@@ -71,6 +76,7 @@ export const applySuccessfulQueryResult = <Extra extends Record<string, unknown>
         queryInfo,
         results,
         status: 'success',
+        ignoreAccents,
         pagination: page.paginated
           ? {
               nextCursor: page.nextCursor,
@@ -132,6 +138,24 @@ export const applySuccessfulPageResult = <Extra extends Record<string, unknown>>
   page: NormalizedMentionDataPage<Extra>,
   focusIndex: number
 ): SuggestionsLifecycleState<Extra> => {
+  if (!Object.hasOwn(currentQueryStates, childIndex)) {
+    return {
+      suggestions: currentSuggestions,
+      queryStates: currentQueryStates,
+      focusIndex,
+    }
+  }
+
+  const currentQueryState = currentQueryStates[childIndex]
+
+  if (currentQueryState.pagination === undefined) {
+    return {
+      suggestions: currentSuggestions,
+      queryStates: currentQueryStates,
+      focusIndex,
+    }
+  }
+
   const previousResults = Object.hasOwn(currentSuggestions, childIndex)
     ? currentSuggestions[childIndex].results
     : []
@@ -151,7 +175,7 @@ export const applySuccessfulPageResult = <Extra extends Record<string, unknown>>
     queryStates: {
       ...currentQueryStates,
       [childIndex]: {
-        ...currentQueryStates[childIndex],
+        ...currentQueryState,
         queryInfo,
         results,
         status: 'success',
@@ -219,6 +243,9 @@ export const applyErroredQueryResult = <Extra extends Record<string, unknown>>(
     Object.entries(currentSuggestions).filter(([key]) => Number(key) !== childIndex)
   ) as SuggestionsMap<Extra>
   const suggestionsCount = countSuggestions(suggestions)
+  const ignoreAccents = Object.hasOwn(currentQueryStates, childIndex)
+    ? currentQueryStates[childIndex].ignoreAccents
+    : false
 
   return {
     suggestions,
@@ -229,6 +256,7 @@ export const applyErroredQueryResult = <Extra extends Record<string, unknown>>(
         queryInfo,
         results: [],
         status: 'error',
+        ignoreAccents,
         error,
       },
     },

--- a/src/MentionsInputSelectors.spec.tsx
+++ b/src/MentionsInputSelectors.spec.tsx
@@ -515,6 +515,54 @@ describe('MentionsInputSelectors', () => {
     })
   })
 
+  it('does not invoke async providers when the signal is already aborted', async () => {
+    const asyncData = vi.fn(() => [{ id: 'alice', display: 'Alice' }])
+    const controller = new AbortController()
+    controller.abort()
+
+    const provider = getDataProvider(asyncData, {
+      ignoreAccents: false,
+      signal: controller.signal,
+      getSubstringIndex: () => 0,
+    })
+
+    await expect(provider('a')).resolves.toEqual({
+      items: [],
+      nextCursor: null,
+      hasMore: false,
+      paginated: false,
+    })
+    expect(asyncData).not.toHaveBeenCalled()
+  })
+
+  it('drops async provider results when the signal aborts before resolution', async () => {
+    let resolveProvider: (value: Array<{ id: string; display: string }>) => void = () => undefined
+    const asyncData = vi.fn(
+      () =>
+        new Promise<Array<{ id: string; display: string }>>((resolve) => {
+          resolveProvider = resolve
+        })
+    )
+    const controller = new AbortController()
+    const provider = getDataProvider(asyncData, {
+      ignoreAccents: false,
+      signal: controller.signal,
+      getSubstringIndex: () => 0,
+    })
+
+    const result = provider('a')
+    controller.abort()
+    resolveProvider([{ id: 'alice', display: 'Alice' }])
+
+    await expect(result).resolves.toEqual({
+      items: [],
+      nextCursor: null,
+      hasMore: false,
+      paginated: false,
+    })
+    expect(asyncData).toHaveBeenCalledTimes(1)
+  })
+
   it('normalizes paginated provider results without applying maxSuggestions', () => {
     expect(
       normalizeMentionDataResult(

--- a/src/MentionsInputSelectors.ts
+++ b/src/MentionsInputSelectors.ts
@@ -416,6 +416,12 @@ export const getDataProvider = <Extra extends Record<string, unknown>>(
   }
 
   return async (query: string, request = {}) => {
+    const isSignalAborted = () => signal.aborted
+
+    if (isSignalAborted()) {
+      return normalizeMentionDataResult<Extra>([], maxSuggestions)
+    }
+
     const provider = data as (
       query: string,
       context: MentionSearchContext
@@ -427,6 +433,11 @@ export const getDataProvider = <Extra extends Record<string, unknown>>(
         reason: request.reason ?? 'query',
       })
     )
+
+    if (isSignalAborted()) {
+      return normalizeMentionDataResult<Extra>([], maxSuggestions)
+    }
+
     return normalizeMentionDataResult(result, maxSuggestions)
   }
 }

--- a/src/SuggestionsOverlay.spec.tsx
+++ b/src/SuggestionsOverlay.spec.tsx
@@ -734,6 +734,60 @@ describe('SuggestionsOverlay', () => {
     expect(onMouseEnter).toHaveBeenCalledWith(2)
   })
 
+  it('resets cached mouse position after closing the overlay.', () => {
+    const suggestions = [
+      { id: '1', display: 'First' },
+      { id: '2', display: 'Second' },
+    ]
+    const suggestionsMap = createSuggestionsMap(suggestions)
+    const onMouseEnter = vi.fn()
+
+    const { container, rerender } = render(
+      <SuggestionsOverlay
+        id="test-suggestions"
+        suggestions={suggestionsMap}
+        focusIndex={0}
+        isOpened
+        onMouseEnter={onMouseEnter}
+      >
+        <Mention trigger="@" data={[]} />
+      </SuggestionsOverlay>
+    )
+
+    let listItems = container.querySelectorAll('li[role="option"]')
+    fireEvent.mouseEnter(listItems[1], { clientX: 20, clientY: 20 })
+    expect(onMouseEnter).toHaveBeenCalledWith(1)
+
+    rerender(
+      <SuggestionsOverlay
+        id="test-suggestions"
+        suggestions={suggestionsMap}
+        focusIndex={0}
+        isOpened={false}
+        onMouseEnter={onMouseEnter}
+      >
+        <Mention trigger="@" data={[]} />
+      </SuggestionsOverlay>
+    )
+
+    rerender(
+      <SuggestionsOverlay
+        id="test-suggestions"
+        suggestions={suggestionsMap}
+        focusIndex={0}
+        isOpened
+        onMouseEnter={onMouseEnter}
+      >
+        <Mention trigger="@" data={[]} />
+      </SuggestionsOverlay>
+    )
+
+    listItems = container.querySelectorAll('li[role="option"]')
+    fireEvent.mouseEnter(listItems[1], { clientX: 20, clientY: 20 })
+    expect(onMouseEnter).toHaveBeenCalledTimes(2)
+    expect(onMouseEnter).toHaveBeenLastCalledWith(1)
+  })
+
   it('does not render anything when closed', () => {
     const { container } = render(
       <SuggestionsOverlay id="test-suggestions" suggestions={{}} focusIndex={0} isOpened={false}>
@@ -893,6 +947,44 @@ describe('SuggestionsOverlay', () => {
     expect(handleLoadMore).not.toHaveBeenCalled()
 
     list.scrollTop = 60
+    fireEvent.scroll(list)
+    expect(handleLoadMore).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not request more suggestions while loading', () => {
+    const handleLoadMore = vi.fn()
+    const { container, rerender } = render(
+      <SuggestionsOverlay
+        id="loading-load-more-overlay"
+        suggestions={createSuggestionsMap([{ id: '1', display: 'First' }])}
+        focusIndex={0}
+        isOpened
+        isLoading
+        onLoadMore={handleLoadMore}
+      >
+        <Mention trigger="@" data={[]} />
+      </SuggestionsOverlay>
+    )
+
+    const list = container.querySelector('ul[role="listbox"]') as HTMLUListElement
+    Object.defineProperty(list, 'scrollHeight', { value: 200, configurable: true })
+    Object.defineProperty(list, 'clientHeight', { value: 100, configurable: true })
+    list.scrollTop = 60
+    fireEvent.scroll(list)
+    expect(handleLoadMore).not.toHaveBeenCalled()
+
+    rerender(
+      <SuggestionsOverlay
+        id="loading-load-more-overlay"
+        suggestions={createSuggestionsMap([{ id: '1', display: 'First' }])}
+        focusIndex={0}
+        isOpened
+        onLoadMore={handleLoadMore}
+      >
+        <Mention trigger="@" data={[]} />
+      </SuggestionsOverlay>
+    )
+
     fireEvent.scroll(list)
     expect(handleLoadMore).toHaveBeenCalledTimes(1)
   })

--- a/src/SuggestionsOverlay.tsx
+++ b/src/SuggestionsOverlay.tsx
@@ -1,4 +1,4 @@
-import React, { useLayoutEffect, useMemo, useRef, useState } from 'react'
+import React, { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import type { CSSProperties } from 'react'
 import { cva } from 'class-variance-authority'
 import LoadingIndicator from './LoadingIndicator'
@@ -136,6 +136,12 @@ function SuggestionsOverlay<Extra extends Record<string, unknown> = Record<strin
     [mentionChildren]
   )
 
+  useEffect(() => {
+    if (!isOpened) {
+      lastMouseEnterPosition.current = null
+    }
+  }, [isOpened])
+
   useLayoutEffect(() => {
     if (!ulElement || ulElement.offsetHeight >= ulElement.scrollHeight || !scrollFocusedIntoView) {
       return
@@ -228,6 +234,10 @@ function SuggestionsOverlay<Extra extends Record<string, unknown> = Record<strin
   )
 
   const handleListScroll = useEventCallback<React.UIEventHandler<HTMLUListElement>>((event) => {
+    if (isLoading === true) {
+      return
+    }
+
     const list = event.currentTarget
     const remainingScrollDistance = list.scrollHeight - list.scrollTop - list.clientHeight
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,12 +38,12 @@ export type SuggestionDataItem<Extra extends Record<string, unknown> = Record<st
 type MaybePromise<T> = T | Promise<T>
 
 export type MentionSearchReason = 'query' | 'page'
-export type MentionPageCursor = NonNullable<unknown>
+export type MentionPageCursor = string | number | boolean | symbol | bigint | object
 
 export interface MentionSearchContext {
   signal: AbortSignal
   cursor?: MentionPageCursor | null
-  reason: MentionSearchReason
+  reason?: MentionSearchReason
 }
 
 export interface MentionDataPage<Extra extends Record<string, unknown> = Record<string, unknown>> {
@@ -95,6 +95,7 @@ export interface SuggestionQueryState<
   queryInfo: QueryInfo
   results: SuggestionDataItem<Extra>[]
   status: 'loading' | 'success' | 'error'
+  ignoreAccents: boolean
   error?: unknown
   pagination?: {
     nextCursor: MentionPageCursor | null


### PR DESCRIPTION
  - MentionsInputSelectors.ts — getDataProvider now checks signal.aborted before invoking the async provider and again after resolution, returning an empty result on abort. Prevents race-y stale result delivery.
  - MentionsInputQueryState.ts — applySuccessfulPageResult bails out when there's no matching query state or no active pagination, dropping stale page results from superseded queries.
  - MentionsInput.tsx — inserting a mention now atomically clears suggestions (_queryId++, cancels pending requests, resets state) in one setState instead of a follow-up clearSuggestions() call, avoiding a brief flash of stale suggestions.
  - SuggestionsOverlay.tsx — scroll handler short-circuits while isLoading, so a single slow page fetch can't trigger repeated onLoadMore calls; cached mouse position resets when the overlay closes, fixing stray onMouseEnter(prevIndex) reports after reopen.
  - ignoreAccents is now carried on the query state itself (threaded through createLoadingQueryState, success/error reducers, and the loadMore path), removing the getIgnoreAccentsForMentionChild re-resolution round-trip.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features & Improvements**
  * Enhanced async data provider handling with proper request cancellation and abort signal support.
  * Improved mention insertion behavior with clearer state management.
  * Fixed suggestions overlay hover tracking to reset when closed.
  * Prevented load-more requests from triggering while suggestions are loading.

* **Documentation**
  * Updated README with expanded feature descriptions and improved structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix data loading race conditions and stale result handling in mentions suggestions
> - Stale page results are now ignored in `applySuccessfulPageResult` when no current pagination state exists for the child, preventing out-of-order updates.
> - Async data providers in `getDataProvider` check `signal.aborted` before invocation and after resolution, discarding results when the signal is already aborted.
> - After selecting a suggestion, pending suggestion requests are cancelled and `_queryId` is incremented, preventing stale results from applying post-selection.
> - `ignoreAccents` is now tracked on `SuggestionQueryState` and propagated through loading, success, and error states rather than being re-derived from the trigger regex.
> - The `SuggestionsOverlay` resets its mouse hover cache on close and suppresses `onLoadMore` triggers while loading is in progress.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 50f22f8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->