### PR TITLE
Fixes for layout regression

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-mentions-ts",
   "private": false,
-  "version": "6.0.0-next.0",
+  "version": "6.0.0-next.1",
   "description": "A React component that enables Facebook/Twitter-style @mentions and tagging in textarea inputs with full TypeScript support.",
   "type": "module",
   "packageManager": "pnpm@10.33.0",
@@ -98,7 +98,7 @@
     "@arethetypeswrong/cli": "^0.18.2",
     "@eslint/eslintrc": "^3.3.5",
     "@eslint/js": "^10.0.1",
-    "@microsoft/api-extractor": "^7.58.5",
+    "@microsoft/api-extractor": "^7.58.6",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
@@ -135,7 +135,7 @@
     "jscodeshift": "^17.3.0",
     "jsdom": "^29.0.2",
     "jsonc-eslint-parser": "^3.1.0",
-    "knip": "^6.4.1",
+    "knip": "^6.5.0",
     "oxfmt": "^0.45.0",
     "oxlint": "^1.60.0",
     "oxlint-tsgolint": "^0.21.1",
@@ -149,7 +149,7 @@
     "tsdown": "^0.21.9",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.58.2",
-    "vite": "^8.0.8",
+    "vite": "^8.0.9",
     "vitest": "^4.1.4"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.2.1(jiti@2.6.1))
       '@microsoft/api-extractor':
-        specifier: ^7.58.5
-        version: 7.58.5(@types/node@24.12.2)
+        specifier: ^7.58.6
+        version: 7.58.6(@types/node@24.12.2)
       '@testing-library/dom':
         specifier: ^10.4.1
         version: 10.4.1
@@ -49,13 +49,13 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: ^6.0.1
-        version: 6.0.1(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3))
+        version: 6.0.1(vite@8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3))
       '@vitest/browser-playwright':
         specifier: ^4.1.4
-        version: 4.1.4(playwright@1.59.1)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3))(vitest@4.1.4)
+        version: 4.1.4(playwright@1.59.1)(vite@8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3))(vitest@4.1.4)
       '@vitest/browser-preview':
         specifier: ^4.1.4
-        version: 4.1.4(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3))(vitest@4.1.4)
+        version: 4.1.4(vite@8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3))(vitest@4.1.4)
       '@vitest/coverage-v8':
         specifier: ^4.1.4
         version: 4.1.4(@vitest/browser@4.1.4)(vitest@4.1.4)
@@ -132,8 +132,8 @@ importers:
         specifier: ^3.1.0
         version: 3.1.0
       knip:
-        specifier: ^6.4.1
-        version: 6.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+        specifier: ^6.5.0
+        version: 6.5.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
       oxfmt:
         specifier: ^0.45.0
         version: 0.45.0
@@ -174,11 +174,11 @@ importers:
         specifier: ^8.58.2
         version: 8.58.2(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.3)
       vite:
-        specifier: ^8.0.8
-        version: 8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3)
+        specifier: ^8.0.9
+        version: 8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.4
-        version: 4.1.4(@types/node@24.12.2)(@vitest/browser-playwright@4.1.4)(@vitest/browser-preview@4.1.4)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.2)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3))
+        version: 4.1.4(@types/node@24.12.2)(@vitest/browser-playwright@4.1.4)(@vitest/browser-preview@4.1.4)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.2)(vite@8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3))
 
 packages:
 
@@ -743,8 +743,8 @@ packages:
   '@microsoft/api-extractor-model@7.33.8':
     resolution: {integrity: sha512-aIcoQggPyer3B6Ze3usz0YWC/oBwUHfRH5ETUsr+oT2BRA6SfTJl7IKPcPZkX4UR+PohowzW4uMxsvjrn8vm+w==}
 
-  '@microsoft/api-extractor@7.58.5':
-    resolution: {integrity: sha512-pKQs2MBtGCVcIs1pxkSjhb1GGxYaS3KRCoi7Ki6qCJw6S/zx5ZYvC3CX39RpexBqYcO0asphyrqdW2ifyuSX6A==}
+  '@microsoft/api-extractor@7.58.6':
+    resolution: {integrity: sha512-+F7lTCwIuGapTDJpkTj2GnHYozqDbqLAmCsySX58PBaMt0cB28zPO9gOG7LijMXpqCkSGwSPh1k1rqvJUc9mzg==}
     hasBin: true
 
   '@microsoft/tsdoc-config@0.18.1':
@@ -774,138 +774,132 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@oxc-parser/binding-android-arm-eabi@0.121.0':
-    resolution: {integrity: sha512-n07FQcySwOlzap424/PLMtOkbS7xOu8nsJduKL8P3COGHKgKoDYXwoAHCbChfgFpHnviehrLWIPX0lKGtbEk/A==}
+  '@oxc-parser/binding-android-arm-eabi@0.126.0':
+    resolution: {integrity: sha512-svyoHt25J4741QJ5aa4R+h0iiBeSRt63Lr3aAZcxy2c/NeSE1IfDeMnSij6rIg7EjxkdlXzz613wUjeCeilBNA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [android]
 
-  '@oxc-parser/binding-android-arm64@0.121.0':
-    resolution: {integrity: sha512-/Dd1xIXboYAicw+twT2utxPD7bL8qh7d3ej0qvaYIMj3/EgIrGR+tSnjCUkiCT6g6uTC0neSS4JY8LxhdSU/sA==}
+  '@oxc-parser/binding-android-arm64@0.126.0':
+    resolution: {integrity: sha512-hPEBRKgplp1mG9GkINFsr4JVMDNrGJLOqfDaadTWpAoTnzYR5Rmv8RMvB3hJZpiNvbk1aacopdHUP1pggMQ/cw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@oxc-parser/binding-darwin-arm64@0.121.0':
-    resolution: {integrity: sha512-A0jNEvv7QMtCO1yk205t3DWU9sWUjQ2KNF0hSVO5W9R9r/R1BIvzG01UQAfmtC0dQm7sCrs5puixurKSfr2bRQ==}
+  '@oxc-parser/binding-darwin-arm64@0.126.0':
+    resolution: {integrity: sha512-ccRpu9sdYmznePJQG5halhs0FW5tw5a8zRSoZXOzM1OjoeZ4jiRRruFiPclsD59edoVAK1l83dvfjWz1nQi6lg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@oxc-parser/binding-darwin-x64@0.121.0':
-    resolution: {integrity: sha512-SsHzipdxTKUs3I9EOAPmnIimEeJOemqRlRDOp9LIj+96wtxZejF51gNibmoGq8KoqbT1ssAI5po/E3J+vEtXGA==}
+  '@oxc-parser/binding-darwin-x64@0.126.0':
+    resolution: {integrity: sha512-CHB4zVjNSKqx8Fw9pHowzQQnjjuq04i4Ng0Avj+DixlwhwAoMYqlFbocYIlbg+q3zOLGlm7vEHm83jqEMitnyg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@oxc-parser/binding-freebsd-x64@0.121.0':
-    resolution: {integrity: sha512-v1APOTkCp+RWOIDAHRoaeW/UoaHF15a60E8eUL6kUQXh+i4K7PBwq2Wi7jm8p0ymID5/m/oC1w3W31Z/+r7HQw==}
+  '@oxc-parser/binding-freebsd-x64@0.126.0':
+    resolution: {integrity: sha512-RQ3nEJdcDKBfBjmLJ3Vl1d0KQERPV1P8eUrnBm7+VTYyoaJSPLVFuPg1mlD1hk3n0/879VLFMfusFkBal4ssWQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@oxc-parser/binding-linux-arm-gnueabihf@0.121.0':
-    resolution: {integrity: sha512-PmqPQuqHZyFVWA4ycr0eu4VnTMmq9laOHZd+8R359w6kzuNZPvmmunmNJ8ybkm769A0nCoVp3TJ6dUz7B3FYIQ==}
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.126.0':
+    resolution: {integrity: sha512-onipc2wCDA7Bauzb4KK1mab0GsEDf4ujiIfWECdnmY/2LlzAoX3xdQRLAUyEDB1kn3yilHBrkmXDdHluyHXxiw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@oxc-parser/binding-linux-arm-musleabihf@0.121.0':
-    resolution: {integrity: sha512-vF24htj+MOH+Q7y9A8NuC6pUZu8t/C2Fr/kDOi2OcNf28oogr2xadBPXAbml802E8wRAVfbta6YLDQTearz+jw==}
+  '@oxc-parser/binding-linux-arm-musleabihf@0.126.0':
+    resolution: {integrity: sha512-5BuJJPohrV5NJ8lmcYOMbfRCUGoYH5J9HZHeuqOLwkHXWAuPMN3X1h8bC/2mWjmosdbfTtmyIdX3spS/TkqKNg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@oxc-parser/binding-linux-arm64-gnu@0.121.0':
-    resolution: {integrity: sha512-wjH8cIG2Lu/3d64iZpbYr73hREMgKAfu7fqpXjgM2S16y2zhTfDIp8EQjxO8vlDtKP5Rc7waZW72lh8nZtWrpA==}
+  '@oxc-parser/binding-linux-arm64-gnu@0.126.0':
+    resolution: {integrity: sha512-r2KApRgm2pOJaduRm6GOT8x0whcr67AyejNkSdzPt34GJ+Y3axcXN2mwlTs+8lfO/SSmpO5ZJGYiHYnxEE0jkw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@oxc-parser/binding-linux-arm64-musl@0.121.0':
-    resolution: {integrity: sha512-qT663J/W8yQFw3dtscbEi9LKJevr20V7uWs2MPGTnvNZ3rm8anhhE16gXGpxDOHeg9raySaSHKhd4IGa3YZvuw==}
+  '@oxc-parser/binding-linux-arm64-musl@0.126.0':
+    resolution: {integrity: sha512-FQ+MMh7MT0Dr/u8+RWmWKlfoeWPQyHDbhhxJShJlYtROXXPHsRs9EvmQOZZ3sx4Nn7JU8NX+oyw2YzQ7anBJcA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@oxc-parser/binding-linux-ppc64-gnu@0.121.0':
-    resolution: {integrity: sha512-mYNe4NhVvDBbPkAP8JaVS8lC1dsoJZWH5WCjpw5E+sjhk1R08wt3NnXYUzum7tIiWPfgQxbCMcoxgeemFASbRw==}
+  '@oxc-parser/binding-linux-ppc64-gnu@0.126.0':
+    resolution: {integrity: sha512-Wv/T8C98hRQhGTlx2XFyLn5raRMp9U1lOQD+YnXNgAr7wHbJJpZ8mDBU7Rw+M3WytGcGTFcr6kqgfyQeHVtLbQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@oxc-parser/binding-linux-riscv64-gnu@0.121.0':
-    resolution: {integrity: sha512-+QiFoGxhAbaI/amqX567784cDyyuZIpinBrJNxUzb+/L2aBRX67mN6Jv40pqduHf15yYByI+K5gUEygCuv0z9w==}
+  '@oxc-parser/binding-linux-riscv64-gnu@0.126.0':
+    resolution: {integrity: sha512-DHx1rT1zauW0ZbLHOiQh5AC9Xs3UkWx2XmfZHs+7nnWYr3sagrufoUQC+/XPwwjMIlCFXiFGM0sFh3TyOCZwqA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  '@oxc-parser/binding-linux-riscv64-musl@0.121.0':
-    resolution: {integrity: sha512-9ykEgyTa5JD/Uhv2sttbKnCfl2PieUfOjyxJC/oDL2UO0qtXOtjPLl7H8Kaj5G7p3hIvFgu3YWvAxvE0sqY+hQ==}
+  '@oxc-parser/binding-linux-riscv64-musl@0.126.0':
+    resolution: {integrity: sha512-umDc2mTShH0U2zcEYf8mIJ163seLJNn54ZUZYeI5jD4qlg9izPwoLrC2aNPKlMJTu6u/ysmQWiEvIiaAG+INkw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
     libc: [musl]
 
-  '@oxc-parser/binding-linux-s390x-gnu@0.121.0':
-    resolution: {integrity: sha512-DB1EW5VHZdc1lIRjOI3bW/wV6R6y0xlfvdVrqj6kKi7Ayu2U3UqUBdq9KviVkcUGd5Oq+dROqvUEEFRXGAM7EQ==}
+  '@oxc-parser/binding-linux-s390x-gnu@0.126.0':
+    resolution: {integrity: sha512-PXXeWayclRtO1pxQEeCpiqIglQdhK2mAI2VX5xnsWdImzSB5GpoQ8TNw7vTCKk2k+GZuxl+q1knncidjCyUP9w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@oxc-parser/binding-linux-x64-gnu@0.121.0':
-    resolution: {integrity: sha512-s4lfobX9p4kPTclvMiH3gcQUd88VlnkMTF6n2MTMDAyX5FPNRhhRSFZK05Ykhf8Zy5NibV4PbGR6DnK7FGNN6A==}
+  '@oxc-parser/binding-linux-x64-gnu@0.126.0':
+    resolution: {integrity: sha512-wzocjxm34TbB3bFlqG65JiLtvf6ZDg2ZxRkLLbgXwDQUNU+0MPjQN8zy/0jBKNA5fnPLk3XeVdZ7Uin+7+CVkg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@oxc-parser/binding-linux-x64-musl@0.121.0':
-    resolution: {integrity: sha512-P9KlyTpuBuMi3NRGpJO8MicuGZfOoqZVRP1WjOecwx8yk4L/+mrCRNc5egSi0byhuReblBF2oVoDSMgV9Bj4Hw==}
+  '@oxc-parser/binding-linux-x64-musl@0.126.0':
+    resolution: {integrity: sha512-e83uftP60jmkPs2+CW6T6A1GYzN2H6IumDAiTntv9WyHR73PI3ImHNBkYqnA3ukeKI3xjcCbhSh9QeJWmufxGQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@oxc-parser/binding-openharmony-arm64@0.121.0':
-    resolution: {integrity: sha512-R+4jrWOfF2OAPPhj3Eb3U5CaKNAH9/btMveMULIrcNW/hjfysFQlF8wE0GaVBr81dWz8JLgQlsxwctoL78JwXw==}
+  '@oxc-parser/binding-openharmony-arm64@0.126.0':
+    resolution: {integrity: sha512-4WiOILHnPrTDY2/L4mE6PZCYwLN1d3ghma6BuTJ452CCgzRMt3uFplCtR+o3r9zdUWJYb370UizpI9CUcWXr1A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@oxc-parser/binding-wasm32-wasi@0.121.0':
-    resolution: {integrity: sha512-5TFISkPTymKvsmIlKasPVTPuWxzCcrT8pM+p77+mtQbIZDd1UC8zww4CJcRI46kolmgrEX6QpKO8AvWMVZ+ifw==}
+  '@oxc-parser/binding-wasm32-wasi@0.126.0':
+    resolution: {integrity: sha512-Y17hhnrQTrxgAxAyAq401vnN9URsAL4s5AjqpG1NDsXSlhe1yBNnns+rC2P6xcMoitgX5nKH2ryYt9oiFRlzLw==}
     engines: {node: '>=14.0.0'}
     cpu: [wasm32]
 
-  '@oxc-parser/binding-win32-arm64-msvc@0.121.0':
-    resolution: {integrity: sha512-V0pxh4mql4XTt3aiEtRNUeBAUFOw5jzZNxPABLaOKAWrVzSr9+XUaB095lY7jqMf5t8vkfh8NManGB28zanYKw==}
+  '@oxc-parser/binding-win32-arm64-msvc@0.126.0':
+    resolution: {integrity: sha512-Znug1u1iRvT4VC3jANz6nhGBHsFwEFMxuimYpJFwMtsB6H5FcEoZRMmH26tHkSTD03JvDmG+gB65W3ajLjPcSw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@oxc-parser/binding-win32-ia32-msvc@0.121.0':
-    resolution: {integrity: sha512-4Ob1qvYMPnlF2N9rdmKdkQFdrq16QVcQwBsO8yiPZXof0fHKFF+LmQV501XFbi7lHyrKm8rlJRfQ/M8bZZPVLw==}
+  '@oxc-parser/binding-win32-ia32-msvc@0.126.0':
+    resolution: {integrity: sha512-qrw7mx5hFFTxVSXToOA40hpnjgNB/DJprZchtB4rDKNLKqkD3F26HbzaQeH1nxAKej0efSZfJd5Sw3qdtOLGhw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ia32]
     os: [win32]
 
-  '@oxc-parser/binding-win32-x64-msvc@0.121.0':
-    resolution: {integrity: sha512-BOp1KCzdboB1tPqoCPXgntgFs0jjeSyOXHzgxVFR7B/qfr3F8r4YDacHkTOUNXtDgM8YwKnkf3rE5gwALYX7NA==}
+  '@oxc-parser/binding-win32-x64-msvc@0.126.0':
+    resolution: {integrity: sha512-ibB1s+mPUFXvS7MFJO2jpw/aCNs/P6ifnWlRyTYB+WYBpniOiCcHQQskZneJtwcjQMDRol3RGG3ihoYnzXSY4w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
-
-  '@oxc-project/types@0.121.0':
-    resolution: {integrity: sha512-CGtOARQb9tyv7ECgdAlFxi0Fv7lmzvmlm2rpD/RdijOO9rfk/JvB1CjT8EnoD+tjna/IYgKKw3IV7objRb+aYw==}
-
-  '@oxc-project/types@0.124.0':
-    resolution: {integrity: sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==}
 
   '@oxc-project/types@0.126.0':
     resolution: {integrity: sha512-oGfVtjAgwQVVpfBrbtk4e1XDyWHRFta6BS3GWVzrF8xYBT2VGQAk39yJS/wFSMrZqoiCU4oghT3Ch0HaHGIHcQ==}
@@ -1309,34 +1303,16 @@ packages:
   '@quansync/fs@1.0.0':
     resolution: {integrity: sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ==}
 
-  '@rolldown/binding-android-arm64@1.0.0-rc.15':
-    resolution: {integrity: sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [android]
-
   '@rolldown/binding-android-arm64@1.0.0-rc.16':
     resolution: {integrity: sha512-rhY3k7Bsae9qQfOtph2Pm2jZEA+s8Gmjoz4hhmx70K9iMQ/ddeae+xhRQcM5IuVx5ry1+bGfkvMn7D6MJggVSA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@rolldown/binding-darwin-arm64@1.0.0-rc.15':
-    resolution: {integrity: sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [darwin]
-
   '@rolldown/binding-darwin-arm64@1.0.0-rc.16':
     resolution: {integrity: sha512-rNz0yK078yrNn3DrdgN+PKiMOW8HfQ92jQiXxwX8yW899ayV00MLVdaCNeVBhG/TbH3ouYVObo8/yrkiectkcQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
-    os: [darwin]
-
-  '@rolldown/binding-darwin-x64@1.0.0-rc.15':
-    resolution: {integrity: sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
     os: [darwin]
 
   '@rolldown/binding-darwin-x64@1.0.0-rc.16':
@@ -1345,36 +1321,17 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-freebsd-x64@1.0.0-rc.15':
-    resolution: {integrity: sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [freebsd]
-
   '@rolldown/binding-freebsd-x64@1.0.0-rc.16':
     resolution: {integrity: sha512-KcRE5w8h0OnjUatG8pldyD14/CQ5Phs1oxfR+3pKDjboHRo9+MkqQaiIZlZRpsxC15paeXme/I127tUa9TXJ6g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.15':
-    resolution: {integrity: sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm]
-    os: [linux]
-
   '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.16':
     resolution: {integrity: sha512-bT0guA1bpxEJ/ZhTRniQf7rNF8ybvXOuWbNIeLABaV5NGjx4EtOWBTSRGWFU9ZWVkPOZ+HNFP8RMcBokBiZ0Kg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
-
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.15':
-    resolution: {integrity: sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.16':
     resolution: {integrity: sha512-+tHktCHWV8BDQSjemUqm/Jl/TPk3QObCTIjmdDy/nlupcujZghmKK2962LYrqFpWu+ai01AN/REOH3NEpqvYQg==}
@@ -1383,13 +1340,6 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.15':
-    resolution: {integrity: sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.16':
     resolution: {integrity: sha512-3fPzdREH806oRLxpTWW1Gt4tQHs0TitZFOECB2xzCFLPKnSOy90gwA7P29cksYilFO6XVRY1kzga0cL2nRjKPg==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -1397,24 +1347,10 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.15':
-    resolution: {integrity: sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.16':
     resolution: {integrity: sha512-EKwI1tSrLs7YVw+JPJT/G2dJQ1jl9qlTTTEG0V2Ok/RdOenRfBw2PQdLPyjhIu58ocdBfP7vIRN/pvMsPxs/AQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
-  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.15':
-    resolution: {integrity: sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
@@ -1425,26 +1361,12 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.15':
-    resolution: {integrity: sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.16':
     resolution: {integrity: sha512-FIb8+uG49sZBtLTn+zt1AJ20TqVcqWeSIyoVt0or7uAWesgKaHbiBh6OpA/k9v0LTt+PTrb1Lao133kP4uVxkg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
-
-  '@rolldown/binding-linux-x64-musl@1.0.0-rc.15':
-    resolution: {integrity: sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.16':
     resolution: {integrity: sha512-RuERhF9/EgWxZEXYWCOaViUWHIboceK4/ivdtQ3R0T44NjLkIIlGIAVAuCddFxsZ7vnRHtNQUrt2vR2n2slB2w==}
@@ -1453,33 +1375,16 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-openharmony-arm64@1.0.0-rc.15':
-    resolution: {integrity: sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [openharmony]
-
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.16':
     resolution: {integrity: sha512-mXcXnvd9GpazCxeUCCnZ2+YF7nut+ZOEbE4GtaiPtyY6AkhZWbK70y1KK3j+RDhjVq5+U8FySkKRb/+w0EeUwA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.15':
-    resolution: {integrity: sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q==}
-    engines: {node: '>=14.0.0'}
-    cpu: [wasm32]
-
   '@rolldown/binding-wasm32-wasi@1.0.0-rc.16':
     resolution: {integrity: sha512-3Q2KQxnC8IJOLqXmUMoYwyIPZU9hzRbnHaoV3Euz+VVnjZKcY8ktnNP8T9R4/GGQtb27C/UYKABxesKWb8lsvQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [wasm32]
-
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.15':
-    resolution: {integrity: sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [win32]
 
   '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.16':
     resolution: {integrity: sha512-tj7XRemQcOcFwv7qhpUxMTBbI5mWMlE4c1Omhg5+h8GuLXzyj8HviYgR+bB2DMDgRqUE+jiDleqSCRjx4aYk/Q==}
@@ -1487,20 +1392,11 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.15':
-    resolution: {integrity: sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [win32]
-
   '@rolldown/binding-win32-x64-msvc@1.0.0-rc.16':
     resolution: {integrity: sha512-PH5DRZT+F4f2PTXRXR8uJxnBq2po/xFtddyabTJVJs/ZYVHqXPEgNIr35IHTEa6bpa0Q8Awg+ymkTaGnKITw4g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
-
-  '@rolldown/pluginutils@1.0.0-rc.15':
-    resolution: {integrity: sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==}
 
   '@rolldown/pluginutils@1.0.0-rc.16':
     resolution: {integrity: sha512-45+YtqxLYKDWQouLKCrpIZhke+nXxhsw+qAHVzHDVwttyBlHNBVs2K25rDXrZzhpTp9w1FlAlvweV1H++fdZoA==}
@@ -2313,9 +2209,9 @@ packages:
     resolution: {integrity: sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==}
     engines: {node: '>=14'}
 
-  entities@6.0.1:
-    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
-    engines: {node: '>=0.12'}
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
 
   environment@1.1.0:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
@@ -2589,10 +2485,6 @@ packages:
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
-  fast-glob@3.3.3:
-    resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
-    engines: {node: '>=8.6.0'}
-
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
 
@@ -2719,18 +2611,11 @@ packages:
     resolution: {integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==}
     engines: {node: '>= 0.4'}
 
-  get-tsconfig@4.13.7:
-    resolution: {integrity: sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==}
-
   get-tsconfig@4.14.0:
     resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
 
   git-hooks-list@4.2.1:
     resolution: {integrity: sha512-WNvqJjOxxs/8ZP9+DWdwWJ7cDsd60NHf39XnD82pDVrKO5q7xfPqpkK6hwEAmBa/ZSEE4IOoR75EzbbIuwGlMw==}
-
-  glob-parent@5.1.2:
-    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
-    engines: {node: '>= 6'}
 
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
@@ -3055,8 +2940,8 @@ packages:
     resolution: {integrity: sha512-75EA7EWZExL/j+MDKQrRbdzcRI2HOkRlmUw8fZJc1ioqFEOvBsq7Rt+A6yCxOt9w/TYNpkt52gC6nm/g5tFIng==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  jsonfile@6.2.0:
-    resolution: {integrity: sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==}
+  jsonfile@6.2.1:
+    resolution: {integrity: sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==}
 
   jsx-ast-utils-x@0.1.0:
     resolution: {integrity: sha512-eQQBjBnsVtGacsG9uJNB8qOr3yA8rga4wAaGG1qRcBzSIvfhERLrWxMAM1hp5fcS6Abo8M4+bUBTekYR0qTPQw==}
@@ -3073,8 +2958,8 @@ packages:
     resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
     engines: {node: '>=0.10.0'}
 
-  knip@6.4.1:
-    resolution: {integrity: sha512-Ry+ywmDFSZvKp/jx7LxMgsZWRTs931alV84e60lh0Stf6kSRYqSIUTkviyyDFRcSO3yY1Kpbi83OirN+4lA2Xw==}
+  knip@6.5.0:
+    resolution: {integrity: sha512-84xSq/g8CtPWLJcY5WZeGWj/pbqQxJRC7iXTTutB0MkMm260hKxlzIXSTnxuTuIxre2MBSokhLkfth8dQQYVPQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -3227,10 +3112,6 @@ packages:
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
-  merge2@1.4.1:
-    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
-    engines: {node: '>= 8'}
-
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
@@ -3341,8 +3222,8 @@ packages:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
     engines: {node: '>= 0.4'}
 
-  oxc-parser@0.121.0:
-    resolution: {integrity: sha512-ek9o58+SCv6AV7nchiAcUJy1DNE2CC5WRdBcO0mF+W4oRjNQfPO7b3pLjTHSFECpHkKGOZSQxx3hk8viIL5YCg==}
+  oxc-parser@0.126.0:
+    resolution: {integrity: sha512-FktCvLby/mOHyuijZt22+nOt10dS24gGUZE3XwIbUg7Kf4+rer3/5T7RgwzazlNuVsCjPloZ3p8E+4ONT3A8Kw==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
   oxc-resolver@11.19.1:
@@ -3410,8 +3291,8 @@ packages:
   parse5@6.0.1:
     resolution: {integrity: sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==}
 
-  parse5@8.0.0:
-    resolution: {integrity: sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==}
+  parse5@8.0.1:
+    resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
 
   path-exists@3.0.0:
     resolution: {integrity: sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==}
@@ -3610,11 +3491,6 @@ packages:
       vue-tsc:
         optional: true
 
-  rolldown@1.0.0-rc.15:
-    resolution: {integrity: sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
-
   rolldown@1.0.0-rc.16:
     resolution: {integrity: sha512-rzi5WqKzEZw3SooTt7cgm4eqIoujPIyGcJNGFL7iPEuajQw7vxMHUkXylu4/vhCkJGXsgRmxqMKXUpT6FEgl0g==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -3627,8 +3503,8 @@ packages:
     resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
     engines: {node: '>=6'}
 
-  safe-array-concat@1.1.3:
-    resolution: {integrity: sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==}
+  safe-array-concat@1.1.4:
+    resolution: {integrity: sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==}
     engines: {node: '>=0.4'}
 
   safe-push-apply@1.0.0:
@@ -4072,8 +3948,8 @@ packages:
     resolution: {integrity: sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
-  vite@8.0.8:
-    resolution: {integrity: sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==}
+  vite@8.0.9:
+    resolution: {integrity: sha512-t7g7GVRpMXjNpa67HaVWI/8BWtdVIQPCL2WoozXXA7LBGEFK4AkkKkHx2hAQf5x1GZSlcmEDPkVLSGahxnEEZw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -4833,7 +4709,7 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
-  '@microsoft/api-extractor@7.58.5(@types/node@24.12.2)':
+  '@microsoft/api-extractor@7.58.6(@types/node@24.12.2)':
     dependencies:
       '@microsoft/api-extractor-model': 7.33.8(@types/node@24.12.2)
       '@microsoft/tsdoc': 0.16.0
@@ -4893,74 +4769,69 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
-  '@oxc-parser/binding-android-arm-eabi@0.121.0':
+  '@oxc-parser/binding-android-arm-eabi@0.126.0':
     optional: true
 
-  '@oxc-parser/binding-android-arm64@0.121.0':
+  '@oxc-parser/binding-android-arm64@0.126.0':
     optional: true
 
-  '@oxc-parser/binding-darwin-arm64@0.121.0':
+  '@oxc-parser/binding-darwin-arm64@0.126.0':
     optional: true
 
-  '@oxc-parser/binding-darwin-x64@0.121.0':
+  '@oxc-parser/binding-darwin-x64@0.126.0':
     optional: true
 
-  '@oxc-parser/binding-freebsd-x64@0.121.0':
+  '@oxc-parser/binding-freebsd-x64@0.126.0':
     optional: true
 
-  '@oxc-parser/binding-linux-arm-gnueabihf@0.121.0':
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.126.0':
     optional: true
 
-  '@oxc-parser/binding-linux-arm-musleabihf@0.121.0':
+  '@oxc-parser/binding-linux-arm-musleabihf@0.126.0':
     optional: true
 
-  '@oxc-parser/binding-linux-arm64-gnu@0.121.0':
+  '@oxc-parser/binding-linux-arm64-gnu@0.126.0':
     optional: true
 
-  '@oxc-parser/binding-linux-arm64-musl@0.121.0':
+  '@oxc-parser/binding-linux-arm64-musl@0.126.0':
     optional: true
 
-  '@oxc-parser/binding-linux-ppc64-gnu@0.121.0':
+  '@oxc-parser/binding-linux-ppc64-gnu@0.126.0':
     optional: true
 
-  '@oxc-parser/binding-linux-riscv64-gnu@0.121.0':
+  '@oxc-parser/binding-linux-riscv64-gnu@0.126.0':
     optional: true
 
-  '@oxc-parser/binding-linux-riscv64-musl@0.121.0':
+  '@oxc-parser/binding-linux-riscv64-musl@0.126.0':
     optional: true
 
-  '@oxc-parser/binding-linux-s390x-gnu@0.121.0':
+  '@oxc-parser/binding-linux-s390x-gnu@0.126.0':
     optional: true
 
-  '@oxc-parser/binding-linux-x64-gnu@0.121.0':
+  '@oxc-parser/binding-linux-x64-gnu@0.126.0':
     optional: true
 
-  '@oxc-parser/binding-linux-x64-musl@0.121.0':
+  '@oxc-parser/binding-linux-x64-musl@0.126.0':
     optional: true
 
-  '@oxc-parser/binding-openharmony-arm64@0.121.0':
+  '@oxc-parser/binding-openharmony-arm64@0.126.0':
     optional: true
 
-  '@oxc-parser/binding-wasm32-wasi@0.121.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+  '@oxc-parser/binding-wasm32-wasi@0.126.0':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
-    transitivePeerDependencies:
-      - '@emnapi/core'
-      - '@emnapi/runtime'
+      '@emnapi/core': 1.9.2
+      '@emnapi/runtime': 1.9.2
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
     optional: true
 
-  '@oxc-parser/binding-win32-arm64-msvc@0.121.0':
+  '@oxc-parser/binding-win32-arm64-msvc@0.126.0':
     optional: true
 
-  '@oxc-parser/binding-win32-ia32-msvc@0.121.0':
+  '@oxc-parser/binding-win32-ia32-msvc@0.126.0':
     optional: true
 
-  '@oxc-parser/binding-win32-x64-msvc@0.121.0':
+  '@oxc-parser/binding-win32-x64-msvc@0.126.0':
     optional: true
-
-  '@oxc-project/types@0.121.0': {}
-
-  '@oxc-project/types@0.124.0': {}
 
   '@oxc-project/types@0.126.0': {}
 
@@ -5174,83 +5045,40 @@ snapshots:
     dependencies:
       quansync: 1.0.0
 
-  '@rolldown/binding-android-arm64@1.0.0-rc.15':
-    optional: true
-
   '@rolldown/binding-android-arm64@1.0.0-rc.16':
-    optional: true
-
-  '@rolldown/binding-darwin-arm64@1.0.0-rc.15':
     optional: true
 
   '@rolldown/binding-darwin-arm64@1.0.0-rc.16':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.0.0-rc.15':
-    optional: true
-
   '@rolldown/binding-darwin-x64@1.0.0-rc.16':
-    optional: true
-
-  '@rolldown/binding-freebsd-x64@1.0.0-rc.15':
     optional: true
 
   '@rolldown/binding-freebsd-x64@1.0.0-rc.16':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.15':
-    optional: true
-
   '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.16':
-    optional: true
-
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.15':
     optional: true
 
   '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.16':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.15':
-    optional: true
-
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.16':
-    optional: true
-
-  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.15':
     optional: true
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.16':
     optional: true
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.15':
-    optional: true
-
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.16':
-    optional: true
-
-  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.15':
     optional: true
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.16':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-rc.15':
-    optional: true
-
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.16':
     optional: true
 
-  '@rolldown/binding-openharmony-arm64@1.0.0-rc.15':
-    optional: true
-
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.16':
-    optional: true
-
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.15':
-    dependencies:
-      '@emnapi/core': 1.9.2
-      '@emnapi/runtime': 1.9.2
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
     optional: true
 
   '@rolldown/binding-wasm32-wasi@1.0.0-rc.16':
@@ -5260,19 +5088,11 @@ snapshots:
       '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.15':
-    optional: true
-
   '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.16':
-    optional: true
-
-  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.15':
     optional: true
 
   '@rolldown/binding-win32-x64-msvc@1.0.0-rc.16':
     optional: true
-
-  '@rolldown/pluginutils@1.0.0-rc.15': {}
 
   '@rolldown/pluginutils@1.0.0-rc.16': {}
 
@@ -5560,46 +5380,46 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
-  '@vitejs/plugin-react@6.0.1(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3))':
+  '@vitejs/plugin-react@6.0.1(vite@8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.7
-      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3)
+      vite: 8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3)
 
-  '@vitest/browser-playwright@4.1.4(playwright@1.59.1)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3))(vitest@4.1.4)':
+  '@vitest/browser-playwright@4.1.4(playwright@1.59.1)(vite@8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3))(vitest@4.1.4)':
     dependencies:
-      '@vitest/browser': 4.1.4(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3))(vitest@4.1.4)
-      '@vitest/mocker': 4.1.4(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3))
+      '@vitest/browser': 4.1.4(vite@8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3))(vitest@4.1.4)
+      '@vitest/mocker': 4.1.4(vite@8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3))
       playwright: 1.59.1
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@types/node@24.12.2)(@vitest/browser-playwright@4.1.4)(@vitest/browser-preview@4.1.4)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.2)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3))
+      vitest: 4.1.4(@types/node@24.12.2)(@vitest/browser-playwright@4.1.4)(@vitest/browser-preview@4.1.4)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.2)(vite@8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3))
     transitivePeerDependencies:
       - bufferutil
       - msw
       - utf-8-validate
       - vite
 
-  '@vitest/browser-preview@4.1.4(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3))(vitest@4.1.4)':
+  '@vitest/browser-preview@4.1.4(vite@8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3))(vitest@4.1.4)':
     dependencies:
       '@testing-library/dom': 10.4.1
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
-      '@vitest/browser': 4.1.4(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3))(vitest@4.1.4)
-      vitest: 4.1.4(@types/node@24.12.2)(@vitest/browser-playwright@4.1.4)(@vitest/browser-preview@4.1.4)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.2)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3))
+      '@vitest/browser': 4.1.4(vite@8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3))(vitest@4.1.4)
+      vitest: 4.1.4(@types/node@24.12.2)(@vitest/browser-playwright@4.1.4)(@vitest/browser-preview@4.1.4)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.2)(vite@8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3))
     transitivePeerDependencies:
       - bufferutil
       - msw
       - utf-8-validate
       - vite
 
-  '@vitest/browser@4.1.4(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3))(vitest@4.1.4)':
+  '@vitest/browser@4.1.4(vite@8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3))(vitest@4.1.4)':
     dependencies:
       '@blazediff/core': 1.9.1
-      '@vitest/mocker': 4.1.4(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3))
+      '@vitest/mocker': 4.1.4(vite@8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3))
       '@vitest/utils': 4.1.4
       magic-string: 0.30.21
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@types/node@24.12.2)(@vitest/browser-playwright@4.1.4)(@vitest/browser-preview@4.1.4)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.2)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3))
+      vitest: 4.1.4(@types/node@24.12.2)(@vitest/browser-playwright@4.1.4)(@vitest/browser-preview@4.1.4)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.2)(vite@8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3))
       ws: 8.20.0
     transitivePeerDependencies:
       - bufferutil
@@ -5619,9 +5439,9 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@types/node@24.12.2)(@vitest/browser-playwright@4.1.4)(@vitest/browser-preview@4.1.4)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.2)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3))
+      vitest: 4.1.4(@types/node@24.12.2)(@vitest/browser-playwright@4.1.4)(@vitest/browser-preview@4.1.4)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.2)(vite@8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3))
     optionalDependencies:
-      '@vitest/browser': 4.1.4(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3))(vitest@4.1.4)
+      '@vitest/browser': 4.1.4(vite@8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3))(vitest@4.1.4)
 
   '@vitest/eslint-plugin@1.6.16(@typescript-eslint/eslint-plugin@8.58.2(@typescript-eslint/parser@8.58.2(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.3))(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.3))(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.3)(vitest@4.1.4)':
     dependencies:
@@ -5631,7 +5451,7 @@ snapshots:
     optionalDependencies:
       '@typescript-eslint/eslint-plugin': 8.58.2(@typescript-eslint/parser@8.58.2(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.3))(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.3)
       typescript: 6.0.3
-      vitest: 4.1.4(@types/node@24.12.2)(@vitest/browser-playwright@4.1.4)(@vitest/browser-preview@4.1.4)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.2)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3))
+      vitest: 4.1.4(@types/node@24.12.2)(@vitest/browser-playwright@4.1.4)(@vitest/browser-preview@4.1.4)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.2)(vite@8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3))
     transitivePeerDependencies:
       - supports-color
 
@@ -5644,13 +5464,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.4(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3))':
+  '@vitest/mocker@4.1.4(vite@8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 4.1.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3)
+      vite: 8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3)
 
   '@vitest/pretty-format@4.1.4':
     dependencies:
@@ -6092,7 +5912,7 @@ snapshots:
 
   empathic@2.0.0: {}
 
-  entities@6.0.1: {}
+  entities@8.0.0: {}
 
   environment@1.1.0: {}
 
@@ -6138,7 +5958,7 @@ snapshots:
       object.assign: 4.1.7
       own-keys: 1.0.1
       regexp.prototype.flags: 1.5.4
-      safe-array-concat: 1.1.3
+      safe-array-concat: 1.1.4
       safe-push-apply: 1.0.0
       safe-regex-test: 1.1.0
       set-proto: 1.0.0
@@ -6551,14 +6371,6 @@ snapshots:
 
   fast-deep-equal@3.1.3: {}
 
-  fast-glob@3.3.3:
-    dependencies:
-      '@nodelib/fs.stat': 2.0.5
-      '@nodelib/fs.walk': 1.2.8
-      glob-parent: 5.1.2
-      merge2: 1.4.1
-      micromatch: 4.0.8
-
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
@@ -6624,7 +6436,7 @@ snapshots:
   fs-extra@11.3.4:
     dependencies:
       graceful-fs: 4.2.11
-      jsonfile: 6.2.0
+      jsonfile: 6.2.1
       universalify: 2.0.1
 
   fsevents@2.3.2:
@@ -6680,19 +6492,11 @@ snapshots:
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
 
-  get-tsconfig@4.13.7:
-    dependencies:
-      resolve-pkg-maps: 1.0.0
-
   get-tsconfig@4.14.0:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
   git-hooks-list@4.2.1: {}
-
-  glob-parent@5.1.2:
-    dependencies:
-      is-glob: 4.0.3
 
   glob-parent@6.0.2:
     dependencies:
@@ -6984,7 +6788,7 @@ snapshots:
       html-encoding-sniffer: 6.0.0
       is-potential-custom-element-name: 1.0.1
       lru-cache: 11.3.5
-      parse5: 8.0.0
+      parse5: 8.0.1
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.1
@@ -7020,7 +6824,7 @@ snapshots:
       eslint-visitor-keys: 5.0.1
       semver: 7.7.4
 
-  jsonfile@6.2.0:
+  jsonfile@6.2.1:
     dependencies:
       universalify: 2.0.1
     optionalDependencies:
@@ -7041,20 +6845,20 @@ snapshots:
 
   kind-of@6.0.3: {}
 
-  knip@6.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0):
+  knip@6.5.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0):
     dependencies:
       '@nodelib/fs.walk': 1.2.8
-      fast-glob: 3.3.3
       formatly: 0.3.0
-      get-tsconfig: 4.13.7
+      get-tsconfig: 4.14.0
       jiti: 2.6.1
       minimist: 1.2.8
-      oxc-parser: 0.121.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      oxc-parser: 0.126.0
       oxc-resolver: 11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
       picocolors: 1.1.1
       picomatch: 4.0.4
       smol-toml: 1.6.1
       strip-json-comments: 5.0.3
+      tinyglobby: 0.2.16
       unbash: 2.2.0
       yaml: 2.8.3
       zod: 4.3.6
@@ -7185,8 +6989,6 @@ snapshots:
 
   mdn-data@2.27.1: {}
 
-  merge2@1.4.1: {}
-
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
@@ -7306,33 +7108,30 @@ snapshots:
       object-keys: 1.1.1
       safe-push-apply: 1.0.0
 
-  oxc-parser@0.121.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0):
+  oxc-parser@0.126.0:
     dependencies:
-      '@oxc-project/types': 0.121.0
+      '@oxc-project/types': 0.126.0
     optionalDependencies:
-      '@oxc-parser/binding-android-arm-eabi': 0.121.0
-      '@oxc-parser/binding-android-arm64': 0.121.0
-      '@oxc-parser/binding-darwin-arm64': 0.121.0
-      '@oxc-parser/binding-darwin-x64': 0.121.0
-      '@oxc-parser/binding-freebsd-x64': 0.121.0
-      '@oxc-parser/binding-linux-arm-gnueabihf': 0.121.0
-      '@oxc-parser/binding-linux-arm-musleabihf': 0.121.0
-      '@oxc-parser/binding-linux-arm64-gnu': 0.121.0
-      '@oxc-parser/binding-linux-arm64-musl': 0.121.0
-      '@oxc-parser/binding-linux-ppc64-gnu': 0.121.0
-      '@oxc-parser/binding-linux-riscv64-gnu': 0.121.0
-      '@oxc-parser/binding-linux-riscv64-musl': 0.121.0
-      '@oxc-parser/binding-linux-s390x-gnu': 0.121.0
-      '@oxc-parser/binding-linux-x64-gnu': 0.121.0
-      '@oxc-parser/binding-linux-x64-musl': 0.121.0
-      '@oxc-parser/binding-openharmony-arm64': 0.121.0
-      '@oxc-parser/binding-wasm32-wasi': 0.121.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
-      '@oxc-parser/binding-win32-arm64-msvc': 0.121.0
-      '@oxc-parser/binding-win32-ia32-msvc': 0.121.0
-      '@oxc-parser/binding-win32-x64-msvc': 0.121.0
-    transitivePeerDependencies:
-      - '@emnapi/core'
-      - '@emnapi/runtime'
+      '@oxc-parser/binding-android-arm-eabi': 0.126.0
+      '@oxc-parser/binding-android-arm64': 0.126.0
+      '@oxc-parser/binding-darwin-arm64': 0.126.0
+      '@oxc-parser/binding-darwin-x64': 0.126.0
+      '@oxc-parser/binding-freebsd-x64': 0.126.0
+      '@oxc-parser/binding-linux-arm-gnueabihf': 0.126.0
+      '@oxc-parser/binding-linux-arm-musleabihf': 0.126.0
+      '@oxc-parser/binding-linux-arm64-gnu': 0.126.0
+      '@oxc-parser/binding-linux-arm64-musl': 0.126.0
+      '@oxc-parser/binding-linux-ppc64-gnu': 0.126.0
+      '@oxc-parser/binding-linux-riscv64-gnu': 0.126.0
+      '@oxc-parser/binding-linux-riscv64-musl': 0.126.0
+      '@oxc-parser/binding-linux-s390x-gnu': 0.126.0
+      '@oxc-parser/binding-linux-x64-gnu': 0.126.0
+      '@oxc-parser/binding-linux-x64-musl': 0.126.0
+      '@oxc-parser/binding-openharmony-arm64': 0.126.0
+      '@oxc-parser/binding-wasm32-wasi': 0.126.0
+      '@oxc-parser/binding-win32-arm64-msvc': 0.126.0
+      '@oxc-parser/binding-win32-ia32-msvc': 0.126.0
+      '@oxc-parser/binding-win32-x64-msvc': 0.126.0
 
   oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0):
     optionalDependencies:
@@ -7456,9 +7255,9 @@ snapshots:
 
   parse5@6.0.1: {}
 
-  parse5@8.0.0:
+  parse5@8.0.1:
     dependencies:
-      entities: 6.0.1
+      entities: 8.0.0
 
   path-exists@3.0.0: {}
 
@@ -7644,27 +7443,6 @@ snapshots:
     transitivePeerDependencies:
       - oxc-resolver
 
-  rolldown@1.0.0-rc.15:
-    dependencies:
-      '@oxc-project/types': 0.124.0
-      '@rolldown/pluginutils': 1.0.0-rc.15
-    optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.0.0-rc.15
-      '@rolldown/binding-darwin-arm64': 1.0.0-rc.15
-      '@rolldown/binding-darwin-x64': 1.0.0-rc.15
-      '@rolldown/binding-freebsd-x64': 1.0.0-rc.15
-      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.15
-      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.15
-      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.15
-      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.15
-      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.15
-      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.15
-      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.15
-      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.15
-      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.15
-      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.15
-      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.15
-
   rolldown@1.0.0-rc.16:
     dependencies:
       '@oxc-project/types': 0.126.0
@@ -7694,7 +7472,7 @@ snapshots:
     dependencies:
       mri: 1.2.0
 
-  safe-array-concat@1.1.3:
+  safe-array-concat@1.1.4:
     dependencies:
       call-bind: 1.0.9
       call-bound: 1.0.4
@@ -8193,12 +7971,12 @@ snapshots:
 
   validate-npm-package-name@7.0.2: {}
 
-  vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3):
+  vite@8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
       postcss: 8.5.10
-      rolldown: 1.0.0-rc.15
+      rolldown: 1.0.0-rc.16
       tinyglobby: 0.2.16
     optionalDependencies:
       '@types/node': 24.12.2
@@ -8207,10 +7985,10 @@ snapshots:
       jiti: 2.6.1
       yaml: 2.8.3
 
-  vitest@4.1.4(@types/node@24.12.2)(@vitest/browser-playwright@4.1.4)(@vitest/browser-preview@4.1.4)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.2)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3)):
+  vitest@4.1.4(@types/node@24.12.2)(@vitest/browser-playwright@4.1.4)(@vitest/browser-preview@4.1.4)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.2)(vite@8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.4
-      '@vitest/mocker': 4.1.4(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3))
+      '@vitest/mocker': 4.1.4(vite@8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3))
       '@vitest/pretty-format': 4.1.4
       '@vitest/runner': 4.1.4
       '@vitest/snapshot': 4.1.4
@@ -8227,12 +8005,12 @@ snapshots:
       tinyexec: 1.1.1
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3)
+      vite: 8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.12.2
-      '@vitest/browser-playwright': 4.1.4(playwright@1.59.1)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3))(vitest@4.1.4)
-      '@vitest/browser-preview': 4.1.4(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3))(vitest@4.1.4)
+      '@vitest/browser-playwright': 4.1.4(playwright@1.59.1)(vite@8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3))(vitest@4.1.4)
+      '@vitest/browser-preview': 4.1.4(vite@8.0.9(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3))(vitest@4.1.4)
       '@vitest/coverage-v8': 4.1.4(@vitest/browser@4.1.4)(vitest@4.1.4)
       jsdom: 29.0.2
     transitivePeerDependencies:

--- a/src/Highlighter.spec.tsx
+++ b/src/Highlighter.spec.tsx
@@ -368,6 +368,41 @@ describe('Highlighter', () => {
     expect(renderedMentions).toHaveLength(2)
   })
 
+  it('keeps unaffected substring spans stable when only the caret moves', () => {
+    const value = 'Hello @[John](user1) and goodbye'
+    const getSuffixSpan = (container: HTMLElement): HTMLSpanElement | undefined =>
+      [...container.querySelectorAll('span')].find(
+        (element): element is HTMLSpanElement => element.textContent === ' and goodbye'
+      )
+
+    const { container, rerender } = render(
+      <Highlighter
+        selectionStart={1}
+        selectionEnd={1}
+        value={value}
+        onCaretPositionChange={vi.fn()}
+      >
+        <Mention trigger="@" data={[]} markup="@[__display__](__id__)" />
+      </Highlighter>
+    )
+
+    const suffixSpan = getSuffixSpan(container)
+    expect(suffixSpan).toBeDefined()
+
+    rerender(
+      <Highlighter
+        selectionStart={3}
+        selectionEnd={3}
+        value={value}
+        onCaretPositionChange={vi.fn()}
+      >
+        <Mention trigger="@" data={[]} markup="@[__display__](__id__)" />
+      </Highlighter>
+    )
+
+    expect(getSuffixSpan(container)).toBe(suffixSpan)
+  })
+
   it('does not emit a redundant caret update when recomputing the same position', async () => {
     const onCaretPositionChange = vi.fn()
     const rafCallbacks: FrameRequestCallback[] = []

--- a/src/Highlighter.tsx
+++ b/src/Highlighter.tsx
@@ -1,7 +1,7 @@
-import React, { useLayoutEffect, useMemo, useState } from 'react'
+import React, { useLayoutEffect, useMemo, useRef } from 'react'
 import type { CSSProperties } from 'react'
 import { cva } from 'class-variance-authority'
-import { iterateMentionsMarkup, mapPlainTextIndex, isNumber, cn } from './utils'
+import { iterateMentionsMarkup, isNumber, cn } from './utils'
 import readConfigFromChildren, { collectMentionElements } from './utils/readConfigFromChildren'
 import { useEventCallback } from './utils/useEventCallback'
 import type {
@@ -37,6 +37,26 @@ interface HighlighterProps<Extra extends Record<string, unknown> = Record<string
   readonly mentionSelectionMap?: Record<string, MentionSelectionState>
 }
 
+interface TextHighlighterSegment {
+  readonly type: 'text'
+  readonly key: string
+  readonly index: number
+  readonly plainTextIndex: number
+  readonly value: string
+}
+
+interface MentionHighlighterSegment {
+  readonly type: 'mention'
+  readonly key: string
+  readonly id: string
+  readonly index: number
+  readonly display: string
+  readonly mentionChildIndex: number
+  readonly plainTextIndex: number
+}
+
+type HighlighterSegment = TextHighlighterSegment | MentionHighlighterSegment
+
 // Note: singleLine intentionally overrides whitespace/break behavior
 const highlighterStyles = cva(
   'box-border w-full overflow-hidden text-start text-transparent pointer-events-none [font-family:inherit] [font-size:inherit] [line-height:inherit]',
@@ -59,37 +79,50 @@ const singleLineContentWrapperStyle: CSSProperties = {
   minWidth: '100%',
 }
 
-function Highlighter<Extra extends Record<string, unknown> = Record<string, unknown>>({
-  selectionStart,
-  selectionEnd,
-  value = '',
-  onCaretPositionChange,
-  containerRef,
-  children,
-  mentionChildren: mentionChildrenProp,
-  config: configProp,
-  singleLine,
+interface HighlighterSubstringProps {
+  readonly className: string
+  readonly value: string
+}
+
+// Hidden substring spans preserve textarea geometry without duplicating visible text on iOS.
+const HighlighterSubstring = React.memo(function HighlighterSubstring({
   className,
-  substringClassName,
-  caretClassName,
+  value,
+}: HighlighterSubstringProps) {
+  return <span className={className}>{value}</span>
+})
+
+interface HighlighterCaretProps {
+  readonly className: string
+  readonly measureKey: string
+  readonly onCaretPositionChange: (position: CaretCoordinates) => void
+  readonly recomputeVersion?: number
+  readonly singleLine: boolean
+}
+
+const HighlighterCaret = React.memo(function HighlighterCaret({
+  className,
+  measureKey,
+  onCaretPositionChange,
   recomputeVersion,
-  mentionSelectionMap,
-}: HighlighterProps<Extra>) {
-  const [position, setPosition] = useState<CaretCoordinates | null>(null)
-  const [caretElement, setCaretElement] = useState<HTMLSpanElement | null>(null)
+  singleLine,
+}: HighlighterCaretProps) {
+  const caretRef = useRef<HTMLSpanElement | null>(null)
+  const positionRef = useRef<CaretCoordinates | null>(null)
 
   const updatePosition = useEventCallback((offsetLeft: number, offsetTop: number) => {
+    const position = positionRef.current
     if (position?.left === offsetLeft && position.top === offsetTop) {
       return
     }
 
     const newPosition: CaretCoordinates = { left: offsetLeft, top: offsetTop }
-    setPosition(newPosition)
+    positionRef.current = newPosition
     onCaretPositionChange(newPosition)
   })
 
-  // Ensure caret position updates whenever content/selection affects layout.
   useLayoutEffect(() => {
+    const caretElement = caretRef.current
     if (caretElement === null) {
       return undefined
     }
@@ -119,17 +152,155 @@ function Highlighter<Extra extends Record<string, unknown> = Record<string, unkn
         globalThis.cancelAnimationFrame(rafId)
       }
     }
-    // value/selection/singleLine impact layout/position
-  }, [
-    caretElement,
-    recomputeVersion,
-    selectionEnd,
-    selectionStart,
-    singleLine,
-    updatePosition,
-    value,
-  ])
+  }, [measureKey, recomputeVersion, singleLine, updatePosition])
 
+  return (
+    <span className={className} data-mentions-caret ref={caretRef} key="caret" aria-hidden="true" />
+  )
+})
+
+interface HighlighterTextSegmentProps {
+  readonly caretClassName: string
+  readonly caretOffset: number | null
+  readonly className: string
+  readonly onCaretPositionChange: (position: CaretCoordinates) => void
+  readonly recomputeVersion?: number
+  readonly segment: TextHighlighterSegment
+  readonly singleLine: boolean
+}
+
+const HighlighterTextSegment = React.memo(function HighlighterTextSegment({
+  caretClassName,
+  caretOffset,
+  className,
+  onCaretPositionChange,
+  recomputeVersion,
+  segment,
+  singleLine,
+}: HighlighterTextSegmentProps) {
+  if (caretOffset === null) {
+    return <HighlighterSubstring className={className} value={segment.value} />
+  }
+
+  return (
+    <>
+      <HighlighterSubstring className={className} value={segment.value.slice(0, caretOffset)} />
+      <HighlighterCaret
+        className={caretClassName}
+        measureKey={`${segment.index.toString()}:${caretOffset.toString()}:${segment.value}`}
+        onCaretPositionChange={onCaretPositionChange}
+        recomputeVersion={recomputeVersion}
+        singleLine={singleLine}
+      />
+      <HighlighterSubstring className={className} value={segment.value.slice(caretOffset)} />
+    </>
+  )
+})
+
+type HighlighterMentionCloneProps = MentionComponentProps & {
+  readonly display?: string
+  readonly id?: string
+}
+
+interface HighlighterMentionSegmentProps {
+  readonly child: React.ReactElement<HighlighterMentionCloneProps>
+  readonly display: string
+  readonly id: string
+  readonly selectionState?: MentionSelectionState
+}
+
+const HighlighterMentionSegment = React.memo(function HighlighterMentionSegment({
+  child,
+  display,
+  id,
+  selectionState,
+}: HighlighterMentionSegmentProps) {
+  return React.cloneElement(child, { id, display, selectionState })
+})
+
+const buildHighlighterSegments = <Extra extends Record<string, unknown>>(
+  value: string,
+  config: ReadonlyArray<MentionChildConfig<Extra>>
+): HighlighterSegment[] => {
+  const segments: HighlighterSegment[] = []
+  const componentKeys: Record<string, number> = {}
+
+  const textIteratee = (substr: string, index: number, plainTextIndex: number) => {
+    segments.push({
+      type: 'text',
+      key: `text:${index.toString()}:${substr.length.toString()}`,
+      index,
+      plainTextIndex,
+      value: substr,
+    })
+  }
+
+  const mentionIteratee = (
+    _markup: string,
+    index: number,
+    plainTextIndex: number,
+    id: string,
+    display: string,
+    mentionChildIndex: number
+  ) => {
+    segments.push({
+      type: 'mention',
+      key: `mention:${generateComponentKey(componentKeys, id)}`,
+      id,
+      index,
+      display,
+      mentionChildIndex,
+      plainTextIndex,
+    })
+  }
+
+  iterateMentionsMarkup(value, config, mentionIteratee, textIteratee)
+
+  return segments
+}
+
+const getCaretPositionInMarkup = (
+  segments: ReadonlyArray<HighlighterSegment>,
+  valueLength: number,
+  selectionStart: number | null,
+  selectionEnd: number | null
+): number | null => {
+  if (selectionStart !== selectionEnd || !isNumber(selectionStart)) {
+    return null
+  }
+
+  for (const segment of segments) {
+    if (segment.type === 'text') {
+      if (segment.plainTextIndex + segment.value.length >= selectionStart) {
+        return segment.index + selectionStart - segment.plainTextIndex
+      }
+      continue
+    }
+
+    if (segment.plainTextIndex + segment.display.length > selectionStart) {
+      return segment.index
+    }
+  }
+
+  return valueLength
+}
+
+function Highlighter<Extra extends Record<string, unknown> = Record<string, unknown>>({
+  selectionStart,
+  selectionEnd,
+  value = '',
+  onCaretPositionChange,
+  containerRef,
+  children,
+  mentionChildren: mentionChildrenProp,
+  config: configProp,
+  singleLine,
+  className,
+  substringClassName,
+  caretClassName,
+  recomputeVersion,
+  mentionSelectionMap,
+}: HighlighterProps<Extra>) {
   const mentionChildren = useMemo(
     () => mentionChildrenProp ?? collectMentionElements(children),
     [children, mentionChildrenProp]
@@ -138,98 +309,61 @@ function Highlighter<Extra extends Record<string, unknown> = Record<string, unkn
     () => configProp ?? readConfigFromChildren<Extra>(mentionChildren),
     [configProp, mentionChildren]
   )
-  let caretPositionInMarkup: number | null | undefined
+  const segments = useMemo(() => buildHighlighterSegments(value, config), [config, value])
 
   const rootClassName = cn(highlighterStyles({ singleLine }), className)
   const substringClass = cn(substringStyles, substringClassName)
   const caretClass = cn(caretStyles, caretClassName)
-
-  if (selectionEnd === selectionStart) {
-    caretPositionInMarkup = mapPlainTextIndex(value, config, selectionStart, 'START') as
-      | number
-      | undefined
-  }
   const selectionMap = mentionSelectionMap ?? {}
-
-  const resultComponents: React.ReactNode[] = []
-  const componentKeys: Record<string, number> = {}
-  let components: React.ReactNode[] = resultComponents
-  let substringComponentKey = 0
-
-  const renderSubstring = (substringValue: string, key: number) => (
-    // set substring span to hidden, so that Emojis are not shown double in Mobile Safari
-    <span className={substringClass} key={key}>
-      {substringValue}
-    </span>
+  const caretPositionInMarkup = getCaretPositionInMarkup(
+    segments,
+    value.length,
+    selectionStart,
+    selectionEnd
   )
 
-  const getMentionComponentForMatch = (
-    id: string,
-    display: string,
-    mentionChildIndex: number,
-    key: string,
-    plainTextIndex: number
-  ) => {
-    const selectionKey = `${mentionChildIndex}:${plainTextIndex}`
-    const selectionState = selectionMap[selectionKey]
-    const props = { id, display, key, selectionState }
-    const child = mentionChildren[mentionChildIndex] as React.ReactElement<MentionComponentProps>
-    return React.cloneElement(child, props)
-  }
+  const resultComponents: React.ReactNode[] = segments.map((segment) => {
+    if (segment.type === 'mention') {
+      const selectionKey = `${segment.mentionChildIndex.toString()}:${segment.plainTextIndex.toString()}`
+      const child = mentionChildren[
+        segment.mentionChildIndex
+      ] as React.ReactElement<HighlighterMentionCloneProps>
 
-  const renderCaretMarker = () => (
-    <span
-      className={caretClass}
-      data-mentions-caret
-      ref={setCaretElement}
-      key="caret"
-      aria-hidden="true"
-    />
-  )
-
-  const textIteratee = (substr: string, index: number, _substrPlainTextIndex: number) => {
-    if (
-      isNumber(caretPositionInMarkup) &&
-      caretPositionInMarkup >= index &&
-      caretPositionInMarkup <= index + substr.length
-    ) {
-      const splitIndex = caretPositionInMarkup - index
-      // Before the reassignment, components still points at resultComponents, so the push stores
-      // the substring that comes before the caret in the final output.
-      components.push(renderSubstring(substr.slice(0, splitIndex), substringComponentKey))
-      substringComponentKey += 1
-      // Reassigning component just switches the working array to a fresh list
-      // for the text after the caret; later we splice that array back in
-      //  Without the initial push, the prefix would not land in resultComponents.
-      components = [renderSubstring(substr.slice(splitIndex), substringComponentKey)]
-    } else {
-      components.push(renderSubstring(substr, substringComponentKey))
+      return (
+        <HighlighterMentionSegment
+          child={child}
+          display={segment.display}
+          id={segment.id}
+          key={segment.key}
+          selectionState={selectionMap[selectionKey]}
+        />
+      )
     }
-    substringComponentKey += 1
-  }
 
-  const mentionIteratee = (
-    _markup: string,
-    _index: number,
-    plainTextIndex: number,
-    id: string,
-    display: string,
-    mentionChildIndex: number
-  ) => {
-    const key = generateComponentKey(componentKeys, id)
-    components.push(
-      getMentionComponentForMatch(id, display, mentionChildIndex, key, plainTextIndex)
+    const caretOffset =
+      isNumber(caretPositionInMarkup) &&
+      caretPositionInMarkup >= segment.index &&
+      caretPositionInMarkup <= segment.index + segment.value.length
+        ? caretPositionInMarkup - segment.index
+        : null
+
+    return (
+      <HighlighterTextSegment
+        caretClassName={caretClass}
+        caretOffset={caretOffset}
+        className={substringClass}
+        key={segment.key}
+        onCaretPositionChange={onCaretPositionChange}
+        recomputeVersion={recomputeVersion}
+        segment={segment}
+        singleLine={singleLine}
+      />
     )
-  }
+  })
 
-  iterateMentionsMarkup(value, config, mentionIteratee, textIteratee)
+  // append a space to ensure the last text line has the correct height
+  resultComponents.push(' ')
 
-  // append a span containing a space, to ensure the last text line has the correct height
-  components.push(' ')
-
-  if (components !== resultComponents) {
-    resultComponents.push(renderCaretMarker(), ...components)
-  }
   const content = singleLine ? (
     <div style={singleLineContentWrapperStyle}>{resultComponents}</div>
   ) : (

--- a/src/MentionsInput.spec.tsx
+++ b/src/MentionsInput.spec.tsx
@@ -1329,6 +1329,88 @@ describe('MentionsInput', () => {
     })
   })
 
+  it('replays a near-bottom scroll made while matching mention children are still loading.', async () => {
+    interface SuggestionPage {
+      items: Array<{ id: string; display: string }>
+      nextCursor: string | null
+    }
+
+    let resolveSecondInitial: (value: SuggestionPage) => void = () => undefined
+
+    const firstAsyncData = vi.fn(async (_query: string, context: MentionSearchContext) =>
+      context.reason === 'page'
+        ? {
+            items: [{ id: 'first-page-2', display: 'First Page 2' }],
+            nextCursor: null,
+          }
+        : {
+            items: [{ id: 'first-page-1', display: 'First Page 1' }],
+            nextCursor: 'first-cursor-2',
+          }
+    )
+    const secondAsyncData = vi.fn((_query: string, context: MentionSearchContext) => {
+      if (context.reason === 'page') {
+        return Promise.resolve({
+          items: [{ id: 'second-page-2', display: 'Second Page 2' }],
+          nextCursor: null,
+        })
+      }
+
+      return new Promise<SuggestionPage>((resolve) => {
+        resolveSecondInitial = resolve
+      })
+    })
+
+    render(
+      <MentionsInput value="@a">
+        <Mention trigger={/(@([a-z]*))$/} data={firstAsyncData} />
+        <Mention trigger={/(@([a-z]*))$/} data={secondAsyncData} />
+      </MentionsInput>
+    )
+
+    const textarea = screen.getByRole('combobox')
+    fireEvent.focus(textarea)
+    textarea.setSelectionRange(2, 2)
+    fireEvent.select(textarea)
+
+    await waitFor(() => {
+      expect(screen.getByText('First Page 1')).toBeInTheDocument()
+      expect(document.querySelector('[data-slot="suggestions"]')).toHaveAttribute(
+        'aria-busy',
+        'true'
+      )
+    })
+
+    scrollSuggestionsNearBottom()
+
+    expect(
+      firstAsyncData.mock.calls.filter(([, context]) => context.reason === 'page')
+    ).toHaveLength(0)
+
+    await act(async () => {
+      resolveSecondInitial({
+        items: [{ id: 'second-page-1', display: 'Second Page 1' }],
+        nextCursor: 'second-cursor-2',
+      })
+    })
+
+    await waitFor(() => {
+      expect(firstAsyncData).toHaveBeenCalledWith(
+        'a',
+        expect.objectContaining({ cursor: 'first-cursor-2', reason: 'page' })
+      )
+      expect(secondAsyncData).toHaveBeenCalledWith(
+        'a',
+        expect.objectContaining({ cursor: 'second-cursor-2', reason: 'page' })
+      )
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('First Page 2')).toBeInTheDocument()
+      expect(screen.getByText('Second Page 2')).toBeInTheDocument()
+    })
+  })
+
   it('replaces the latest query range when selecting a preserved async suggestion.', async () => {
     interface DeferredResult {
       resolve: (value: Array<{ id: string; display: string }>) => void

--- a/src/MentionsInputLayout.spec.ts
+++ b/src/MentionsInputLayout.spec.ts
@@ -407,13 +407,175 @@ describe('MentionsInputLayout', () => {
       }),
     })
 
-    expect(calculateInlineSuggestionPosition({ highlighter })).toEqual({
+    expect(calculateInlineSuggestionPosition({ highlighter })).toMatchObject({
       left: 22,
       top: 18,
     })
     expect(areInlineSuggestionPositionsEqual({ left: 22, top: 18 }, { left: 22, top: 18 })).toBe(
       true
     )
+  })
+
+  it('aligns inline suggestion top with the current text line', () => {
+    const control = document.createElement('div')
+    const highlighter = document.createElement('div')
+    const previousText = document.createElement('span')
+    const caret = document.createElement('span')
+
+    caret.dataset.mentionsCaret = 'true'
+    highlighter.append(previousText, caret)
+    control.append(highlighter)
+
+    Object.defineProperty(control, 'getBoundingClientRect', {
+      value: () => ({
+        left: 20,
+        top: 10,
+        right: 0,
+        bottom: 0,
+        width: 0,
+        height: 0,
+      }),
+    })
+    Object.defineProperty(previousText, 'getBoundingClientRect', {
+      value: () => ({
+        left: 20,
+        top: 28,
+        right: 42,
+        bottom: 44,
+        width: 22,
+        height: 16,
+      }),
+    })
+    Object.defineProperty(caret, 'getBoundingClientRect', {
+      value: () => ({
+        left: 42,
+        top: 44,
+        right: 42,
+        bottom: 44,
+        width: 0,
+        height: 0,
+      }),
+    })
+
+    expect(calculateInlineSuggestionPosition({ highlighter })).toMatchObject({
+      left: 22,
+      top: 18,
+    })
+  })
+
+  it('carries input typography metrics from the synced highlighter to inline suggestions', () => {
+    const control = document.createElement('div')
+    const highlighter = document.createElement('div')
+    const previousText = document.createElement('span')
+    const caret = document.createElement('span')
+
+    highlighter.style.fontFamily = 'Inter, sans-serif'
+    highlighter.style.fontSize = '16px'
+    highlighter.style.letterSpacing = '0.02em'
+    highlighter.style.lineHeight = '26px'
+    highlighter.style.textTransform = 'uppercase'
+    highlighter.style.wordSpacing = '1px'
+
+    caret.dataset.mentionsCaret = 'true'
+    highlighter.append(previousText, caret)
+    control.append(highlighter)
+
+    Object.defineProperty(control, 'getBoundingClientRect', {
+      value: () => ({
+        left: 20,
+        top: 10,
+        right: 0,
+        bottom: 0,
+        width: 0,
+        height: 0,
+      }),
+    })
+    Object.defineProperty(previousText, 'getBoundingClientRect', {
+      value: () => ({
+        left: 20,
+        top: 28,
+        right: 42,
+        bottom: 44,
+        width: 22,
+        height: 16,
+      }),
+    })
+    Object.defineProperty(caret, 'getBoundingClientRect', {
+      value: () => ({
+        left: 42,
+        top: 44,
+        right: 42,
+        bottom: 44,
+        width: 0,
+        height: 0,
+      }),
+    })
+
+    expect(calculateInlineSuggestionPosition({ highlighter })).toEqual({
+      left: 22,
+      top: 13,
+      fontFamily: 'Inter, sans-serif',
+      fontSize: '16px',
+      letterSpacing: '0.02em',
+      lineHeight: '26px',
+      textTransform: 'uppercase',
+      wordSpacing: '1px',
+    })
+    expect(
+      areInlineSuggestionPositionsEqual(
+        { left: 22, top: 18, lineHeight: '24px' },
+        { left: 22, top: 18, lineHeight: '26px' }
+      )
+    ).toBe(false)
+  })
+
+  it('positions inline suggestions from the control padding edge', () => {
+    const control = document.createElement('div')
+    const highlighter = document.createElement('div')
+    const previousText = document.createElement('span')
+    const caret = document.createElement('span')
+
+    control.style.borderLeftWidth = '2px'
+    control.style.borderTopWidth = '3px'
+    caret.dataset.mentionsCaret = 'true'
+    highlighter.append(previousText, caret)
+    control.append(highlighter)
+
+    Object.defineProperty(control, 'getBoundingClientRect', {
+      value: () => ({
+        left: 20,
+        top: 10,
+        right: 0,
+        bottom: 0,
+        width: 0,
+        height: 0,
+      }),
+    })
+    Object.defineProperty(previousText, 'getBoundingClientRect', {
+      value: () => ({
+        left: 24,
+        top: 30,
+        right: 42,
+        bottom: 44,
+        width: 18,
+        height: 14,
+      }),
+    })
+    Object.defineProperty(caret, 'getBoundingClientRect', {
+      value: () => ({
+        left: 42,
+        top: 44,
+        right: 42,
+        bottom: 44,
+        width: 0,
+        height: 0,
+      }),
+    })
+
+    expect(calculateInlineSuggestionPosition({ highlighter })).toEqual({
+      left: 20,
+      top: 17,
+    })
   })
 
   it('merges pending view-sync flags without dropping prior work', () => {

--- a/src/MentionsInputLayout.ts
+++ b/src/MentionsInputLayout.ts
@@ -44,6 +44,15 @@ interface InlineSuggestionPositionArgs {
   highlighter: HTMLDivElement | null
 }
 
+const INLINE_TYPOGRAPHY_STYLE_PROPS = [
+  'fontFamily',
+  'fontSize',
+  'letterSpacing',
+  'lineHeight',
+  'textTransform',
+  'wordSpacing',
+] as const
+
 interface HighlighterViewPatch {
   scrollLeft: number
   scrollTop: number
@@ -246,14 +255,39 @@ export const calculateInlineSuggestionPosition = ({
   const controlElement = highlighter.parentElement
   const controlRect = controlElement?.getBoundingClientRect()
   const caretRect = caretElement?.getBoundingClientRect()
+  const previousInlineBoxRect = caretElement?.previousElementSibling?.getBoundingClientRect()
 
-  if (!caretRect || !controlRect) {
+  if (!caretRect || !controlElement || !controlRect) {
     return null
   }
 
+  const controlBorderLeft = getComputedStyleLengthProp(controlElement, 'border-left-width')
+  const controlBorderTop = getComputedStyleLengthProp(controlElement, 'border-top-width')
+  const lineHeight = getComputedStyleLengthProp(highlighter, 'line-height')
+  const inlineLeadingOffset =
+    previousInlineBoxRect === undefined || lineHeight <= previousInlineBoxRect.height
+      ? 0
+      : (lineHeight - previousInlineBoxRect.height) / 2
+  const typographyStyle: Pick<
+    InlineSuggestionPosition,
+    'fontFamily' | 'fontSize' | 'letterSpacing' | 'lineHeight' | 'textTransform' | 'wordSpacing'
+  > = {}
+
+  for (const styleProperty of INLINE_TYPOGRAPHY_STYLE_PROPS) {
+    const value = highlighter.style[styleProperty]
+    if (value.length > 0) {
+      typographyStyle[styleProperty] = value
+    }
+  }
+
   return {
-    left: caretRect.left - controlRect.left,
-    top: caretRect.top - controlRect.top,
+    left: caretRect.left - controlRect.left - controlBorderLeft,
+    top:
+      (previousInlineBoxRect?.top ?? caretRect.top) -
+      controlRect.top -
+      controlBorderTop -
+      inlineLeadingOffset,
+    ...typographyStyle,
   }
 }
 
@@ -270,7 +304,15 @@ export const areSuggestionsPositionsEqual = (
 export const areInlineSuggestionPositionsEqual = (
   left: InlineSuggestionPosition | null,
   right: InlineSuggestionPosition | null
-): boolean => left?.left === right?.left && left?.top === right?.top
+): boolean =>
+  left?.left === right?.left &&
+  left?.top === right?.top &&
+  left?.fontFamily === right?.fontFamily &&
+  left?.fontSize === right?.fontSize &&
+  left?.letterSpacing === right?.letterSpacing &&
+  left?.lineHeight === right?.lineHeight &&
+  left?.textTransform === right?.textTransform &&
+  left?.wordSpacing === right?.wordSpacing
 
 export const getHighlighterViewPatch = (
   input: InputElement | null,

--- a/src/SuggestionsOverlay.spec.tsx
+++ b/src/SuggestionsOverlay.spec.tsx
@@ -186,6 +186,103 @@ describe('SuggestionsOverlay', () => {
     }
   })
 
+  it('ignores stationary mouse enters after keyboard scrolling moves the list', () => {
+    const longSuggestions = Array.from({ length: 6 }, (_, index) => ({
+      id: `item-${index}`,
+      display: `Item ${index}`,
+    }))
+    const suggestionsMap = createSuggestionsMap(longSuggestions)
+    const onMouseEnter = vi.fn()
+
+    const getBoundingClientRectMock = vi
+      .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
+      .mockImplementation(function getBoundingRect(this: HTMLElement) {
+        if (this.dataset.slot === 'suggestions-list') {
+          return {
+            top: 0,
+            bottom: 100,
+            left: 0,
+            right: 0,
+            width: 0,
+            height: 100,
+            x: 0,
+            y: 0,
+          }
+        }
+
+        if (this.dataset.focused === 'true') {
+          return {
+            top: 150,
+            bottom: 170,
+            left: 0,
+            right: 0,
+            width: 0,
+            height: 20,
+            x: 0,
+            y: 150,
+          }
+        }
+
+        return {
+          top: 0,
+          bottom: 20,
+          left: 0,
+          right: 0,
+          width: 0,
+          height: 20,
+          x: 0,
+          y: 0,
+        }
+      })
+
+    try {
+      const { container, rerender } = render(
+        <SuggestionsOverlay
+          id="test-suggestions"
+          suggestions={suggestionsMap}
+          focusIndex={0}
+          isOpened
+          onMouseEnter={onMouseEnter}
+          scrollFocusedIntoView
+        >
+          <Mention trigger="@" data={[]} />
+        </SuggestionsOverlay>
+      )
+
+      const list = container.querySelector('ul[role="listbox"]') as HTMLUListElement
+      expect(list).not.toBeNull()
+
+      Object.defineProperty(list, 'offsetHeight', { configurable: true, value: 100 })
+      Object.defineProperty(list, 'scrollHeight', { configurable: true, value: 400 })
+      list.scrollTop = 0
+
+      fireEvent.mouseMove(list, { clientX: 20, clientY: 20 })
+
+      rerender(
+        <SuggestionsOverlay
+          id="test-suggestions"
+          suggestions={suggestionsMap}
+          focusIndex={4}
+          isOpened
+          onMouseEnter={onMouseEnter}
+          scrollFocusedIntoView
+        >
+          <Mention trigger="@" data={[]} />
+        </SuggestionsOverlay>
+      )
+
+      const listItems = container.querySelectorAll('li[role="option"]')
+      fireEvent.mouseEnter(listItems[2], { clientX: 20, clientY: 20 })
+      expect(onMouseEnter).not.toHaveBeenCalled()
+
+      fireEvent.mouseEnter(listItems[2], { clientX: 20, clientY: 40 })
+      expect(onMouseEnter).toHaveBeenCalledTimes(1)
+      expect(onMouseEnter).toHaveBeenLastCalledWith(2)
+    } finally {
+      getBoundingClientRectMock.mockRestore()
+    }
+  })
+
   it('scrolls the focused suggestion upward when it is above the viewport', () => {
     const longSuggestions = Array.from({ length: 6 }, (_, index) => ({
       id: `item-${index}`,
@@ -951,7 +1048,7 @@ describe('SuggestionsOverlay', () => {
     expect(handleLoadMore).toHaveBeenCalledTimes(1)
   })
 
-  it('does not request more suggestions while loading', () => {
+  it('defers load more requests made while loading', () => {
     const handleLoadMore = vi.fn()
     const { container, rerender } = render(
       <SuggestionsOverlay
@@ -985,7 +1082,6 @@ describe('SuggestionsOverlay', () => {
       </SuggestionsOverlay>
     )
 
-    fireEvent.scroll(list)
     expect(handleLoadMore).toHaveBeenCalledTimes(1)
   })
 

--- a/src/SuggestionsOverlay.tsx
+++ b/src/SuggestionsOverlay.tsx
@@ -59,6 +59,11 @@ const listStyles =
   'm-0 max-h-64 list-none divide-y divide-border overflow-y-auto scroll-py-1 p-0 focus:outline-none'
 const loadMoreThresholdPx = 48
 
+const isNearLoadMoreThreshold = (list: HTMLUListElement): boolean => {
+  const remainingScrollDistance = list.scrollHeight - list.scrollTop - list.clientHeight
+  return remainingScrollDistance <= loadMoreThresholdPx
+}
+
 interface MousePosition {
   readonly clientX: number
   readonly clientY: number
@@ -121,6 +126,9 @@ function SuggestionsOverlay<Extra extends Record<string, unknown> = Record<strin
 }: SuggestionsOverlayProps<Extra>) {
   const [ulElement, setUlElement] = useState<HTMLUListElement | null>(null)
   const lastMouseEnterPosition = useRef<MousePosition | null>(null)
+  const lastMousePosition = useRef<MousePosition | null>(null)
+  const suppressedMouseEnterPosition = useRef<MousePosition | null>(null)
+  const pendingLoadMoreRef = useRef(false)
   const mentionChildren = useMemo(
     () => mentionChildrenProp ?? collectMentionElements(children),
     [children, mentionChildrenProp]
@@ -139,6 +147,9 @@ function SuggestionsOverlay<Extra extends Record<string, unknown> = Record<strin
   useEffect(() => {
     if (!isOpened) {
       lastMouseEnterPosition.current = null
+      lastMousePosition.current = null
+      suppressedMouseEnterPosition.current = null
+      pendingLoadMoreRef.current = false
     }
   }, [isOpened])
 
@@ -157,10 +168,19 @@ function SuggestionsOverlay<Extra extends Record<string, unknown> = Record<strin
     const scrollTop = ulElement.scrollTop
     const childTop = childRect.top - topContainer + scrollTop
     const childBottom = childRect.bottom - topContainer + scrollTop
+    const suppressStationaryMouseEnter = (): void => {
+      const currentMousePosition = lastMousePosition.current ?? lastMouseEnterPosition.current
+
+      if (currentMousePosition !== null) {
+        suppressedMouseEnterPosition.current = currentMousePosition
+      }
+    }
 
     if (childTop < scrollTop) {
+      suppressStationaryMouseEnter()
       ulElement.scrollTop = childTop
     } else if (childBottom > scrollTop + ulElement.offsetHeight) {
+      suppressStationaryMouseEnter()
       ulElement.scrollTop = childBottom - ulElement.offsetHeight
     }
   }, [focusIndex, scrollFocusedIntoView, ulElement])
@@ -177,11 +197,21 @@ function SuggestionsOverlay<Extra extends Record<string, unknown> = Record<strin
   const handleMouseEnter = useEventCallback(
     (index: number, event: React.MouseEvent<HTMLLIElement>) => {
       const nextMousePosition = { clientX: event.clientX, clientY: event.clientY }
+      lastMousePosition.current = nextMousePosition
+
+      if (
+        suppressedMouseEnterPosition.current !== null &&
+        !didMousePositionChange(suppressedMouseEnterPosition.current, nextMousePosition)
+      ) {
+        lastMouseEnterPosition.current = nextMousePosition
+        return
+      }
 
       if (!didMousePositionChange(lastMouseEnterPosition.current, nextMousePosition)) {
         return
       }
 
+      suppressedMouseEnterPosition.current = null
       lastMouseEnterPosition.current = nextMousePosition
       onMouseEnter?.(index)
     }
@@ -195,7 +225,24 @@ function SuggestionsOverlay<Extra extends Record<string, unknown> = Record<strin
 
   const handleListMouseLeave = useEventCallback<React.MouseEventHandler<HTMLUListElement>>(() => {
     lastMouseEnterPosition.current = null
+    lastMousePosition.current = null
+    suppressedMouseEnterPosition.current = null
   })
+
+  const handleListMouseMove = useEventCallback<React.MouseEventHandler<HTMLUListElement>>(
+    (event) => {
+      const nextMousePosition = { clientX: event.clientX, clientY: event.clientY }
+
+      if (
+        suppressedMouseEnterPosition.current !== null &&
+        didMousePositionChange(suppressedMouseEnterPosition.current, nextMousePosition)
+      ) {
+        suppressedMouseEnterPosition.current = null
+      }
+
+      lastMousePosition.current = nextMousePosition
+    }
+  )
 
   const flattenedSuggestions = useMemo<FlattenedSuggestion<Extra>[]>(() => {
     return flattenSuggestions(mentionChildren, suggestions)
@@ -233,15 +280,32 @@ function SuggestionsOverlay<Extra extends Record<string, unknown> = Record<strin
     }
   )
 
-  const handleListScroll = useEventCallback<React.UIEventHandler<HTMLUListElement>>((event) => {
-    if (isLoading === true) {
+  const flushPendingLoadMore = useEventCallback(() => {
+    if (isLoading === true || !pendingLoadMoreRef.current || ulElement === null) {
       return
     }
 
-    const list = event.currentTarget
-    const remainingScrollDistance = list.scrollHeight - list.scrollTop - list.clientHeight
+    pendingLoadMoreRef.current = false
+    if (isNearLoadMoreThreshold(ulElement)) {
+      onLoadMore?.()
+    }
+  })
 
-    if (remainingScrollDistance <= loadMoreThresholdPx) {
+  useLayoutEffect(() => {
+    flushPendingLoadMore()
+  }, [flushPendingLoadMore, isLoading, ulElement])
+
+  const handleListScroll = useEventCallback<React.UIEventHandler<HTMLUListElement>>((event) => {
+    const list = event.currentTarget
+
+    if (isLoading === true) {
+      if (isNearLoadMoreThreshold(list)) {
+        pendingLoadMoreRef.current = true
+      }
+      return
+    }
+
+    if (isNearLoadMoreThreshold(list)) {
       onLoadMore?.()
     }
   })
@@ -257,6 +321,7 @@ function SuggestionsOverlay<Extra extends Record<string, unknown> = Record<strin
         data-slot="suggestions-list"
         onMouseDown={handleListMouseDown}
         onMouseLeave={handleListMouseLeave}
+        onMouseMove={handleListMouseMove}
         onScroll={handleListScroll}
       >
         {suggestionEntries.map(

--- a/src/types.ts
+++ b/src/types.ts
@@ -252,7 +252,10 @@ export interface SuggestionsPosition {
   width?: number
 }
 
-export interface InlineSuggestionPosition {
+export interface InlineSuggestionPosition extends Pick<
+  React.CSSProperties,
+  'fontFamily' | 'fontSize' | 'letterSpacing' | 'lineHeight' | 'textTransform' | 'wordSpacing'
+> {
   left: number
   top: number
 }

--- a/src/useCaretLayout.ts
+++ b/src/useCaretLayout.ts
@@ -459,6 +459,12 @@ export const useCaretLayout = <Extra extends Record<string, unknown>>(
 
   const setSuggestionsElement = useEventCallback((element: HTMLDivElement | null): void => {
     suggestionsElementRef.current = element
+
+    if (element !== null) {
+      requestViewSync({
+        measureSuggestions: true,
+      })
+    }
   })
 
   const setInputRef = useEventCallback((element: InputElement | null): void => {
@@ -470,6 +476,18 @@ export const useCaretLayout = <Extra extends Record<string, unknown>>(
       ;(inputRef as React.RefObject<InputElement | null>).current = element
     }
   })
+
+  useLayoutEffect(() => {
+    didUnmountRef.current = false
+
+    return () => {
+      didUnmountRef.current = true
+      cancelScheduledFrame(scrollSyncFrameRef)
+      cancelScheduledFrame(autoResizeFrameRef)
+      pendingHighlighterRecomputeRef.current = false
+      queuedHighlighterRecomputeRef.current = false
+    }
+  }, [cancelScheduledFrame])
 
   useLayoutEffect(() => {
     if (!pendingHighlighterRecomputeRef.current) {
@@ -548,17 +566,6 @@ export const useCaretLayout = <Extra extends Record<string, unknown>>(
       caretPosition: state.caretPosition,
     }
   })
-
-  useLayoutEffect(
-    () => () => {
-      didUnmountRef.current = true
-      cancelScheduledFrame(scrollSyncFrameRef)
-      cancelScheduledFrame(autoResizeFrameRef)
-      pendingHighlighterRecomputeRef.current = false
-      queuedHighlighterRecomputeRef.current = false
-    },
-    [cancelScheduledFrame]
-  )
 
   useEffect(() => {
     document.addEventListener('scroll', handleDocumentScroll, true)

--- a/tests/browser/MentionsInput.browser.test.tsx
+++ b/tests/browser/MentionsInput.browser.test.tsx
@@ -9,6 +9,47 @@ const users = [
   { id: 'second', display: 'Second entry' },
 ]
 
+const browserLayoutStyles = `
+.relative { position: relative; }
+.block { display: block; }
+.w-full { width: 100%; }
+.box-border { box-sizing: border-box; }
+`
+
+const inlineTypographyStyles = `
+${browserLayoutStyles}
+.inline-control {
+  border: 1px solid transparent;
+  display: inline-block;
+  line-height: 16px;
+  position: relative;
+}
+.inline-highlighter,
+.inline-input {
+  border: 1px solid transparent;
+  box-sizing: border-box;
+  font-family: Arial, sans-serif;
+  font-size: 20px;
+  letter-spacing: 0.5px;
+  line-height: 34px;
+  padding: 8px 12px;
+  width: 320px;
+}
+.inline-input {
+  background: white;
+  color: black;
+  display: block;
+  position: relative;
+}
+.inline-suggestion {
+  color: rgb(100 116 139);
+  line-height: 16px;
+  pointer-events: none;
+  position: absolute;
+  white-space: pre;
+}
+`
+
 interface ControlledMentionsFixtureProps {
   readonly initialValue?: string
 }
@@ -51,6 +92,30 @@ function ControlledMentionsFixture({ initialValue = '' }: ControlledMentionsFixt
       <output data-testid="id-value">{lastChange.idValue}</output>
       <output data-testid="trigger-type">{lastChange.triggerType}</output>
       <output data-testid="mention-id">{lastChange.mentionId}</output>
+    </section>
+  )
+}
+
+function InlineAutocompleteFixture() {
+  const [value, setValue] = useState('')
+
+  return (
+    <section>
+      <style>{inlineTypographyStyles}</style>
+      <MentionsInput
+        aria-label="Inline composer"
+        value={value}
+        onMentionsChange={({ value: nextValue }) => setValue(nextValue)}
+        suggestionsDisplay="inline"
+        classNames={{
+          control: 'inline-control',
+          highlighter: 'inline-highlighter',
+          input: 'inline-input',
+          inlineSuggestion: 'inline-suggestion',
+        }}
+      >
+        <Mention trigger="@" data={users} />
+      </MentionsInput>
     </section>
   )
 }
@@ -124,6 +189,80 @@ describe('MentionsInput browser caret and IME behavior', () => {
     await expect.element(page.getByTestId('mention-id')).toHaveTextContent('first')
     await expect.element(composerLocator).toHaveValue('First entry')
     await expectSelection('First entry'.length)
+  })
+
+  it('positions portal suggestions near the composer after Strict Mode effect replay', async () => {
+    await renderBrowser(
+      <React.StrictMode>
+        <main>
+          <style>{browserLayoutStyles}</style>
+          <div style={{ height: 1200 }} aria-hidden="true" />
+          <ControlledMentionsFixture />
+          <div style={{ height: 2400 }} aria-hidden="true" />
+        </main>
+      </React.StrictMode>
+    )
+
+    const composerLocator = page.getByRole('combobox', { name: 'Composer' })
+    await userEvent.type(composerLocator, '@fi')
+
+    const option = page.getByRole('option', { name: 'First entry' })
+    await expect.element(option).toBeVisible()
+
+    await expect
+      .poll(async () => {
+        const composer = await getComposer()
+        const optionElement = await option.findElement()
+        const composerRect = composer.getBoundingClientRect()
+        const optionRect = optionElement.getBoundingClientRect()
+
+        const distanceFromComposer = optionRect.top - composerRect.bottom
+
+        return distanceFromComposer > -100 && distanceFromComposer < 200
+      })
+      .toBe(true)
+  })
+
+  it('keeps inline autocomplete typography aligned with the measured input text', async () => {
+    await renderBrowser(<InlineAutocompleteFixture />)
+
+    const composerLocator = page.getByRole('combobox', { name: 'Inline composer' })
+    await userEvent.type(composerLocator, '@fi')
+
+    await expect
+      .poll(async () => {
+        const inlineElement = document.querySelector<HTMLElement>('[data-slot="inline-suggestion"]')
+        const highlighter = document.querySelector<HTMLElement>('[data-slot="highlighter"]')
+        const highlighterText = highlighter?.querySelector<HTMLElement>('span')
+
+        if (
+          inlineElement === null ||
+          highlighter === null ||
+          highlighterText === null ||
+          highlighterText === undefined
+        ) {
+          return null
+        }
+
+        const inlineRect = inlineElement.getBoundingClientRect()
+        const textRect = highlighterText.getBoundingClientRect()
+        const highlighterLineHeight = getComputedStyle(highlighter).lineHeight
+        const leadingOffset = Math.max(
+          0,
+          (Number.parseFloat(highlighterLineHeight) - textRect.height) / 2
+        )
+
+        return {
+          inlineLineHeight: getComputedStyle(inlineElement).lineHeight,
+          highlighterLineHeight,
+          leadingAdjustedTop: Math.abs(inlineRect.top - textRect.top + leadingOffset) < 0.5,
+        }
+      })
+      .toEqual({
+        inlineLineHeight: '34px',
+        highlighterLineHeight: '34px',
+        leadingAdjustedTop: true,
+      })
   })
 
   it('restores the caret when real typing edits inside mention text', async () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes – Version 6.0.0-next.1

* **Improvements**
  * Enhanced inline suggestion positioning with typography-aware alignment
  * Better scroll and keyboard interaction handling in suggestions list
  * Improved caret positioning stability and text measurement reliability

* **Tests**
  * Added test coverage for suggestion positioning and DOM stability during text editing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix layout regression in highlighter caret positioning and inline suggestion rendering
> - Refactors [Highlighter.tsx](https://github.com/hbmartin/react-mentions-ts/pull/204/files#diff-2d8fdc86aaeb8d7adcdd60631f48110e3e6cce38d17b7e31828f5c0088eadcc2) to use memoized segment components (`HighlighterTextSegment`, `HighlighterMentionSegment`, `HighlighterSubstring`, `HighlighterCaret`), so caret-only updates no longer recreate unaffected DOM spans.
> - Adds `getCaretPositionInMarkup` to compute caret index from segment metadata instead of `mapPlainTextIndex`, and emits `onCaretPositionChange` only when coordinates actually change.
> - Extends `calculateInlineSuggestionPosition` in [MentionsInputLayout.ts](https://github.com/hbmartin/react-mentions-ts/pull/204/files#diff-7d40540d82b40ebe0cf0576049c2f8f73039531f16f648e29f85078d7777a473) to account for control border widths, align suggestion top to the current text line, and include typography styles (`fontFamily`, `fontSize`, `lineHeight`, etc.) in the returned position object.
> - Fixes `SuggestionsOverlay` to defer `onLoadMore` until loading completes and to ignore `mouseenter` events that fire without pointer movement after keyboard-driven scrolling.
> - Behavioral Change: `InlineSuggestionPosition` now includes typography fields; `areInlineSuggestionPositionsEqual` considers these fields, which may trigger additional re-renders when typography changes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 103c7cd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->