### PR TITLE
Changed waitForAbortableDelay.ts (line 1) and updated the three demo …

### DIFF
--- a/demo/src/examples/EmptyAndError.tsx
+++ b/demo/src/examples/EmptyAndError.tsx
@@ -8,6 +8,7 @@ import {
   mergeClassNames,
   multilineMentionsClassNames,
 } from './mentionsClassNames'
+import { waitForAbortableDelay } from './waitForAbortableDelay'
 
 const DIRECTORY: MentionDataItem[] = [
   { id: 'ada', display: 'Ada Lovelace' },
@@ -16,29 +17,11 @@ const DIRECTORY: MentionDataItem[] = [
   { id: 'margaret', display: 'Margaret Hamilton' },
 ]
 
-const wait = (ms: number, signal: AbortSignal) =>
-  new Promise<void>((resolve, reject) => {
-    if (signal.aborted) {
-      reject(signal.reason as Error)
-      return
-    }
-
-    const onAbort = () => {
-      clearTimeout(timer)
-      reject(signal.reason as Error)
-    }
-    const timer = setTimeout(() => {
-      signal.removeEventListener('abort', onAbort)
-      resolve()
-    }, ms)
-    signal.addEventListener('abort', onAbort, { once: true })
-  })
-
 async function fetchPeople(
   query: string,
   { signal }: MentionSearchContext
 ): Promise<MentionDataItem[]> {
-  await wait(250, signal)
+  await waitForAbortableDelay(250, signal)
 
   if (query.toLowerCase().includes('fail')) {
     throw new Error('Directory service is offline')

--- a/demo/src/examples/PaginatedUsers.tsx
+++ b/demo/src/examples/PaginatedUsers.tsx
@@ -14,6 +14,7 @@ import {
   mergeClassNames,
   multilineMentionsClassNames,
 } from './mentionsClassNames'
+import { waitForAbortableDelay } from './waitForAbortableDelay'
 
 type UserExtra = {
   department: string
@@ -33,29 +34,11 @@ const ALL_USERS: MentionDataItem<UserExtra>[] = Array.from({ length: TOTAL_USERS
   }
 })
 
-const wait = (ms: number, signal: AbortSignal) =>
-  new Promise<void>((resolve, reject) => {
-    if (signal.aborted) {
-      reject(signal.reason as Error)
-      return
-    }
-
-    const onAbort = () => {
-      clearTimeout(timer)
-      reject(signal.reason as Error)
-    }
-    const timer = setTimeout(() => {
-      signal.removeEventListener('abort', onAbort)
-      resolve()
-    }, ms)
-    signal.addEventListener('abort', onAbort, { once: true })
-  })
-
 async function fetchUserPage(
   query: string,
   { cursor, signal }: MentionSearchContext
 ): Promise<MentionDataPage<UserExtra>> {
-  await wait(SIMULATED_LATENCY_MS, signal)
+  await waitForAbortableDelay(SIMULATED_LATENCY_MS, signal)
 
   const matches = ALL_USERS.filter((user) =>
     (user.display ?? String(user.id)).toLowerCase().includes(query.toLowerCase())

--- a/demo/src/examples/RichSuggestionData.tsx
+++ b/demo/src/examples/RichSuggestionData.tsx
@@ -9,6 +9,7 @@ import {
   mergeClassNames,
   multilineMentionsClassNames,
 } from './mentionsClassNames'
+import { waitForAbortableDelay } from './waitForAbortableDelay'
 
 type Availability = 'online' | 'away' | 'offline'
 
@@ -63,24 +64,6 @@ const PEOPLE: MentionDataItem<PersonExtra>[] = [
   },
 ]
 
-const wait = (ms: number, signal: AbortSignal) =>
-  new Promise<void>((resolve, reject) => {
-    if (signal.aborted) {
-      reject(signal.reason as Error)
-      return
-    }
-
-    const onAbort = () => {
-      clearTimeout(timer)
-      reject(signal.reason as Error)
-    }
-    const timer = setTimeout(() => {
-      signal.removeEventListener('abort', onAbort)
-      resolve()
-    }, ms)
-    signal.addEventListener('abort', onAbort, { once: true })
-  })
-
 /**
  * Subsequence fuzzy matcher that returns a highlight range per matched character —
  * demonstrates multi-range highlights, which the built-in array source (single
@@ -117,7 +100,7 @@ async function searchPeople(
   query: string,
   { signal }: MentionSearchContext
 ): Promise<MentionDataItem<PersonExtra>[]> {
-  await wait(180, signal)
+  await waitForAbortableDelay(180, signal)
 
   return PEOPLE.flatMap((person) => {
     const display = person.display ?? String(person.id)

--- a/demo/src/examples/waitForAbortableDelay.ts
+++ b/demo/src/examples/waitForAbortableDelay.ts
@@ -1,0 +1,20 @@
+export function waitForAbortableDelay(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal.aborted) {
+      reject(signal.reason)
+      return
+    }
+
+    let timer: ReturnType<typeof setTimeout>
+    const onAbort = () => {
+      clearTimeout(timer)
+      reject(signal.reason)
+    }
+
+    timer = setTimeout(() => {
+      signal.removeEventListener('abort', onAbort)
+      resolve()
+    }, ms)
+    signal.addEventListener('abort', onAbort, { once: true })
+  })
+}


### PR DESCRIPTION
…examples to use it, removing the duplicated local wait helpers

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Extract shared `waitForAbortableDelay` utility from demo examples
> Moves the abortable delay helper that was duplicated across three demo files into a shared [waitForAbortableDelay.ts](https://github.com/hbmartin/react-mentions-ts/pull/202/files#diff-b8e48d8597b8cfcf9102af4c333d52ef7b419d6f8a3bf550e87f9adc33915ce7) module. Each demo (`EmptyAndError`, `PaginatedUsers`, `RichSuggestionData`) now imports and calls `waitForAbortableDelay` instead of defining its own local version.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9373990.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->