### PR TITLE
Updated wait helpers in EmptyAndError.tsx, PaginatedUsers.tsx, and Ri…

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -11,6 +11,7 @@ jobs:
     if: github.event_name == 'pull_request'
     permissions:
       contents: read
+      issues: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -33,7 +34,76 @@ jobs:
           if git ls-remote --exit-code origin refs/notes/perf >/dev/null 2>&1; then
             git fetch origin +refs/notes/perf:refs/notes/perf
           fi
-      - run: pnpm perf:check
+      - name: Run perf check
+        shell: bash
+        run: |
+          set -o pipefail
+          pnpm perf:check 2>&1 | tee perf-check.log
+      - name: Comment on failure
+        if: failure()
+        uses: actions/github-script@v8
+        continue-on-error: true
+        with:
+          script: |
+            const fs = require('node:fs')
+
+            const marker = '<!-- react-mentions-ts-perf-check-failure -->'
+            const output = fs.existsSync('perf-check.log')
+              ? fs.readFileSync('perf-check.log', 'utf8').trim()
+              : 'The perf-check job failed before perf output was captured.'
+            const truncatedOutput =
+              output.length > 6000
+                ? `${output.slice(-6000)}\n\n[output truncated to the last 6000 characters]`
+                : output
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
+            const headSha = context.payload.pull_request?.head.sha
+            const commitLabel =
+              typeof headSha === 'string' && headSha.length > 0
+                ? `\`${headSha.slice(0, 7)}\``
+                : 'this commit'
+            const body = [
+              marker,
+              '### Performance check failed',
+              '',
+              `The \`perf-check\` job failed for ${commitLabel}.`,
+              '',
+              `[View workflow run](${runUrl})`,
+              '',
+              '<details><summary>perf-check output</summary>',
+              '',
+              '```text',
+              truncatedOutput.length > 0 ? truncatedOutput : 'No output was captured.',
+              '```',
+              '',
+              '</details>',
+            ].join('\n')
+
+            const { owner, repo } = context.repo
+            const issue_number = context.issue.number
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+            })
+            const existingComment = comments.find(
+              (comment) => comment.user?.type === 'Bot' && comment.body?.includes(marker)
+            )
+
+            if (existingComment) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existingComment.id,
+                body,
+              })
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body,
+              })
+            }
 
   perf-record:
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'

--- a/demo/src/examples/EmptyAndError.tsx
+++ b/demo/src/examples/EmptyAndError.tsx
@@ -18,15 +18,20 @@ const DIRECTORY: MentionDataItem[] = [
 
 const wait = (ms: number, signal: AbortSignal) =>
   new Promise<void>((resolve, reject) => {
-    const timer = setTimeout(resolve, ms)
-    signal.addEventListener(
-      'abort',
-      () => {
-        clearTimeout(timer)
-        reject(signal.reason as Error)
-      },
-      { once: true }
-    )
+    if (signal.aborted) {
+      reject(signal.reason as Error)
+      return
+    }
+
+    const onAbort = () => {
+      clearTimeout(timer)
+      reject(signal.reason as Error)
+    }
+    const timer = setTimeout(() => {
+      signal.removeEventListener('abort', onAbort)
+      resolve()
+    }, ms)
+    signal.addEventListener('abort', onAbort, { once: true })
   })
 
 async function fetchPeople(

--- a/demo/src/examples/PaginatedUsers.tsx
+++ b/demo/src/examples/PaginatedUsers.tsx
@@ -35,17 +35,20 @@ const ALL_USERS: MentionDataItem<UserExtra>[] = Array.from({ length: TOTAL_USERS
 
 const wait = (ms: number, signal: AbortSignal) =>
   new Promise<void>((resolve, reject) => {
+    if (signal.aborted) {
+      reject(signal.reason as Error)
+      return
+    }
+
+    const onAbort = () => {
+      clearTimeout(timer)
+      reject(signal.reason as Error)
+    }
     const timer = setTimeout(() => {
+      signal.removeEventListener('abort', onAbort)
       resolve()
     }, ms)
-    signal.addEventListener(
-      'abort',
-      () => {
-        clearTimeout(timer)
-        reject(signal.reason as Error)
-      },
-      { once: true }
-    )
+    signal.addEventListener('abort', onAbort, { once: true })
   })
 
 async function fetchUserPage(

--- a/demo/src/examples/RichSuggestionData.tsx
+++ b/demo/src/examples/RichSuggestionData.tsx
@@ -65,15 +65,20 @@ const PEOPLE: MentionDataItem<PersonExtra>[] = [
 
 const wait = (ms: number, signal: AbortSignal) =>
   new Promise<void>((resolve, reject) => {
-    const timer = setTimeout(resolve, ms)
-    signal.addEventListener(
-      'abort',
-      () => {
-        clearTimeout(timer)
-        reject(signal.reason as Error)
-      },
-      { once: true }
-    )
+    if (signal.aborted) {
+      reject(signal.reason as Error)
+      return
+    }
+
+    const onAbort = () => {
+      clearTimeout(timer)
+      reject(signal.reason as Error)
+    }
+    const timer = setTimeout(() => {
+      signal.removeEventListener('abort', onAbort)
+      resolve()
+    }, ms)
+    signal.addEventListener('abort', onAbort, { once: true })
   })
 
 /**

--- a/src/MentionsInput.spec.tsx
+++ b/src/MentionsInput.spec.tsx
@@ -889,6 +889,73 @@ describe('MentionsInput', () => {
     expect(screen.getByText('Beta')).toBeInTheDocument()
   })
 
+  it('keeps suggestions cleared when a late page result resolves after escape.', async () => {
+    interface DeferredPage {
+      resolve: (value: {
+        items: Array<{ id: string; display: string }>
+        nextCursor: string | null
+      }) => void
+      signal: AbortSignal
+    }
+
+    const pageRequests: DeferredPage[] = []
+    const asyncData = vi.fn((query: string, context: MentionSearchContext) => {
+      if (context.reason === 'page') {
+        return new Promise<{
+          items: Array<{ id: string; display: string }>
+          nextCursor: string | null
+        }>((resolve) => {
+          pageRequests.push({ resolve, signal: context.signal })
+        })
+      }
+
+      return Promise.resolve({
+        items: [{ id: `${query}-first`, display: 'Alpha' }],
+        nextCursor: 'cursor-2',
+      })
+    })
+
+    render(
+      <MentionsInput value="@a">
+        <Mention trigger="@" data={asyncData} />
+      </MentionsInput>
+    )
+
+    const textarea = screen.getByRole('combobox')
+    fireEvent.focus(textarea)
+    textarea.setSelectionRange(2, 2)
+    fireEvent.select(textarea)
+
+    await waitFor(() => {
+      expect(screen.getByText('Alpha')).toBeInTheDocument()
+    })
+
+    scrollSuggestionsNearBottom()
+
+    await waitFor(() => {
+      expect(pageRequests).toHaveLength(1)
+    })
+
+    fireEvent.keyDown(textarea, { key: 'Escape' })
+
+    await waitFor(() => {
+      expect(document.querySelector('[data-slot="suggestions"]')).toBeNull()
+    })
+    expect(pageRequests[0]?.signal.aborted).toBe(true)
+
+    pageRequests[0]?.resolve({
+      items: [{ id: 'stale-page', display: 'Stale Page' }],
+      nextCursor: null,
+    })
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(screen.queryByText('Stale Page')).not.toBeInTheDocument()
+    expect(document.querySelector('[data-slot="suggestions"]')).toBeNull()
+  })
+
   it('keeps current suggestions visible when loading the next page fails.', async () => {
     const asyncData = vi.fn((query: string, context: MentionSearchContext) => {
       if (context.reason === 'page') {

--- a/src/MentionsInputQueryState.spec.ts
+++ b/src/MentionsInputQueryState.spec.ts
@@ -264,17 +264,51 @@ describe('MentionsInputQueryState', () => {
         hasMore: false,
         paginated: true,
       },
-      0
+      5
     )
 
     expect(nextState.suggestions[0]?.results).toEqual([
       { id: 'first', display: 'First' },
       { id: 'second', display: 'Second' },
     ])
+    expect(nextState.focusIndex).toBe(1)
     expect(nextState.queryStates[0]?.pagination).toEqual({
       nextCursor: null,
       hasMore: false,
       isLoading: false,
+    })
+  })
+
+  it('ignores page lifecycle updates after query state has been cleared', () => {
+    const suggestions = {
+      0: {
+        queryInfo,
+        results: [{ id: 'first', display: 'First' }],
+      },
+    }
+    const queryStates = {}
+    const page = {
+      items: [{ id: 'stale', display: 'Stale' }],
+      nextCursor: null,
+      hasMore: false,
+      paginated: true,
+    }
+    const error = new Error('stale')
+
+    expect(applyLoadingPageResult(suggestions, queryStates, 0, 2)).toEqual({
+      suggestions,
+      queryStates,
+      focusIndex: 2,
+    })
+    expect(applySuccessfulPageResult(suggestions, queryStates, 0, queryInfo, page, 2)).toEqual({
+      suggestions,
+      queryStates,
+      focusIndex: 2,
+    })
+    expect(applyErroredPageResult(suggestions, queryStates, 0, error, 2)).toEqual({
+      suggestions,
+      queryStates,
+      focusIndex: 2,
     })
   })
 


### PR DESCRIPTION
…chSuggestionData.tsx to reject pre-aborted signals immediately and remove abort listeners after successful timeout resolution.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `wait` helper to reject immediately on pre-aborted signals and clean up abort listeners
> - Updates the `wait` utility in [EmptyAndError.tsx](https://github.com/hbmartin/react-mentions-ts/pull/201/files#diff-a859b760eb09f09b193d8eec91f599d2dd401bee5bf300fdf4b548b658b84ac4), [PaginatedUsers.tsx](https://github.com/hbmartin/react-mentions-ts/pull/201/files#diff-43b2b00e50ef93804868fb18cabcf221d2290d24ff99534b64edbab946883dde), and [RichSuggestionData.tsx](https://github.com/hbmartin/react-mentions-ts/pull/201/files#diff-4a9a97c4033dcae88bb5f05824537b3b8ee0a25db1dcfb541cc1f4d8508adfe9) to reject immediately if the signal is already aborted when `wait` is called.
> - Introduces a named `onAbort` handler registered with `{ once: true }` that clears the timeout and rejects; the timeout callback removes the listener before resolving, preventing leaks.
> - Adds a test in [MentionsInput.spec.tsx](https://github.com/hbmartin/react-mentions-ts/pull/201/files#diff-b685f69aea6de57d68f84daa62a580acd4b95f6de2c7c04d3f723142ddb2245f) verifying that stale paginated results resolved after Escape do not re-render suggestions.
> - Adds tests in [MentionsInputQueryState.spec.ts](https://github.com/hbmartin/react-mentions-ts/pull/201/files#diff-974fc946c7cb7ffbd1e8b657c764fdd6789f22bfcf11fc86e855b99766f0e6a8) covering page lifecycle methods when query state has been cleared.
> - Updates the perf-check workflow to capture output to a log file and post or update a bot comment on the PR on failure.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4d110a1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of canceled async requests to prevent stale suggestions from rendering
  * Enhanced abort signal listener cleanup to prevent memory leaks

* **Tests**
  * Added coverage for request cancellation during async data loading
  * Added coverage for preventing stale pagination updates from being applied

<!-- end of auto-generated comment: release notes by coderabbit.ai -->