### PR TITLE
Improves fallback handling scenarios

### DIFF
--- a/src/Highlighter.spec.tsx
+++ b/src/Highlighter.spec.tsx
@@ -368,6 +368,28 @@ describe('Highlighter', () => {
     expect(renderedMentions).toHaveLength(2)
   })
 
+  it('renders a caret marker after a trailing mention', async () => {
+    const onCaretPositionChange = vi.fn()
+    const { container } = render(
+      <Highlighter
+        selectionStart={5}
+        selectionEnd={5}
+        value="@[Alice](alice)"
+        onCaretPositionChange={onCaretPositionChange}
+      >
+        <Mention trigger="@" data={[]} markup="@[__display__](__id__)" />
+      </Highlighter>
+    )
+
+    const caret = container.querySelector('[data-mentions-caret]')
+    expect(caret).not.toBeNull()
+    expect(caret?.previousElementSibling?.textContent).toBe('Alice')
+
+    await waitFor(() => {
+      expect(onCaretPositionChange).toHaveBeenCalled()
+    })
+  })
+
   it('keeps unaffected substring spans stable when only the caret moves', () => {
     const value = 'Hello @[John](user1) and goodbye'
     const getSuffixSpan = (container: HTMLElement): HTMLSpanElement | undefined =>

--- a/src/Highlighter.tsx
+++ b/src/Highlighter.tsx
@@ -361,6 +361,23 @@ function Highlighter<Extra extends Record<string, unknown> = Record<string, unkn
     )
   })
 
+  if (
+    isNumber(caretPositionInMarkup) &&
+    caretPositionInMarkup === value.length &&
+    segments.at(-1)?.type === 'mention'
+  ) {
+    resultComponents.push(
+      <HighlighterCaret
+        className={caretClass}
+        key="caret:trailing-mention"
+        measureKey={`trailing:${value.length.toString()}`}
+        onCaretPositionChange={onCaretPositionChange}
+        recomputeVersion={recomputeVersion}
+        singleLine={singleLine}
+      />
+    )
+  }
+
   // append a space to ensure the last text line has the correct height
   resultComponents.push(' ')
 

--- a/src/MeasurementBridge.spec.tsx
+++ b/src/MeasurementBridge.spec.tsx
@@ -151,47 +151,50 @@ describe('MeasurementBridge', () => {
     }
   })
 
-  it('skips viewport listener registration when no owner or global window is available', () => {
-    const requestViewSync = vi.fn()
-    const addListener = vi.spyOn(globalThis, 'addEventListener')
-    const originalReflectGet = Reflect.get
-    const reflectGetSpy = vi
-      .spyOn(Reflect, 'get')
-      .mockImplementation((target: object, propertyKey: PropertyKey, receiver?: unknown) => {
-        if (target === globalThis && propertyKey === 'window') {
-          return undefined
-        }
+  it.each([undefined, null])(
+    'skips viewport listener registration when global window fallback is %s',
+    (globalWindow) => {
+      const requestViewSync = vi.fn()
+      const addListener = vi.spyOn(globalThis, 'addEventListener')
+      const originalReflectGet = Reflect.get
+      const reflectGetSpy = vi
+        .spyOn(Reflect, 'get')
+        .mockImplementation((target: object, propertyKey: PropertyKey, receiver?: unknown) => {
+          if (target === globalThis && propertyKey === 'window') {
+            return globalWindow
+          }
 
-        if (target === null || target === undefined) {
-          return undefined
-        }
+          if (target === null || target === undefined) {
+            return undefined
+          }
 
-        return receiver === undefined
-          ? originalReflectGet(target, propertyKey)
-          : originalReflectGet(target, propertyKey, receiver)
-      })
+          return receiver === undefined
+            ? originalReflectGet(target, propertyKey)
+            : originalReflectGet(target, propertyKey, receiver)
+        })
 
-    try {
-      render(
-        <MeasurementBridge
-          container={null}
-          highlighter={null}
-          input={null}
-          suggestions={null}
-          requestViewSync={requestViewSync}
-        />
-      )
+      try {
+        render(
+          <MeasurementBridge
+            container={null}
+            highlighter={null}
+            input={null}
+            suggestions={null}
+            requestViewSync={requestViewSync}
+          />
+        )
 
-      expect(requestViewSync).toHaveBeenCalledWith({
-        syncScroll: true,
-        measureSuggestions: true,
-        measureInline: true,
-      })
-      expect(addListener).not.toHaveBeenCalledWith('resize', expect.any(Function))
-      expect(addListener).not.toHaveBeenCalledWith('orientationchange', expect.any(Function))
-    } finally {
-      addListener.mockRestore()
-      reflectGetSpy.mockRestore()
+        expect(requestViewSync).toHaveBeenCalledWith({
+          syncScroll: true,
+          measureSuggestions: true,
+          measureInline: true,
+        })
+        expect(addListener).not.toHaveBeenCalledWith('resize', expect.any(Function))
+        expect(addListener).not.toHaveBeenCalledWith('orientationchange', expect.any(Function))
+      } finally {
+        addListener.mockRestore()
+        reflectGetSpy.mockRestore()
+      }
     }
-  })
+  )
 })

--- a/src/MeasurementBridge.tsx
+++ b/src/MeasurementBridge.tsx
@@ -29,7 +29,8 @@ const getOwnerWindow = (...elements: Array<Element | null>): Window | undefined 
     }
   }
 
-  return Reflect.get(globalThis, 'window') as Window | undefined
+  const globalWindow = Reflect.get(globalThis, 'window') as Window | null | undefined
+  return globalWindow ?? undefined
 }
 
 const MeasurementBridge = ({

--- a/src/MentionsInputLayout.spec.ts
+++ b/src/MentionsInputLayout.spec.ts
@@ -229,6 +229,89 @@ describe('MentionsInputLayout', () => {
     }
   })
 
+  it('uses the portal host document viewport when the portal host belongs to another document', () => {
+    const highlighter = document.createElement('div')
+    const suggestions = document.createElement('div')
+    const container = document.createElement('div')
+    const portalDocument = document.implementation.createHTMLDocument('portal')
+    const originalInnerHeight = globalThis.innerHeight
+    const originalInnerWidth = globalThis.innerWidth
+    const originalClientHeight = document.documentElement.clientHeight
+    const originalClientWidth = document.documentElement.clientWidth
+
+    highlighter.style.fontSize = '16px'
+    suggestions.style.marginLeft = '0px'
+    suggestions.style.marginTop = '0px'
+
+    Object.defineProperty(globalThis, 'innerHeight', { value: 600, configurable: true })
+    Object.defineProperty(globalThis, 'innerWidth', { value: 600, configurable: true })
+    Object.defineProperty(document.documentElement, 'clientHeight', {
+      value: 600,
+      configurable: true,
+    })
+    Object.defineProperty(document.documentElement, 'clientWidth', {
+      value: 600,
+      configurable: true,
+    })
+    Object.defineProperty(portalDocument.documentElement, 'clientHeight', {
+      value: 120,
+      configurable: true,
+    })
+    Object.defineProperty(portalDocument.documentElement, 'clientWidth', {
+      value: 140,
+      configurable: true,
+    })
+    Object.defineProperty(highlighter, 'getBoundingClientRect', {
+      value: () => ({
+        left: 130,
+        top: 80,
+        right: 0,
+        bottom: 0,
+        width: 0,
+        height: 0,
+      }),
+    })
+    Object.defineProperty(highlighter, 'offsetWidth', { value: 200, configurable: true })
+    Object.defineProperty(suggestions, 'offsetHeight', { value: 40, configurable: true })
+    Object.defineProperty(container, 'offsetWidth', { value: 220, configurable: true })
+
+    try {
+      const position = calculateSuggestionsPosition({
+        caretPosition: { left: 24, top: 32 },
+        suggestionsPlacement: 'auto',
+        anchorMode: 'caret',
+        resolvedPortalHost: portalDocument.body,
+        suggestions,
+        highlighter,
+        container,
+      })
+
+      expect(position).toEqual({
+        left: 0,
+        position: 'fixed',
+        top: 56,
+        width: 140,
+      })
+    } finally {
+      Object.defineProperty(globalThis, 'innerHeight', {
+        value: originalInnerHeight,
+        configurable: true,
+      })
+      Object.defineProperty(globalThis, 'innerWidth', {
+        value: originalInnerWidth,
+        configurable: true,
+      })
+      Object.defineProperty(document.documentElement, 'clientHeight', {
+        value: originalClientHeight,
+        configurable: true,
+      })
+      Object.defineProperty(document.documentElement, 'clientWidth', {
+        value: originalClientWidth,
+        configurable: true,
+      })
+    }
+  })
+
   it('supports explicit above placement in a portal and prefers window dimensions when larger', () => {
     const highlighter = document.createElement('div')
     const suggestions = document.createElement('div')
@@ -460,6 +543,75 @@ describe('MentionsInputLayout', () => {
     expect(calculateInlineSuggestionPosition({ highlighter })).toMatchObject({
       left: 22,
       top: 18,
+    })
+  })
+
+  it('uses the last inline client rect when preceding text wraps', () => {
+    const control = document.createElement('div')
+    const highlighter = document.createElement('div')
+    const previousText = document.createElement('span')
+    const caret = document.createElement('span')
+    const firstLineRect = {
+      left: 20,
+      top: 20,
+      right: 70,
+      bottom: 36,
+      width: 50,
+      height: 16,
+    }
+    const lastLineRect = {
+      left: 20,
+      top: 48,
+      right: 74,
+      bottom: 64,
+      width: 54,
+      height: 16,
+    }
+
+    caret.dataset.mentionsCaret = 'true'
+    highlighter.append(previousText, caret)
+    control.append(highlighter)
+
+    Object.defineProperty(control, 'getBoundingClientRect', {
+      value: () => ({
+        left: 20,
+        top: 10,
+        right: 0,
+        bottom: 0,
+        width: 0,
+        height: 0,
+      }),
+    })
+    Object.defineProperty(previousText, 'getBoundingClientRect', {
+      value: () => ({
+        left: 20,
+        top: 20,
+        right: 74,
+        bottom: 64,
+        width: 54,
+        height: 44,
+      }),
+    })
+    Object.defineProperty(previousText, 'getClientRects', {
+      value: () => ({
+        length: 2,
+        item: (index: number) => (index === 0 ? firstLineRect : lastLineRect),
+      }),
+    })
+    Object.defineProperty(caret, 'getBoundingClientRect', {
+      value: () => ({
+        left: 74,
+        top: 64,
+        right: 74,
+        bottom: 64,
+        width: 0,
+        height: 0,
+      }),
+    })
+
+    expect(calculateInlineSuggestionPosition({ highlighter })).toMatchObject({
+      left: 54,
+      top: 38,
     })
   })
 

--- a/src/MentionsInputLayout.ts
+++ b/src/MentionsInputLayout.ts
@@ -53,6 +53,19 @@ const INLINE_TYPOGRAPHY_STYLE_PROPS = [
   'wordSpacing',
 ] as const
 
+const getLastClientRect = (element: Element | null): DOMRect | undefined => {
+  if (element === null) {
+    return undefined
+  }
+
+  const rects = element.getClientRects()
+  if (rects.length > 0) {
+    return rects.item(rects.length - 1) ?? undefined
+  }
+
+  return element.getBoundingClientRect()
+}
+
 interface HighlighterViewPatch {
   scrollLeft: number
   scrollTop: number
@@ -181,11 +194,11 @@ export const calculateSuggestionsPosition = ({
     left: caretOffsetParentRect.left + (anchorToLeft ? 0 : caretPosition.left),
     top: caretOffsetParentRect.top + caretPosition.top,
   }
-  const ownerDocument = highlighter.ownerDocument
-  const ownerWindow = ownerDocument.defaultView
+  const viewportDocument = (resolvedPortalHost ?? highlighter).ownerDocument
+  const viewportWindow = viewportDocument.defaultView
   const viewportHeight = Math.max(
-    ownerDocument.documentElement.clientHeight,
-    ownerWindow?.innerHeight ?? 0
+    viewportDocument.documentElement.clientHeight,
+    viewportWindow?.innerHeight ?? 0
   )
   const desiredWidth = highlighter.offsetWidth
 
@@ -193,8 +206,8 @@ export const calculateSuggestionsPosition = ({
 
   if (resolvedPortalHost) {
     const viewportWidth = Math.max(
-      ownerDocument.documentElement.clientWidth,
-      ownerWindow?.innerWidth ?? 0
+      viewportDocument.documentElement.clientWidth,
+      viewportWindow?.innerWidth ?? 0
     )
     const width = Math.min(desiredWidth, viewportWidth)
     position.width = width
@@ -263,7 +276,7 @@ export const calculateInlineSuggestionPosition = ({
   const controlElement = highlighter.parentElement
   const controlRect = controlElement?.getBoundingClientRect()
   const caretRect = caretElement?.getBoundingClientRect()
-  const previousInlineBoxRect = caretElement?.previousElementSibling?.getBoundingClientRect()
+  const previousInlineBoxRect = getLastClientRect(caretElement?.previousElementSibling ?? null)
 
   if (!caretRect || !controlElement || !controlRect) {
     return null


### PR DESCRIPTION
src/Highlighter.tsx (line 363): renders a fallback caret after a trailing mention so caret geometry does not go stale.
src/MentionsInputLayout.ts (line 56): uses the previous inline element’s last client rect, with bounding-rect fallback, for wrapped-line positioning.
src/MeasurementBridge.tsx: normalizes a null global window fallback to undefined.
src/MentionsInputLayout.ts: portal positioning now derives viewport dimensions from resolvedPortalHost.ownerDocument when portaled.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix fallback handling for trailing mentions, null window, and multi-line inline suggestions
> - Adds a trailing caret marker in `Highlighter` when the caret is at the end of the input and the last segment is a mention, so the caret position is correctly reported in that edge case.
> - Fixes `getOwnerWindow` in [MeasurementBridge.tsx](https://github.com/hbmartin/react-mentions-ts/pull/206/files#diff-f05f418c2b64673088d3968a6d394b6f13b7dc48a13f8e0a4b7088f5a3635787) to return `undefined` instead of `null` when `globalThis.window` is null, preventing unexpected null propagation.
> - Updates `calculateSuggestionsPosition` to derive viewport dimensions from the portal host's document when it belongs to a different document, fixing fixed-position suggestions in cross-document portals.
> - Updates `calculateInlineSuggestionPosition` to anchor to the last client rect of preceding content via a new `getLastClientRect` utility, so inline suggestions correctly align to the last line when preceding text wraps.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 97ed934.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed caret display when positioned at the end of trailing mentions.
  * Improved suggestion positioning for portals hosted in different documents using appropriate viewport dimensions.
  * Fixed suggestion positioning when preceding text wraps across multiple lines.
  * Enhanced null value handling in window lookups for better edge-case coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->