### PR TITLE
Removed render-time useEventCallback reads for snapshots, selection m…

### DIFF
--- a/src/MeasurementBridge.spec.tsx
+++ b/src/MeasurementBridge.spec.tsx
@@ -151,11 +151,8 @@ describe('MeasurementBridge', () => {
     }
   })
 
-  it('skips viewport listener registration when window lookup is unavailable', () => {
+  it('skips viewport listener registration when no owner or global window is available', () => {
     const requestViewSync = vi.fn()
-    const container = document.createElement('div')
-    const highlighter = document.createElement('div')
-    const suggestions = document.createElement('div')
     const addListener = vi.spyOn(globalThis, 'addEventListener')
     const originalReflectGet = Reflect.get
     const reflectGetSpy = vi
@@ -177,10 +174,10 @@ describe('MeasurementBridge', () => {
     try {
       render(
         <MeasurementBridge
-          container={container}
-          highlighter={highlighter}
+          container={null}
+          highlighter={null}
           input={null}
-          suggestions={suggestions}
+          suggestions={null}
           requestViewSync={requestViewSync}
         />
       )

--- a/src/MeasurementBridge.tsx
+++ b/src/MeasurementBridge.tsx
@@ -21,6 +21,17 @@ const SUGGESTIONS_ONLY_FLAGS: Partial<PendingViewSync> = {
   measureSuggestions: true,
 }
 
+const getOwnerWindow = (...elements: Array<Element | null>): Window | undefined => {
+  for (const element of elements) {
+    const ownerWindow = element?.ownerDocument.defaultView
+    if (ownerWindow !== undefined && ownerWindow !== null) {
+      return ownerWindow
+    }
+  }
+
+  return Reflect.get(globalThis, 'window') as Window | undefined
+}
+
 const MeasurementBridge = ({
   container,
   highlighter,
@@ -37,9 +48,9 @@ const MeasurementBridge = ({
   })
 
   const observe = useEventCallback((element: Element | null, callback: () => void) => {
-    const resizeObserverConstructor = Reflect.get(globalThis, 'ResizeObserver') as
-      | typeof ResizeObserver
-      | undefined
+    const resizeObserverConstructor =
+      element?.ownerDocument.defaultView?.ResizeObserver ??
+      (Reflect.get(globalThis, 'ResizeObserver') as typeof ResizeObserver | undefined)
 
     if (!element || resizeObserverConstructor === undefined) {
       return undefined
@@ -78,7 +89,7 @@ const MeasurementBridge = ({
   )
 
   useLayoutEffect(() => {
-    const windowObject = Reflect.get(globalThis, 'window') as Window | undefined
+    const windowObject = getOwnerWindow(input, container, highlighter, suggestions)
 
     if (windowObject === undefined) {
       return undefined
@@ -95,7 +106,7 @@ const MeasurementBridge = ({
       windowObject.removeEventListener('resize', handleViewportChange)
       windowObject.removeEventListener('orientationchange', handleViewportChange)
     }
-  }, [requestAllMeasurements])
+  }, [container, highlighter, input, requestAllMeasurements, suggestions])
 
   useLayoutEffect(() => {
     if (!input) {

--- a/src/MentionsInput.spec.tsx
+++ b/src/MentionsInput.spec.tsx
@@ -78,6 +78,7 @@ const INTERNAL_KEY = {
   ESC: 'Escape',
   UP: 'ArrowUp',
   DOWN: 'ArrowDown',
+  RIGHT: 'ArrowRight',
 } as const
 
 const MentionsInputInternalsHarness = React.forwardRef<MentionsInputHandle, MentionsInputProps>(
@@ -85,17 +86,23 @@ const MentionsInputInternalsHarness = React.forwardRef<MentionsInputHandle, Ment
     const { state, stateRef, setState } = useMentionsInputState()
     const value = props.value ?? ''
     const suggestionsDisplay = props.suggestionsDisplay ?? 'overlay'
-    const { getMentionChildren, getCurrentConfig, getCurrentSnapshot, cacheSnapshot } =
-      useMentionValueSnapshot(props.children, props.value)
-    const config = getCurrentConfig()
-    const isInlineAutocomplete = React.useCallback(
-      (): boolean => suggestionsDisplay === 'inline',
-      [suggestionsDisplay]
-    )
+    const {
+      preparedChildren,
+      currentSnapshot,
+      getMentionChildren,
+      getCurrentConfig,
+      getCurrentSnapshot,
+      cacheSnapshot,
+    } = useMentionValueSnapshot(props.children, props.value)
+    const config = preparedChildren.config
+    const mentionChildren = preparedChildren.mentionChildren
+    const isInlineAutocomplete = suggestionsDisplay === 'inline'
     const suggestionsQuery = useSuggestionsQuery({
       props,
+      state,
       stateRef,
       setState,
+      mentionChildren,
       getMentionChildren,
       getCurrentConfig,
       isInlineAutocomplete,
@@ -126,7 +133,7 @@ const MentionsInputInternalsHarness = React.forwardRef<MentionsInputHandle, Ment
     const selectFocused = React.useCallback((): void => {
       const entry = getFocusedSuggestionEntryForMentionChildren(
         getMentionChildren(),
-        stateRef.current.queryStates,
+        stateRef.current.suggestions,
         stateRef.current.focusIndex
       )
       if (entry === null) {
@@ -139,18 +146,41 @@ const MentionsInputInternalsHarness = React.forwardRef<MentionsInputHandle, Ment
 
     const handleKeyDown = React.useCallback(
       (event: React.KeyboardEvent<InputElement>): void => {
-        props.onKeyDown?.(event)
-
         if (suggestionsDisplay === 'inline') {
-          if (
-            (event.key === INTERNAL_KEY.TAB ||
-              event.key === INTERNAL_KEY.RETURN ||
-              event.key === 'ArrowRight') &&
-            suggestionsQuery.canApplyInlineSuggestion()
-          ) {
-            event.preventDefault()
-            selectFocused()
+          const inlineSuggestion = suggestionsQuery.getInlineSuggestionDetails()
+          if (inlineSuggestion === null) {
+            props.onKeyDown?.(event)
+            return
           }
+
+          switch (event.key) {
+            case INTERNAL_KEY.ESC: {
+              if (utils.countSuggestions(stateRef.current.suggestions) > 0) {
+                event.preventDefault()
+                event.stopPropagation()
+                suggestionsQuery.shiftFocus(1)
+                return
+              }
+              break
+            }
+            case INTERNAL_KEY.RETURN:
+            case INTERNAL_KEY.TAB:
+            case INTERNAL_KEY.RIGHT: {
+              if (
+                (event.key === INTERNAL_KEY.TAB && event.shiftKey) ||
+                !suggestionsQuery.canApplyInlineSuggestion()
+              ) {
+                break
+              }
+              event.preventDefault()
+              event.stopPropagation()
+              selectFocused()
+              return
+            }
+            default:
+          }
+
+          props.onKeyDown?.(event)
           return
         }
 
@@ -158,7 +188,19 @@ const MentionsInputInternalsHarness = React.forwardRef<MentionsInputHandle, Ment
           utils.countSuggestions(stateRef.current.suggestions) === 0 ||
           caretLayout.suggestionsElementRef.current === null
         ) {
+          props.onKeyDown?.(event)
           return
+        }
+
+        if (
+          event.key === INTERNAL_KEY.ESC ||
+          event.key === INTERNAL_KEY.DOWN ||
+          event.key === INTERNAL_KEY.UP ||
+          event.key === INTERNAL_KEY.RETURN ||
+          event.key === INTERNAL_KEY.TAB
+        ) {
+          event.preventDefault()
+          event.stopPropagation()
         }
 
         switch (event.key) {
@@ -177,10 +219,12 @@ const MentionsInputInternalsHarness = React.forwardRef<MentionsInputHandle, Ment
           case INTERNAL_KEY.RETURN:
           case INTERNAL_KEY.TAB: {
             selectFocused()
-            break
+            return
           }
           default:
         }
+
+        props.onKeyDown?.(event)
       },
       [
         caretLayout.suggestionsElementRef,
@@ -303,8 +347,6 @@ const MentionsInputInternalsHarness = React.forwardRef<MentionsInputHandle, Ment
       return handle
     })
 
-    const snapshot = getCurrentSnapshot()
-
     return (
       <div ref={caretLayout.setContainerElement}>
         <div data-slot="highlighter" ref={caretLayout.setHighlighterElement} />
@@ -314,7 +356,7 @@ const MentionsInputInternalsHarness = React.forwardRef<MentionsInputHandle, Ment
           aria-expanded="false"
           ref={caretLayout.setInputRef}
           role="combobox"
-          value={snapshot.plainText}
+          value={currentSnapshot.plainText}
           onBlur={editing.handleBlur}
           onChange={editing.handleChange}
           onCompositionEnd={editing.handleCompositionEnd}
@@ -328,7 +370,6 @@ const MentionsInputInternalsHarness = React.forwardRef<MentionsInputHandle, Ment
 ) as typeof MentionsInput
 
 const PublicMentionsInput = MentionsInput
-MentionsInputInternalsHarness.defaultProps = MentionsInput.defaultProps
 
 describe('MentionsInput', () => {
   it('should render a textarea by default.', () => {
@@ -545,6 +586,45 @@ describe('MentionsInput', () => {
     })
   })
 
+  it('refreshes suggestions immediately after ordinary input changes.', async () => {
+    let value = ''
+    const handleChange = vi.fn(
+      (event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+        value = event.target.value
+        renderResult.rerender(
+          <MentionsInput value={value} onChange={handleChange}>
+            <Mention trigger="@" data={data} />
+          </MentionsInput>
+        )
+      }
+    )
+    const renderResult = render(
+      <MentionsInput value={value} onChange={handleChange}>
+        <Mention trigger="@" data={data} />
+      </MentionsInput>
+    )
+
+    const textarea = screen.getByRole<HTMLTextAreaElement>('combobox')
+    fireEvent.focus(textarea)
+    textarea.setSelectionRange(0, 0)
+    fireEvent.change(textarea, {
+      target: {
+        value: '@',
+        selectionStart: 1,
+        selectionEnd: 1,
+      },
+      nativeEvent: {
+        data: '@',
+        isComposing: false,
+      },
+    })
+
+    await waitFor(() => {
+      const suggestions = screen.getAllByRole('option', { hidden: true })
+      expect(suggestions.length).toBeGreaterThan(0)
+    })
+  })
+
   it('should be possible to navigate through the suggestions with the up and down arrows.', async () => {
     render(
       <MentionsInput value="@">
@@ -580,6 +660,29 @@ describe('MentionsInput', () => {
     suggestions = screen.getAllByRole('option', { hidden: true })
     expect(suggestions[0]).toHaveAttribute('aria-selected', 'true')
     expect(suggestions[1]).toHaveAttribute('aria-selected', 'false')
+  })
+
+  it('forwards unhandled keydown events while overlay suggestions are open.', async () => {
+    const onKeyDown = vi.fn()
+    render(
+      <MentionsInput value="@" onKeyDown={onKeyDown}>
+        <Mention trigger="@" data={data} />
+      </MentionsInput>
+    )
+
+    const textarea = screen.getByRole('combobox')
+    fireEvent.focus(textarea)
+    textarea.setSelectionRange(1, 1)
+    fireEvent.select(textarea)
+
+    await waitFor(() => {
+      const suggestions = screen.getAllByRole('option', { hidden: true })
+      expect(suggestions.length).toBeGreaterThan(0)
+    })
+
+    fireEvent.keyDown(textarea, { key: 'a' })
+
+    expect(onKeyDown).toHaveBeenCalledTimes(1)
   })
 
   it('should update the focused suggestion when hovering over items.', async () => {
@@ -1974,6 +2077,38 @@ describe('MentionsInput', () => {
       expect(suggestionsNode).toBeTruthy()
       expect(suggestionsNode?.parentElement).toBe(document.body)
     })
+  })
+
+  it("defaults the suggestions portal to the input element's owner document.", async () => {
+    const iframe = document.createElement('iframe')
+    document.body.append(iframe)
+    const iframeDocument = iframe.contentDocument
+    expect(iframeDocument).not.toBeNull()
+    const root = iframeDocument!.createElement('div')
+    iframeDocument!.body.append(root)
+    const renderResult = render(
+      <MentionsInput value="@">
+        <Mention trigger="@" data={data} />
+      </MentionsInput>,
+      { container: root }
+    )
+
+    try {
+      const textarea = root.querySelector('[data-slot="input"]') as HTMLTextAreaElement | null
+      expect(textarea).not.toBeNull()
+      fireEvent.focus(textarea!)
+      textarea!.setSelectionRange(1, 1)
+      fireEvent.select(textarea!)
+
+      await waitFor(() => {
+        const suggestionsNode = iframeDocument!.body.querySelector('[data-slot="suggestions"]')
+        expect(suggestionsNode).toBeTruthy()
+        expect(suggestionsNode?.ownerDocument).toBe(iframeDocument)
+      })
+    } finally {
+      renderResult.unmount()
+      iframe.remove()
+    }
   })
 
   it('should accept a custom markup string', () => {
@@ -3857,9 +3992,30 @@ describe('MentionsInput', () => {
   describe('internal behaviors', () => {
     const MentionsInput = MentionsInputInternalsHarness
 
-    it('exposes null-returning defaults for keydown and select handlers.', () => {
-      expect(MentionsInput.defaultProps?.onKeyDown?.()).toBeNull()
-      expect(MentionsInput.defaultProps?.onSelect?.()).toBeNull()
+    it('keeps keydown and select handlers optional.', () => {
+      const ref = React.createRef<MentionsInputHandle>()
+      const { unmount } = render(
+        <MentionsInput ref={ref} value="">
+          <Mention trigger="@" data={data} />
+        </MentionsInput>
+      )
+
+      const instance = ref.current as unknown as any
+      const event = {
+        key: 'x',
+        shiftKey: false,
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+      }
+
+      expect(() => {
+        act(() => {
+          instance.handleKeyDown(event)
+          instance.selectFocused()
+        })
+      }).not.toThrow()
+
+      unmount()
     })
 
     it('updates scroll flags when handling document scroll.', () => {

--- a/src/MentionsInput.tsx
+++ b/src/MentionsInput.tsx
@@ -109,19 +109,23 @@ const MentionsInputInner = <Extra extends Record<string, unknown> = Record<strin
     props.suggestionsDisplay ?? defaultMentionsInputProps.suggestionsDisplay
   const {
     preparedChildren,
+    currentSnapshot,
     getMentionChildren,
     getCurrentConfig,
     getCurrentSnapshot,
     cacheSnapshot,
   } = useMentionValueSnapshot<Extra>(props.children, props.value)
   const config = preparedChildren.config
+  const mentionChildren = preparedChildren.mentionChildren
 
-  const isInlineAutocomplete = useEventCallback((): boolean => suggestionsDisplay === 'inline')
+  const isInlineAutocomplete = suggestionsDisplay === 'inline'
 
   const suggestionsQuery = useSuggestionsQuery<Extra>({
     props,
+    state,
     stateRef,
     setState,
+    mentionChildren,
     getMentionChildren,
     getCurrentConfig,
     isInlineAutocomplete,
@@ -151,10 +155,11 @@ const MentionsInputInner = <Extra extends Record<string, unknown> = Record<strin
     requestHighlighterScrollSync: caretLayout.requestHighlighterScrollSync,
   })
 
-  const { getCurrentMentionSelectionMap } = useMentionSelectionChange<Extra>({
+  const { currentMentionSelectionMap } = useMentionSelectionChange<Extra>({
     props,
     state,
     config,
+    currentSnapshot,
     getCurrentSnapshot,
   })
 
@@ -169,7 +174,7 @@ const MentionsInputInner = <Extra extends Record<string, unknown> = Record<strin
   })
 
   const handleKeyDown = useEventCallback((event: KeyboardEvent<InputElement>): void => {
-    if (isInlineAutocomplete()) {
+    if (isInlineAutocomplete) {
       const inlineSuggestion = suggestionsQuery.getInlineSuggestionDetails()
       if (!inlineSuggestion) {
         props.onKeyDown?.(event)
@@ -236,10 +241,12 @@ const MentionsInputInner = <Extra extends Record<string, unknown> = Record<strin
       case KEY.RETURN:
       case KEY.TAB: {
         selectFocused()
-        break
+        return
       }
       default:
     }
+
+    props.onKeyDown?.(event)
   })
 
   useImperativeHandle(
@@ -252,7 +259,6 @@ const MentionsInputInner = <Extra extends Record<string, unknown> = Record<strin
 
   const getInputProps = (): InputComponentProps => {
     const { readOnly, disabled } = props
-    const currentSnapshot = getCurrentSnapshot()
     const passthroughProps = omit(
       props as unknown as Record<string, unknown>,
       HANDLED_PROPS as ReadonlyArray<keyof MentionsInputProps>
@@ -285,22 +291,16 @@ const MentionsInputInner = <Extra extends Record<string, unknown> = Record<strin
       })
     }
 
-    const inlineAutocomplete = isInlineAutocomplete()
-    const inlineSuggestion = inlineAutocomplete
-      ? suggestionsQuery.getInlineSuggestionDetails()
-      : null
-    const isOverlayOpen = !inlineAutocomplete && suggestionsQuery.isOpened()
-    const overlayId = caretLayout.getSuggestionsOverlayId()
+    const inlineAutocomplete = isInlineAutocomplete
+    const inlineSuggestion = inlineAutocomplete ? suggestionsQuery.inlineSuggestionDetails : null
+    const isOverlayOpen = !inlineAutocomplete && suggestionsQuery.isOpened
+    const overlayId = caretLayout.suggestionsOverlayId
     const hasOverlayId = overlayId !== undefined
 
     Object.assign(inputProps, {
       role: 'combobox',
       'aria-autocomplete': inlineAutocomplete ? 'inline' : 'list',
-      'aria-expanded': inlineAutocomplete
-        ? 'false'
-        : suggestionsQuery.isOpened()
-          ? 'true'
-          : 'false',
+      'aria-expanded': inlineAutocomplete ? 'false' : suggestionsQuery.isOpened ? 'true' : 'false',
       'aria-haspopup': inlineAutocomplete ? undefined : 'listbox',
       'aria-controls': isOverlayOpen && hasOverlayId ? overlayId : undefined,
       'aria-activedescendant':
@@ -310,7 +310,7 @@ const MentionsInputInner = <Extra extends Record<string, unknown> = Record<strin
     })
 
     if (inlineAutocomplete && inlineSuggestion) {
-      const liveRegionId = caretLayout.getInlineAutocompleteLiveRegionId()
+      const liveRegionId = caretLayout.inlineAutocompleteLiveRegionId
       const existingDescribedBy =
         typeof inputProps['aria-describedby'] === 'string'
           ? inputProps['aria-describedby']
@@ -340,7 +340,7 @@ const MentionsInputInner = <Extra extends Record<string, unknown> = Record<strin
   }
 
   const renderSuggestionsOverlay = (): React.ReactNode | null => {
-    if (isInlineAutocomplete()) {
+    if (isInlineAutocomplete) {
       return null
     }
 
@@ -350,9 +350,8 @@ const MentionsInputInner = <Extra extends Record<string, unknown> = Record<strin
 
     const { position, left, top, right, width } = state.suggestionsPosition
     const portalTarget = caretLayout.resolvePortalHost()
-    const overlayId = caretLayout.getSuggestionsOverlayId()
-    const { statusContent, statusType } = suggestionsQuery.getSuggestionsStatusContent()
-    const mentionChildren = getMentionChildren()
+    const overlayId = caretLayout.suggestionsOverlayId
+    const { statusContent, statusType } = suggestionsQuery.suggestionsStatusContent
 
     const suggestionsNode = (
       <SuggestionsOverlay<Extra>
@@ -384,8 +383,8 @@ const MentionsInputInner = <Extra extends Record<string, unknown> = Record<strin
         onMouseDown={editing.handleSuggestionsMouseDown}
         onMouseEnter={suggestionsQuery.handleSuggestionsMouseEnter}
         onLoadMore={suggestionsQuery.loadMoreSuggestions}
-        isLoading={suggestionsQuery.isLoading()}
-        isOpened={suggestionsQuery.isOpened()}
+        isLoading={suggestionsQuery.isLoading}
+        isOpened={suggestionsQuery.isOpened}
         a11ySuggestionsListLabel={props.a11ySuggestionsListLabel}
       >
         {props.children}
@@ -396,13 +395,13 @@ const MentionsInputInner = <Extra extends Record<string, unknown> = Record<strin
   }
 
   const renderInlineSuggestion = (): React.ReactNode => {
-    if (!isInlineAutocomplete() || !isNumber(state.selectionStart)) {
+    if (!isInlineAutocomplete || !isNumber(state.selectionStart)) {
       return null
     }
 
     return (
       <MentionsInputInlineSuggestion<Extra>
-        inlineSuggestion={suggestionsQuery.getInlineSuggestionDetails()}
+        inlineSuggestion={suggestionsQuery.inlineSuggestionDetails}
         inlineSuggestionPosition={state.inlineSuggestionPosition}
         classNames={props.classNames}
       />
@@ -410,19 +409,19 @@ const MentionsInputInner = <Extra extends Record<string, unknown> = Record<strin
   }
 
   const renderInlineSuggestionLiveRegion = (): React.ReactNode => {
-    if (!isInlineAutocomplete()) {
+    if (!isInlineAutocomplete) {
       return null
     }
 
-    const inlineSuggestion = suggestionsQuery.getInlineSuggestionDetails()
+    const inlineSuggestion = suggestionsQuery.inlineSuggestionDetails
     const announcement = getInlineSuggestionAnnouncement(
       inlineSuggestion,
-      suggestionsQuery.getSuggestionsStatusContent()
+      suggestionsQuery.suggestionsStatusContent
     )
 
     return (
       <MentionsInputInlineLiveRegion
-        id={caretLayout.getInlineAutocompleteLiveRegionId()}
+        id={caretLayout.inlineAutocompleteLiveRegionId}
         announcement={announcement}
       />
     )
@@ -434,7 +433,7 @@ const MentionsInputInner = <Extra extends Record<string, unknown> = Record<strin
       className={props.classNames?.highlighter}
       substringClassName={props.classNames?.highlighterSubstring}
       caretClassName={props.classNames?.highlighterCaret}
-      mentionChildren={getMentionChildren()}
+      mentionChildren={mentionChildren}
       config={config}
       value={props.value}
       singleLine={singleLine}
@@ -442,7 +441,7 @@ const MentionsInputInner = <Extra extends Record<string, unknown> = Record<strin
       selectionEnd={state.selectionEnd}
       recomputeVersion={state.highlighterRecomputeVersion}
       onCaretPositionChange={caretLayout.handleCaretPositionChange}
-      mentionSelectionMap={getCurrentMentionSelectionMap()}
+      mentionSelectionMap={currentMentionSelectionMap}
     >
       {props.children}
     </Highlighter>
@@ -475,14 +474,10 @@ const MentionsInputInner = <Extra extends Record<string, unknown> = Record<strin
   )
 }
 
-const MentionsInput = React.forwardRef(MentionsInputInner) as (<
+const MentionsInput = React.forwardRef(MentionsInputInner) as <
   Extra extends Record<string, unknown> = Record<string, unknown>,
 >(
   props: MentionsInputProps<Extra> & React.RefAttributes<MentionsInputHandle>
-) => React.ReactElement | null) & {
-  defaultProps?: typeof defaultMentionsInputProps
-}
-
-MentionsInput.defaultProps = defaultMentionsInputProps
+) => React.ReactElement | null
 
 export default MentionsInput

--- a/src/MentionsInputLayout.ts
+++ b/src/MentionsInputLayout.ts
@@ -181,13 +181,21 @@ export const calculateSuggestionsPosition = ({
     left: caretOffsetParentRect.left + (anchorToLeft ? 0 : caretPosition.left),
     top: caretOffsetParentRect.top + caretPosition.top,
   }
-  const viewportHeight = Math.max(document.documentElement.clientHeight, window.innerHeight || 0)
+  const ownerDocument = highlighter.ownerDocument
+  const ownerWindow = ownerDocument.defaultView
+  const viewportHeight = Math.max(
+    ownerDocument.documentElement.clientHeight,
+    ownerWindow?.innerHeight ?? 0
+  )
   const desiredWidth = highlighter.offsetWidth
 
   const position: SuggestionsPosition = {}
 
   if (resolvedPortalHost) {
-    const viewportWidth = Math.max(document.documentElement.clientWidth, window.innerWidth || 0)
+    const viewportWidth = Math.max(
+      ownerDocument.documentElement.clientWidth,
+      ownerWindow?.innerWidth ?? 0
+    )
     const width = Math.min(desiredWidth, viewportWidth)
     position.width = width
     position.position = 'fixed'

--- a/src/useCaretLayout.ts
+++ b/src/useCaretLayout.ts
@@ -45,7 +45,7 @@ interface UseCaretLayoutArgs<Extra extends Record<string, unknown>> {
   setState: SetMentionsInputState<Extra>
   value: string
   config: ReadonlyArray<MentionChildConfig<Extra>>
-  isInlineAutocomplete: () => boolean
+  isInlineAutocomplete: boolean
   hasInlineSuggestion: () => boolean
 }
 
@@ -59,6 +59,16 @@ interface PreviousCommit<Extra extends Record<string, unknown>> {
   caretPosition: MentionsInputState<Extra>['caretPosition']
 }
 
+const getExplicitId = (id: unknown): string | null =>
+  typeof id === 'string' && id.trim().length > 0 ? id.trim() : null
+
+const isDocumentLike = (value: unknown): value is Document =>
+  typeof value === 'object' &&
+  value !== null &&
+  'nodeType' in value &&
+  (value as { nodeType: number }).nodeType === 9 &&
+  'body' in value
+
 export const useCaretLayout = <Extra extends Record<string, unknown>>(
   args: UseCaretLayoutArgs<Extra>
 ) => {
@@ -69,9 +79,7 @@ export const useCaretLayout = <Extra extends Record<string, unknown>>(
   const inputElementRef = useRef<InputElement | null>(null)
   const highlighterElementRef = useRef<HTMLDivElement | null>(null)
   const suggestionsElementRef = useRef<HTMLDivElement | null>(null)
-  const defaultSuggestionsPortalHostRef = useRef<HTMLElement | null>(
-    typeof document === 'undefined' ? null : document.body
-  )
+  const defaultSuggestionsPortalHostRef = useRef<HTMLElement | null>(null)
   const pendingViewSyncRef = useRef<PendingViewSync>(createPendingViewSync())
   const isFlushingViewSyncRef = useRef(false)
   const scrollSyncFrameRef = useRef<number | null>(null)
@@ -91,42 +99,31 @@ export const useCaretLayout = <Extra extends Record<string, unknown>>(
     }
   )
 
-  const getExplicitId = useEventCallback((): string | null => {
-    const { id } = argsRef.current.props
-    return typeof id === 'string' && id.trim().length > 0 ? id.trim() : null
-  })
+  const explicitId = getExplicitId(args.props.id)
+  const baseId = explicitId ?? args.state.generatedId
+  const suggestionsOverlayId = baseId === null ? undefined : `${baseId}-suggestions`
+  const inlineAutocompleteLiveRegionId = baseId === null ? undefined : `${baseId}-inline-live`
 
   const ensureGeneratedId = useEventCallback((): void => {
-    if (getExplicitId() !== null || argsRef.current.stateRef.current.generatedId !== null) {
+    if (
+      getExplicitId(argsRef.current.props.id) !== null ||
+      argsRef.current.stateRef.current.generatedId !== null
+    ) {
       return
     }
 
     argsRef.current.setState({ generatedId: createGeneratedId() })
   })
 
-  const getBaseId = useEventCallback(
-    (): string | null => getExplicitId() ?? argsRef.current.stateRef.current.generatedId
-  )
-
-  const getSuggestionsOverlayId = useEventCallback((): string | undefined => {
-    const baseId = getBaseId()
-    return baseId === null ? undefined : `${baseId}-suggestions`
-  })
-
-  const getInlineAutocompleteLiveRegionId = useEventCallback((): string | undefined => {
-    const baseId = getBaseId()
-    return baseId === null ? undefined : `${baseId}-inline-live`
-  })
-
   const shouldMeasureSuggestions = useEventCallback(
     (): boolean =>
-      !argsRef.current.isInlineAutocomplete() &&
+      !argsRef.current.isInlineAutocomplete &&
       typeof argsRef.current.stateRef.current.selectionStart === 'number'
   )
 
   const shouldMeasureInline = useEventCallback(
     (): boolean =>
-      argsRef.current.isInlineAutocomplete() &&
+      argsRef.current.isInlineAutocomplete &&
       typeof argsRef.current.stateRef.current.selectionStart === 'number'
   )
 
@@ -137,15 +134,15 @@ export const useCaretLayout = <Extra extends Record<string, unknown>>(
       return null
     }
 
-    if (typeof Document !== 'undefined' && suggestionsPortalHost instanceof Document) {
+    if (isDocumentLike(suggestionsPortalHost)) {
       return suggestionsPortalHost.body
     }
 
     if (suggestionsPortalHost) {
-      return suggestionsPortalHost as Element
+      return suggestionsPortalHost
     }
 
-    return defaultSuggestionsPortalHostRef.current
+    return inputElementRef.current?.ownerDocument.body ?? defaultSuggestionsPortalHostRef.current
   })
 
   const resolveViewSyncFlags = useEventCallback(
@@ -242,7 +239,7 @@ export const useCaretLayout = <Extra extends Record<string, unknown>>(
   const updateInlineSuggestionPosition = useEventCallback((): boolean => {
     const { stateRef, setState } = argsRef.current
 
-    if (!argsRef.current.isInlineAutocomplete()) {
+    if (!argsRef.current.isInlineAutocomplete) {
       if (stateRef.current.inlineSuggestionPosition === null) {
         return false
       }
@@ -469,6 +466,7 @@ export const useCaretLayout = <Extra extends Record<string, unknown>>(
 
   const setInputRef = useEventCallback((element: InputElement | null): void => {
     inputElementRef.current = element
+    defaultSuggestionsPortalHostRef.current = element?.ownerDocument.body ?? null
     const { inputRef } = argsRef.current.props
     if (typeof inputRef === 'function') {
       inputRef(element)
@@ -565,15 +563,46 @@ export const useCaretLayout = <Extra extends Record<string, unknown>>(
       generatedId: state.generatedId,
       caretPosition: state.caretPosition,
     }
-  })
+  }, [
+    args.config,
+    args.isInlineAutocomplete,
+    args.props.anchorMode,
+    args.props.autoResize,
+    args.props.singleLine,
+    args.props.suggestionsPlacement,
+    args.props.suggestionsPortalHost,
+    args.state.caretPosition,
+    args.state.focusIndex,
+    args.state.generatedId,
+    args.state.pendingSelectionUpdate,
+    args.state.queryStates,
+    args.state.selectionEnd,
+    args.state.selectionStart,
+    args.state.suggestions,
+    args.value,
+    ensureGeneratedId,
+    flushPendingViewSync,
+    requestViewSync,
+  ])
 
   useEffect(() => {
-    document.addEventListener('scroll', handleDocumentScroll, true)
+    const ownerDocument = inputElementRef.current?.ownerDocument
+
+    if (ownerDocument === undefined) {
+      return undefined
+    }
+
+    ownerDocument.addEventListener('scroll', handleDocumentScroll, true)
 
     return () => {
-      document.removeEventListener('scroll', handleDocumentScroll, true)
+      ownerDocument.removeEventListener('scroll', handleDocumentScroll, true)
     }
-  }, [handleDocumentScroll])
+  }, [
+    args.props.inputComponent,
+    args.props.singleLine,
+    args.state.generatedId,
+    handleDocumentScroll,
+  ])
 
   return {
     containerElementRef,
@@ -587,8 +616,8 @@ export const useCaretLayout = <Extra extends Record<string, unknown>>(
     setInputRef,
     setHighlighterElement,
     setSuggestionsElement,
-    getSuggestionsOverlayId,
-    getInlineAutocompleteLiveRegionId,
+    suggestionsOverlayId,
+    inlineAutocompleteLiveRegionId,
     ensureGeneratedIdIfNeeded: ensureGeneratedId,
     resolvePortalHost,
     requestViewSync,

--- a/src/useMentionSelectionChange.ts
+++ b/src/useMentionSelectionChange.ts
@@ -10,12 +10,12 @@ import type {
   MentionsInputState,
 } from './types'
 import { areMentionSelectionsEqual } from './utils/areMentionSelectionsEqual'
-import { useEventCallback } from './utils/useEventCallback'
 
 interface UseMentionSelectionChangeArgs<Extra extends Record<string, unknown>> {
   props: MentionsInputProps<Extra>
   state: MentionsInputState<Extra>
   config: ReadonlyArray<MentionChildConfig<Extra>>
+  currentSnapshot: MentionValueSnapshot<Extra>
   getCurrentSnapshot: (
     value?: string,
     config?: ReadonlyArray<MentionChildConfig<Extra>>
@@ -33,6 +33,7 @@ export const useMentionSelectionChange = <Extra extends Record<string, unknown>>
   props,
   state,
   config,
+  currentSnapshot,
   getCurrentSnapshot,
 }: UseMentionSelectionChangeArgs<Extra>) => {
   const previousCommitRef = useRef<PreviousSelectionCommit<Extra>>({
@@ -42,17 +43,15 @@ export const useMentionSelectionChange = <Extra extends Record<string, unknown>>
     selectionEnd: state.selectionEnd,
   })
 
-  const getCurrentMentionSelectionMap = useEventCallback(
-    (): Record<string, MentionSelectionState> => {
-      const { selectionStart, selectionEnd } = state
-      if (selectionStart === null || selectionEnd === null) {
-        return {}
-      }
-
-      const { mentions } = getCurrentSnapshot(props.value ?? '', config)
-      return getMentionSelectionMap(mentions, config, selectionStart, selectionEnd)
-    }
-  )
+  const currentMentionSelectionMap: Record<string, MentionSelectionState> =
+    state.selectionStart === null || state.selectionEnd === null
+      ? {}
+      : getMentionSelectionMap(
+          currentSnapshot.mentions,
+          config,
+          state.selectionStart,
+          state.selectionEnd
+        )
 
   useEffect(() => {
     const previousCommit = previousCommitRef.current
@@ -62,11 +61,11 @@ export const useMentionSelectionChange = <Extra extends Record<string, unknown>>
     const currentValue = props.value ?? ''
     const configChanged = !areMentionConfigsEqual(previousCommit.config, config)
     const valueChanged = currentValue !== previousCommit.value || configChanged
-    const currentSnapshot = getCurrentSnapshot(currentValue, config)
+    const currentValueSnapshot = getCurrentSnapshot(currentValue, config)
 
     if ((selectionPositionsChanged || valueChanged) && props.onMentionSelectionChange) {
       const currentSelection = computeMentionSelectionDetails<Extra>(
-        currentSnapshot.mentions,
+        currentValueSnapshot.mentions,
         config,
         state.selectionStart,
         state.selectionEnd
@@ -94,7 +93,7 @@ export const useMentionSelectionChange = <Extra extends Record<string, unknown>>
         const selectionMentionIds = currentSelection.selections.map((selection) => selection.id)
         const selectionContext = createMentionSelectionContext(
           currentValue,
-          currentSnapshot,
+          currentValueSnapshot,
           selectionMentionIds
         )
         props.onMentionSelectionChange(currentSelection.selections, selectionContext)
@@ -110,6 +109,6 @@ export const useMentionSelectionChange = <Extra extends Record<string, unknown>>
   })
 
   return {
-    getCurrentMentionSelectionMap,
+    currentMentionSelectionMap,
   }
 }

--- a/src/useMentionValueSnapshot.ts
+++ b/src/useMentionValueSnapshot.ts
@@ -1,15 +1,10 @@
-import { useRef } from 'react'
+import { useMemo, useRef } from 'react'
 import type { PreparedMentionsInputChildren } from './MentionsInputChildren'
 import { areMentionConfigsEqual, prepareMentionsInputChildren } from './MentionsInputChildren'
 import type { MentionValueSnapshot } from './MentionsInputDerived'
 import { deriveMentionValueSnapshot } from './MentionsInputDerived'
 import type { MentionChildConfig, MentionsInputProps } from './types'
 import { useEventCallback } from './utils/useEventCallback'
-
-interface PreparedChildrenCache<Extra extends Record<string, unknown>> {
-  source: MentionsInputProps<Extra>['children']
-  value: PreparedMentionsInputChildren<Extra>
-}
 
 interface SnapshotCache<Extra extends Record<string, unknown>> {
   value: string
@@ -21,40 +16,33 @@ export const useMentionValueSnapshot = <Extra extends Record<string, unknown>>(
   children: MentionsInputProps<Extra>['children'],
   value: string | undefined
 ) => {
-  const preparedChildrenCacheRef = useRef<PreparedChildrenCache<Extra> | null>(null)
   const snapshotCacheRef = useRef<SnapshotCache<Extra> | null>(null)
+  const preparedChildren = useMemo(() => prepareMentionsInputChildren<Extra>(children), [children])
+  const currentValue = value ?? ''
+  const currentSnapshot = useMemo(() => {
+    const cachedSnapshot = snapshotCacheRef.current
+
+    if (
+      cachedSnapshot?.value === currentValue &&
+      areMentionConfigsEqual(preparedChildren.config, cachedSnapshot.config)
+    ) {
+      return cachedSnapshot.snapshot
+    }
+
+    return deriveMentionValueSnapshot<Extra>(currentValue, preparedChildren.config)
+  }, [currentValue, preparedChildren.config])
 
   const getPreparedChildren = useEventCallback(
     (
       nextChildren: MentionsInputProps<Extra>['children'] = children
     ): PreparedMentionsInputChildren<Extra> => {
-      if (preparedChildrenCacheRef.current?.source === nextChildren) {
-        return preparedChildrenCacheRef.current.value
-      }
-
-      const preparedChildren = prepareMentionsInputChildren<Extra>(nextChildren)
-
       if (nextChildren === children) {
-        preparedChildrenCacheRef.current = {
-          source: nextChildren,
-          value: preparedChildren,
-        }
+        return preparedChildren
       }
 
-      return preparedChildren
+      return prepareMentionsInputChildren<Extra>(nextChildren)
     }
   )
-
-  const preparedChildren = getPreparedChildren(children)
-  const initialValue = value ?? ''
-
-  if (snapshotCacheRef.current === null) {
-    snapshotCacheRef.current = {
-      value: initialValue,
-      config: [...preparedChildren.config],
-      snapshot: deriveMentionValueSnapshot<Extra>(initialValue, preparedChildren.config),
-    }
-  }
 
   const cacheSnapshot = useEventCallback(
     (
@@ -71,15 +59,19 @@ export const useMentionValueSnapshot = <Extra extends Record<string, unknown>>(
     }
   )
 
-  const getCurrentConfig = useEventCallback(() => getPreparedChildren(children).config)
+  const getCurrentConfig = useEventCallback(() => preparedChildren.config)
 
-  const getMentionChildren = useEventCallback(() => getPreparedChildren(children).mentionChildren)
+  const getMentionChildren = useEventCallback(() => preparedChildren.mentionChildren)
 
   const getCurrentSnapshot = useEventCallback(
     (
-      nextValue: string = value ?? '',
+      nextValue: string = currentValue,
       config: ReadonlyArray<MentionChildConfig<Extra>> = getCurrentConfig()
     ): MentionValueSnapshot<Extra> => {
+      if (nextValue === currentValue && areMentionConfigsEqual(config, preparedChildren.config)) {
+        return currentSnapshot
+      }
+
       const cachedSnapshot = snapshotCacheRef.current
 
       if (
@@ -95,6 +87,7 @@ export const useMentionValueSnapshot = <Extra extends Record<string, unknown>>(
 
   return {
     preparedChildren,
+    currentSnapshot,
     getPreparedChildren,
     getMentionChildren,
     getCurrentConfig,

--- a/src/useMentionsEditing.ts
+++ b/src/useMentionsEditing.ts
@@ -343,6 +343,7 @@ export const useMentionsEditing = <Extra extends Record<string, unknown>>(
       getCurrentSnapshot,
       cacheSnapshot,
       updateMentionsQueries,
+      clearSuggestions,
       requestHighlighterScrollSync,
     } = argsRef.current
     const native = event.nativeEvent
@@ -387,12 +388,18 @@ export const useMentionsEditing = <Extra extends Record<string, unknown>>(
         prevState.pendingSelectionUpdate || inputChangeResult.shouldRestoreSelection,
     }))
 
-    if (
-      nativeEvent.isComposing === true &&
-      inputChangeResult.nextSelectionStart === inputChangeResult.nextSelectionEnd &&
-      inputElementRef.current !== null
-    ) {
-      updateMentionsQueries(inputElementRef.current.value, inputChangeResult.nextSelectionStart)
+    if (inputChangeResult.nextSelectionStart === inputChangeResult.nextSelectionEnd) {
+      const querySource =
+        nativeEvent.isComposing === true && inputElementRef.current !== null
+          ? inputElementRef.current.value
+          : inputChangeResult.snapshot.plainText
+      updateMentionsQueries(
+        querySource,
+        inputChangeResult.nextSelectionStart,
+        inputChangeResult.value
+      )
+    } else {
+      clearSuggestions()
     }
 
     executeOnChange(

--- a/src/useSuggestionsQuery.ts
+++ b/src/useSuggestionsQuery.ts
@@ -51,11 +51,13 @@ interface ActiveSuggestionQuery<Extra extends Record<string, unknown>> {
 
 interface UseSuggestionsQueryArgs<Extra extends Record<string, unknown>> {
   props: MentionsInputProps<Extra>
+  state: MentionsInputState<Extra>
   stateRef: React.RefObject<MentionsInputState<Extra>>
   setState: SetMentionsInputState<Extra>
+  mentionChildren: React.ReactElement<MentionComponentProps<Extra>>[]
   getMentionChildren: () => React.ReactElement<MentionComponentProps<Extra>>[]
   getCurrentConfig: () => PreparedConfig<Extra>
-  isInlineAutocomplete: () => boolean
+  isInlineAutocomplete: boolean
 }
 
 type PreparedConfig<Extra extends Record<string, unknown>> = ReadonlyArray<
@@ -228,7 +230,7 @@ export const useSuggestionsQuery = <Extra extends Record<string, unknown>>(
             queryInfo,
             page,
             prevState.focusIndex,
-            argsRef.current.isInlineAutocomplete()
+            argsRef.current.isInlineAutocomplete
           )
         )
       } catch (error) {
@@ -455,7 +457,7 @@ export const useSuggestionsQuery = <Extra extends Record<string, unknown>>(
   )
 
   const loadMoreSuggestions = useEventCallback((): void => {
-    if (argsRef.current.isInlineAutocomplete()) {
+    if (argsRef.current.isInlineAutocomplete) {
       return
     }
 
@@ -520,7 +522,7 @@ export const useSuggestionsQuery = <Extra extends Record<string, unknown>>(
   )
 
   const getInlineSuggestionDetails = useEventCallback((): InlineSuggestionDetails<Extra> | null =>
-    argsRef.current.isInlineAutocomplete()
+    argsRef.current.isInlineAutocomplete
       ? getInlineSuggestionDetailsForMentionChildren<Extra>(
           argsRef.current.getMentionChildren(),
           argsRef.current.stateRef.current.suggestions,
@@ -530,7 +532,7 @@ export const useSuggestionsQuery = <Extra extends Record<string, unknown>>(
   )
 
   const canApplyInlineSuggestion = useEventCallback((): boolean => {
-    if (!argsRef.current.isInlineAutocomplete()) {
+    if (!argsRef.current.isInlineAutocomplete) {
       return false
     }
 
@@ -560,22 +562,29 @@ export const useSuggestionsQuery = <Extra extends Record<string, unknown>>(
     )
   )
 
-  const isLoading = useEventCallback(
-    (): boolean =>
-      argsRef.current.getMentionChildren().some((child) => child.props.isLoading === true) ||
-      getSuggestionQueryStateEntries(argsRef.current.stateRef.current.queryStates).some(
-        ([, queryState]) =>
-          queryState.status === 'loading' || queryState.pagination?.isLoading === true
+  const inlineSuggestionDetails = args.isInlineAutocomplete
+    ? getInlineSuggestionDetailsForMentionChildren<Extra>(
+        args.mentionChildren,
+        args.state.suggestions,
+        args.state.focusIndex
       )
+    : null
+  const suggestionsStatusContent = getSuggestionsStatusContentForMentionChildren<Extra>(
+    args.mentionChildren,
+    args.state.suggestions,
+    args.state.queryStates
   )
-
-  const isOpened = useEventCallback(
-    (): boolean =>
-      typeof argsRef.current.stateRef.current.selectionStart === 'number' &&
-      (countSuggestions(argsRef.current.stateRef.current.suggestions) !== 0 ||
-        isLoading() ||
-        getSuggestionsStatusContent().statusType !== null)
-  )
+  const isLoading =
+    args.mentionChildren.some((child) => child.props.isLoading === true) ||
+    getSuggestionQueryStateEntries(args.state.queryStates).some(
+      ([, queryState]) =>
+        queryState.status === 'loading' || queryState.pagination?.isLoading === true
+    )
+  const isOpened =
+    typeof args.state.selectionStart === 'number' &&
+    (countSuggestions(args.state.suggestions) !== 0 ||
+      isLoading ||
+      suggestionsStatusContent.statusType !== null)
 
   useEffect(() => clearPendingSuggestionRequests, [clearPendingSuggestionRequests])
 
@@ -597,9 +606,11 @@ export const useSuggestionsQuery = <Extra extends Record<string, unknown>>(
     getFocusedSuggestionEntry,
     getSuggestionData,
     getInlineSuggestionDetails,
+    inlineSuggestionDetails,
     canApplyInlineSuggestion,
     getPreferredQueryState,
     getSuggestionsStatusContent,
+    suggestionsStatusContent,
     isLoading,
     isOpened,
   }


### PR DESCRIPTION
…aps, suggestion state, IDs, and inline mode.

Fixed ordinary input changes so mention queries refresh immediately. Restored onKeyDown forwarding for unhandled overlay keys. Fixed owner-document portal, scroll, viewport, and resize behavior for iframe/alternate document usage. Removed function-component defaultProps usage.
Aligned the internal test harness with real keydown behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved support for iframe environments by properly resolving window and document contexts from element ownership.
  * Enhanced keyboard navigation for suggestion handling with better distinction between inline and overlay modes.
  * Refined mention selection behavior and suggestion refresh logic following input changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Scope resize observers, scroll listeners, and suggestions portal to the input element's owner document
> - Replaces global `document`/`window` references throughout with per-element owner document and window lookups, enabling correct behavior when the input is rendered inside an iframe.
> - Introduces `getOwnerWindow` in [MeasurementBridge.tsx](https://github.com/hbmartin/react-mentions-ts/pull/205/files#diff-f05f418c2b64673088d3968a6d394b6f13b7dc48a13f8e0a4b7088f5a3635787) to resolve the owning window from provided elements, falling back to `globalThis.window`.
> - Moves the default suggestions portal host to `input.ownerDocument.body` and scopes document scroll listeners to `input.ownerDocument` in [useCaretLayout.ts](https://github.com/hbmartin/react-mentions-ts/pull/205/files#diff-fbc5d5b9cdf51e43d4fcf59fb092303fadb9b6f458b15745ac16f5e1e66cf739).
> - Fixes suggestions positioning in [MentionsInputLayout.ts](https://github.com/hbmartin/react-mentions-ts/pull/205/files#diff-7d40540d82b40ebe0cf0576049c2f8f73039531f16f648e29f85078d7777a473) to use the highlighter's owning document/window instead of the top-level globals.
> - Replaces render-time getter calls (`isInlineAutocomplete()`, `getCurrentMentionSelectionMap()`, etc.) with stable memoized values and boolean properties across [MentionsInput.tsx](https://github.com/hbmartin/react-mentions-ts/pull/205/files#diff-5324a6e48c1ed3e0637605dab500fd0e512b7917d46884c35cba8e68698b5473), [useSuggestionsQuery.ts](https://github.com/hbmartin/react-mentions-ts/pull/205/files#diff-7b83662a7d4322a926407a0d5787cd3a5294565a4aed27f7e8bdd684259e6e7e), and [useMentionSelectionChange.ts](https://github.com/hbmartin/react-mentions-ts/pull/205/files#diff-1d8f4a8a7e07ac58f9521d583a81976486e5eb4a34a1e39f9952851e9251ec86).
> - Behavioral Change: `MentionsInput.defaultProps` is no longer present on the exported component; unhandled keydown events while overlay suggestions are open are now forwarded to the consumer `onKeyDown` handler.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9ccb6b8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->