### PR TITLE
Implemented the sideEffects tree-shake report.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ A React component that enables Facebook/Twitter-style @mentions and tagging in t
   - [Async Data Loading](#async-data-loading)
 - [More Examples](#more-examples)
 - [Advanced Usage](#advanced-usage)
+- [Package & Tree Shaking](#package--tree-shaking)
 - [Styling](#styling)
 - [Testing](#testing)
 - [FAQ & Gotchas](#faq--gotchas)
@@ -498,6 +499,24 @@ import { MentionsInput, Mention } from 'react-mentions-ts'
 ```
 
 No dynamic imports or `next/dynamic` wrappers are needed.
+
+## Package & Tree Shaking
+
+The package is published as side-effect free, and the release evidence is repeatable:
+
+```bash
+pnpm tree-shake:report
+```
+
+The report command rebuilds `dist`, runs `npx publint --pack npm`, requires `"sideEffects": false`, inspects `npm pack --dry-run --json`, and bundles small Vite consumer fixtures against `dist/index.js`.
+
+Current verified behavior:
+
+- A fixture that imports only `Mention` and `getSubstringIndex` must not retain `LoadingIndicator`, `SuggestionsOverlay`, or inline-suggestion markers.
+- A fixture that imports `MentionsInput` currently retains overlay, loading, and inline-suggestion markers because those branches are statically imported by the orchestration shell.
+- The npm pack check prints the tarball filename, packed size, unpacked size, and file count so publish contents stay visible.
+
+Maintainer follow-up opportunities are `LoadingIndicator`, `SuggestionsOverlay`, and the inline-suggestion UI/selector path. Those can be split or lazy-loaded in a future packaging change for consumers that never use those branches. This is not a consumer setup requirement; apps can keep importing `MentionsInput` normally, including in SSR frameworks, without `next/dynamic` wrappers.
 
 ## Styling
 

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "lint:rule-counts": "oxlint src --format json | jq '[.diagnostics[].code] | group_by(.) | map({ rule: .[0], count: length }) | sort_by(-.count)'",
     "lint:all-rules": "node ./scripts/write-oxlint-all-rules.mjs",
     "publint": "npx publint --pack npm",
+    "tree-shake:report": "pnpm build && npx publint --pack npm && node ./scripts/tree-shake-report.mjs",
     "types:lint": "npm_config_cache=.npm-cache attw --pack .",
     "ci:verify": "pnpm lint && pnpm typecheck && pnpm build && npx publint --pack npm && pnpm types:lint",
     "dev": "node ./scripts/dev-with-wdyr.mjs",

--- a/scripts/tree-shake-report.mjs
+++ b/scripts/tree-shake-report.mjs
@@ -1,0 +1,212 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'node:child_process'
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { build } from 'vite'
+
+const root = process.cwd()
+const packageJsonPath = resolve(root, 'package.json')
+const distEntry = resolve(root, 'dist/index.js')
+const reactExternals = ['react', 'react-dom', 'react/jsx-runtime']
+
+const ownFeatureMarkers = [
+  { label: 'LoadingIndicator', value: 'function LoadingIndicator' },
+  { label: 'SuggestionsOverlay', value: 'function SuggestionsOverlay' },
+  { label: 'inline suggestion UI', value: 'inline-suggestion-live-region' },
+  { label: 'inline suggestion fallback', value: 'No inline suggestions available' },
+]
+
+const splitCandidateRegions = [
+  'src/LoadingIndicator.tsx',
+  'src/SuggestionsOverlay.tsx',
+  'src/MentionsInputInlineSuggestion.tsx',
+  'src/MentionsInputSelectors.ts',
+]
+
+const formatBytes = (bytes) => {
+  const kib = bytes / 1024
+
+  return `${kib.toFixed(2)} KiB`
+}
+
+const readJson = async (filePath) => JSON.parse(await readFile(filePath, 'utf8'))
+
+const fail = (message) => {
+  console.error(`tree-shake report failed: ${message}`)
+  process.exit(1)
+}
+
+const readPackReport = () => {
+  const output = execFileSync('npm', ['pack', '--dry-run', '--json'], {
+    cwd: root,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+  const parsed = JSON.parse(output)
+
+  if (!Array.isArray(parsed) || parsed.length === 0) {
+    fail('npm pack --dry-run --json returned no package entries')
+  }
+
+  return parsed[0]
+}
+
+const writeFixtureBundle = async ({ fixture, outDir }) => {
+  const entry = join(outDir, `${fixture.name}.js`)
+  const bundleDir = join(outDir, fixture.name)
+
+  await writeFile(entry, fixture.source)
+  await mkdir(bundleDir, { recursive: true })
+  await build({
+    logLevel: 'silent',
+    build: {
+      emptyOutDir: true,
+      minify: false,
+      outDir: bundleDir,
+      lib: {
+        entry,
+        formats: ['es'],
+        fileName: () => 'bundle.js',
+      },
+      rollupOptions: {
+        external: reactExternals,
+      },
+    },
+  })
+
+  return readFile(join(bundleDir, 'bundle.js'), 'utf8')
+}
+
+const inspectMarkers = (bundle) =>
+  ownFeatureMarkers.map((marker) => ({
+    ...marker,
+    present: bundle.includes(marker.value),
+  }))
+
+const describeMarkers = (markers) =>
+  markers.map((marker) => `${marker.label}: ${marker.present ? 'present' : 'absent'}`).join(', ')
+
+const getRegionSize = (bundle, region) => {
+  const marker = `//#region ${region}`
+  const start = bundle.indexOf(marker)
+
+  if (start === -1) {
+    return null
+  }
+
+  const nextRegion = bundle.indexOf('//#region ', start + marker.length)
+  const end = nextRegion === -1 ? bundle.length : nextRegion
+
+  return end - start
+}
+
+const main = async () => {
+  const packageJson = await readJson(packageJsonPath)
+
+  if (packageJson.sideEffects !== false) {
+    fail('package.json must declare "sideEffects": false')
+  }
+
+  let distBundle
+
+  try {
+    distBundle = await readFile(distEntry, 'utf8')
+  } catch (error) {
+    fail(`missing ${distEntry}; run pnpm build before this report`)
+  }
+
+  const packReport = readPackReport()
+  const tmp = await mkdtemp(join(tmpdir(), 'react-mentions-ts-tree-shake-'))
+  const fixtures = [
+    {
+      name: 'mention-utility-only',
+      description: 'Mention + utility only',
+      source: `import { Mention, getSubstringIndex } from ${JSON.stringify(distEntry)}
+console.log(Mention, getSubstringIndex('abc', 'b', 0))
+`,
+    },
+    {
+      name: 'mentions-input',
+      description: 'MentionsInput shell',
+      source: `import { Mention, MentionsInput } from ${JSON.stringify(distEntry)}
+console.log(Mention, MentionsInput)
+`,
+    },
+  ]
+
+  try {
+    const results = []
+
+    for (const fixture of fixtures) {
+      const bundle = await writeFixtureBundle({ fixture, outDir: tmp })
+
+      results.push({
+        ...fixture,
+        size: Buffer.byteLength(bundle),
+        markers: inspectMarkers(bundle),
+      })
+    }
+
+    const mentionOnly = results.find((result) => result.name === 'mention-utility-only')
+    const mentionsInput = results.find((result) => result.name === 'mentions-input')
+
+    if (!mentionOnly || !mentionsInput) {
+      fail('fixture report was incomplete')
+    }
+
+    const leakedMarkers = mentionOnly.markers.filter((marker) => marker.present)
+
+    if (leakedMarkers.length > 0) {
+      fail(
+        `Mention + utility fixture retained unused feature markers: ${leakedMarkers
+          .map((marker) => marker.label)
+          .join(', ')}`
+      )
+    }
+
+    const missingStaticMarkers = mentionsInput.markers.filter((marker) => !marker.present)
+
+    if (missingStaticMarkers.length > 0) {
+      fail(
+        `MentionsInput fixture no longer contains expected static feature markers: ${missingStaticMarkers
+          .map((marker) => marker.label)
+          .join(', ')}`
+      )
+    }
+
+    console.log('SideEffects tree-shake report')
+    console.log(`sideEffects: ${String(packageJson.sideEffects)}`)
+    console.log(
+      `npm pack: ${packReport.filename}; packed ${formatBytes(packReport.size)}; unpacked ${formatBytes(packReport.unpackedSize)}; files ${packReport.entryCount}`
+    )
+    console.log('')
+    console.log('Consumer fixture bundles:')
+
+    for (const result of results) {
+      console.log(
+        `- ${result.description}: ${formatBytes(result.size)} (${describeMarkers(result.markers)})`
+      )
+    }
+
+    console.log('')
+    console.log('Current split candidates inside dist/index.js:')
+
+    for (const region of splitCandidateRegions) {
+      const size = getRegionSize(distBundle, region)
+      const formattedSize = size === null ? 'not found' : formatBytes(size)
+
+      console.log(`- ${region}: ${formattedSize}`)
+    }
+
+    console.log('')
+    console.log(
+      'MentionsInput still statically imports overlay, loading, and inline-suggestion code; consumers that only import Mention/utilities can shake those branches.'
+    )
+  } finally {
+    await rm(tmp, { recursive: true, force: true })
+  }
+}
+
+await main()

--- a/src/Highlighter.spec.tsx
+++ b/src/Highlighter.spec.tsx
@@ -390,6 +390,90 @@ describe('Highlighter', () => {
     })
   })
 
+  it('remeasures a trailing mention caret when same-length mention markup changes', async () => {
+    const onCaretPositionChange = vi.fn()
+    const rafCallbacks: FrameRequestCallback[] = []
+    const originalRAF = globalThis.requestAnimationFrame
+    const originalCAF = globalThis.cancelAnimationFrame
+
+    setFrameApi('requestAnimationFrame', (cb: FrameRequestCallback) => {
+      rafCallbacks.push(cb)
+      return rafCallbacks.length
+    })
+    setFrameApi('cancelAnimationFrame', () => undefined)
+
+    try {
+      const { container, rerender } = render(
+        <Highlighter
+          selectionStart={5}
+          selectionEnd={5}
+          value="@[Alice](alice)"
+          onCaretPositionChange={onCaretPositionChange}
+        >
+          <Mention trigger="@" data={[]} markup="@[__display__](__id__)" />
+        </Highlighter>
+      )
+
+      const applyCaretMetrics = (left: number, previousTop: number, previousHeight: number) => {
+        const caret = container.querySelector('[data-mentions-caret]') as HTMLSpanElement
+        const previous = caret.previousElementSibling as HTMLSpanElement
+
+        Object.defineProperty(caret, 'offsetLeft', { configurable: true, value: left })
+        Object.defineProperty(previous, 'offsetTop', { configurable: true, value: previousTop })
+        Object.defineProperty(previous, 'offsetHeight', {
+          configurable: true,
+          value: previousHeight,
+        })
+      }
+
+      applyCaretMetrics(10, 20, 5)
+
+      for (const callback of rafCallbacks.splice(0)) {
+        callback(0)
+      }
+
+      await waitFor(() => {
+        expect(onCaretPositionChange).toHaveBeenLastCalledWith({ left: 10, top: 25 })
+      })
+
+      onCaretPositionChange.mockClear()
+
+      rerender(
+        <Highlighter
+          selectionStart={5}
+          selectionEnd={5}
+          value="@[Margo](margo)"
+          onCaretPositionChange={onCaretPositionChange}
+        >
+          <Mention trigger="@" data={[]} markup="@[__display__](__id__)" />
+        </Highlighter>
+      )
+
+      expect(rafCallbacks).toHaveLength(1)
+      applyCaretMetrics(30, 40, 7)
+
+      for (const callback of rafCallbacks.splice(0)) {
+        callback(0)
+      }
+
+      await waitFor(() => {
+        expect(onCaretPositionChange).toHaveBeenLastCalledWith({ left: 30, top: 47 })
+      })
+    } finally {
+      if (originalRAF) {
+        setFrameApi('requestAnimationFrame', originalRAF)
+      } else {
+        delete (globalThis as typeof globalThis & Record<string, unknown>).requestAnimationFrame
+      }
+
+      if (originalCAF) {
+        setFrameApi('cancelAnimationFrame', originalCAF)
+      } else {
+        delete (globalThis as typeof globalThis & Record<string, unknown>).cancelAnimationFrame
+      }
+    }
+  })
+
   it('keeps unaffected substring spans stable when only the caret moves', () => {
     const value = 'Hello @[John](user1) and goodbye'
     const getSuffixSpan = (container: HTMLElement): HTMLSpanElement | undefined =>

--- a/src/Highlighter.tsx
+++ b/src/Highlighter.tsx
@@ -370,7 +370,7 @@ function Highlighter<Extra extends Record<string, unknown> = Record<string, unkn
       <HighlighterCaret
         className={caretClass}
         key="caret:trailing-mention"
-        measureKey={`trailing:${value.length.toString()}`}
+        measureKey={`trailing:${value}`}
         onCaretPositionChange={onCaretPositionChange}
         recomputeVersion={recomputeVersion}
         singleLine={singleLine}

--- a/src/MentionsInput.tsx
+++ b/src/MentionsInput.tsx
@@ -1,5 +1,5 @@
-import type { KeyboardEvent } from 'react'
-import React, { useImperativeHandle } from 'react'
+import type { KeyboardEvent, ReactElement, ReactNode, Ref } from 'react'
+import { useImperativeHandle } from 'react'
 import { cva } from 'class-variance-authority'
 import { createPortal } from 'react-dom'
 import Highlighter from './Highlighter'
@@ -98,10 +98,15 @@ const getSlotClassName = (
   baseClass: string
 ): string => cn(baseClass, classNames?.[slot])
 
-const MentionsInputInner = <Extra extends Record<string, unknown> = Record<string, unknown>>(
-  props: MentionsInputProps<Extra>,
-  ref: React.ForwardedRef<MentionsInputHandle>
-) => {
+type MentionsInputComponentProps<Extra extends Record<string, unknown> = Record<string, unknown>> =
+  MentionsInputProps<Extra> & {
+    ref?: Ref<MentionsInputHandle>
+  }
+
+const MentionsInput = <Extra extends Record<string, unknown> = Record<string, unknown>>({
+  ref,
+  ...props
+}: MentionsInputComponentProps<Extra>): ReactElement | null => {
   const { state, stateRef, setState } = useMentionsInputState<Extra>()
   const value = props.value ?? ''
   const singleLine = props.singleLine ?? defaultMentionsInputProps.singleLine
@@ -324,7 +329,7 @@ const MentionsInputInner = <Extra extends Record<string, unknown> = Record<strin
     return inputProps as InputComponentProps
   }
 
-  const renderInputControl = (): React.ReactElement => {
+  const renderInputControl = (): ReactElement => {
     const CustomInput = props.inputComponent
     const inputProps = getInputProps()
 
@@ -339,7 +344,7 @@ const MentionsInputInner = <Extra extends Record<string, unknown> = Record<strin
     return <CustomInput ref={caretLayout.setInputRef} {...inputProps} />
   }
 
-  const renderSuggestionsOverlay = (): React.ReactNode | null => {
+  const renderSuggestionsOverlay = (): ReactNode | null => {
     if (isInlineAutocomplete) {
       return null
     }
@@ -394,7 +399,7 @@ const MentionsInputInner = <Extra extends Record<string, unknown> = Record<strin
     return portalTarget ? createPortal(suggestionsNode, portalTarget) : suggestionsNode
   }
 
-  const renderInlineSuggestion = (): React.ReactNode => {
+  const renderInlineSuggestion = (): ReactNode => {
     if (!isInlineAutocomplete || !isNumber(state.selectionStart)) {
       return null
     }
@@ -408,7 +413,7 @@ const MentionsInputInner = <Extra extends Record<string, unknown> = Record<strin
     )
   }
 
-  const renderInlineSuggestionLiveRegion = (): React.ReactNode => {
+  const renderInlineSuggestionLiveRegion = (): ReactNode => {
     if (!isInlineAutocomplete) {
       return null
     }
@@ -427,7 +432,7 @@ const MentionsInputInner = <Extra extends Record<string, unknown> = Record<strin
     )
   }
 
-  const renderHighlighter = (): React.ReactElement => (
+  const renderHighlighter = (): ReactElement => (
     <Highlighter
       containerRef={caretLayout.setHighlighterElement}
       className={props.classNames?.highlighter}
@@ -447,7 +452,7 @@ const MentionsInputInner = <Extra extends Record<string, unknown> = Record<strin
     </Highlighter>
   )
 
-  const renderMeasurementBridge = (): React.ReactElement => (
+  const renderMeasurementBridge = (): ReactElement => (
     <MeasurementBridge
       container={caretLayout.containerElementRef.current}
       highlighter={caretLayout.highlighterElementRef.current}
@@ -473,11 +478,5 @@ const MentionsInputInner = <Extra extends Record<string, unknown> = Record<strin
     />
   )
 }
-
-const MentionsInput = React.forwardRef(MentionsInputInner) as <
-  Extra extends Record<string, unknown> = Record<string, unknown>,
->(
-  props: MentionsInputProps<Extra> & React.RefAttributes<MentionsInputHandle>
-) => React.ReactElement | null
 
 export default MentionsInput

--- a/src/MentionsInputEditing.spec.tsx
+++ b/src/MentionsInputEditing.spec.tsx
@@ -122,4 +122,101 @@ describe('MentionsInputEditing', () => {
     expect(result.nextSelectionStart).toBe(plainTextValue.length)
     expect(result.nextSelectionEnd).toBe(plainTextValue.length)
   })
+
+  it.each([
+    {
+      name: 'before a mention start',
+      value: 'Hi @[Walter White](user:walter)!',
+      plainTextValue: 'Hi \u65B0Walter White!',
+      selectionStartBefore: 'Hi '.length,
+      selectionEndBefore: 'Hi '.length,
+      selectionEndAfter: 'Hi \u65B0'.length,
+      trackedSelectionEnd: 'Hi '.length,
+      insertedText: '\u65B0',
+      expectedValue: 'Hi \u65B0@[Walter White](user:walter)!',
+      expectedPlainText: 'Hi \u65B0Walter White!',
+      expectedSelection: 'Hi \u65B0'.length,
+      shouldRestoreSelection: false,
+      expectedMentionCount: 1,
+    },
+    {
+      name: 'after a mention end',
+      value: 'Hi @[Walter White](user:walter)!',
+      plainTextValue: 'Hi Walter White\u65B0!',
+      selectionStartBefore: 'Hi Walter White'.length,
+      selectionEndBefore: 'Hi Walter White'.length,
+      selectionEndAfter: 'Hi Walter White\u65B0'.length,
+      trackedSelectionEnd: 'Hi Walter White'.length,
+      insertedText: '\u65B0',
+      expectedValue: 'Hi @[Walter White](user:walter)\u65B0!',
+      expectedPlainText: 'Hi Walter White\u65B0!',
+      expectedSelection: 'Hi Walter White\u65B0'.length,
+      shouldRestoreSelection: false,
+      expectedMentionCount: 1,
+    },
+    {
+      name: 'inside mention display text',
+      value: 'Hi @[Walter White](user:walter)!',
+      plainTextValue: 'Hi Wa\u65B0lter White!',
+      selectionStartBefore: 'Hi Wa'.length,
+      selectionEndBefore: 'Hi Wa'.length,
+      selectionEndAfter: 'Hi Wa\u65B0'.length,
+      trackedSelectionEnd: 'Hi Wa'.length,
+      insertedText: '\u65B0',
+      expectedValue: 'Hi \u65B0!',
+      expectedPlainText: 'Hi \u65B0!',
+      expectedSelection: 'Hi \u65B0'.length,
+      shouldRestoreSelection: true,
+      expectedMentionCount: 0,
+    },
+    {
+      name: 'near an existing mention with decomposed text',
+      value: 'Hi @[Walter White](user:walter) cafe',
+      plainTextValue: 'Hi Walter White cafe\u0301',
+      selectionStartBefore: 'Hi Walter White cafe'.length,
+      selectionEndBefore: 'Hi Walter White cafe'.length,
+      selectionEndAfter: 'Hi Walter White cafe\u0301'.length,
+      trackedSelectionEnd: 'Hi Walter White cafe'.length,
+      insertedText: '\u0301',
+      expectedValue: 'Hi @[Walter White](user:walter) cafe\u0301',
+      expectedPlainText: 'Hi Walter White cafe\u0301',
+      expectedSelection: 'Hi Walter White cafe\u0301'.length,
+      shouldRestoreSelection: false,
+      expectedMentionCount: 1,
+    },
+  ])(
+    'applies composition input at mention boundaries: $name',
+    ({
+      value,
+      plainTextValue,
+      selectionStartBefore,
+      selectionEndBefore,
+      selectionEndAfter,
+      trackedSelectionEnd,
+      insertedText,
+      expectedValue,
+      expectedPlainText,
+      expectedSelection,
+      shouldRestoreSelection,
+      expectedMentionCount,
+    }) => {
+      const result = applyInputChangeToMentionsValue(
+        value,
+        plainTextValue,
+        config,
+        selectionStartBefore,
+        selectionEndBefore,
+        selectionEndAfter,
+        trackedSelectionEnd,
+        insertedText
+      )
+
+      expect(result.value).toBe(expectedValue)
+      expect(result.snapshot.plainText).toBe(expectedPlainText)
+      expect(result.snapshot.mentions).toHaveLength(expectedMentionCount)
+      expect(result.shouldRestoreSelection).toBe(shouldRestoreSelection)
+      expect(result.nextSelectionStart).toBe(expectedSelection)
+      expect(result.nextSelectionEnd).toBe(expectedSelection)
+    }
+  )
 })

--- a/src/useMentionsEditing.ts
+++ b/src/useMentionsEditing.ts
@@ -51,6 +51,11 @@ interface UseMentionsEditingArgs<Extra extends Record<string, unknown>> {
   requestHighlighterScrollSync: () => void
 }
 
+interface SelectionRange {
+  start: number
+  end: number
+}
+
 const getMentionDiffKey = <Extra extends Record<string, unknown>>(
   mention: MentionOccurrence<Extra>
 ): string => JSON.stringify([mention.childIndex, String(mention.id), mention.display])
@@ -91,6 +96,7 @@ export const useMentionsEditing = <Extra extends Record<string, unknown>>(
 
   const suggestionsMouseDownRef = useRef(false)
   const isComposingRef = useRef(false)
+  const compositionSelectionRef = useRef<SelectionRange | null>(null)
 
   const emitOnRemoveCallbacks = useEventCallback(
     (
@@ -347,26 +353,40 @@ export const useMentionsEditing = <Extra extends Record<string, unknown>>(
       requestHighlighterScrollSync,
     } = argsRef.current
     const native = event.nativeEvent
+    const wasComposing = isComposingRef.current
     if ('isComposing' in native && typeof native.isComposing === 'boolean') {
       isComposingRef.current = native.isComposing
     }
     const value = props.value ?? ''
     const newPlainTextValue = event.target.value
 
-    let selectionStartBefore = stateRef.current.selectionStart
+    const nativeEvent = event.nativeEvent as unknown as ReactCompositionEvent<InputElement> & {
+      data?: string | null
+      inputType?: string
+      isComposing?: boolean
+    }
+    const isCompositionInput =
+      wasComposing ||
+      nativeEvent.isComposing === true ||
+      nativeEvent.inputType === 'insertCompositionText'
+    const compositionSelection = isCompositionInput ? compositionSelectionRef.current : null
+    const trackedSelectionEnd = compositionSelection?.end ?? stateRef.current.selectionEnd
+
+    let selectionStartBefore = compositionSelection?.start ?? stateRef.current.selectionStart
     if (selectionStartBefore === null) {
       selectionStartBefore = event.target.selectionStart ?? 0
     }
 
-    let selectionEndBefore = stateRef.current.selectionEnd
+    let selectionEndBefore = compositionSelection?.end ?? stateRef.current.selectionEnd
     if (selectionEndBefore === null) {
       selectionEndBefore = event.target.selectionEnd ?? selectionStartBefore
     }
 
-    const nativeEvent = event.nativeEvent as unknown as ReactCompositionEvent<InputElement> & {
-      data?: string | null
-      isComposing?: boolean
-    }
+    const selectionEndAfter = event.target.selectionEnd ?? selectionEndBefore
+    const insertedText =
+      typeof nativeEvent.data === 'string'
+        ? nativeEvent.data
+        : newPlainTextValue.slice(selectionStartBefore, selectionEndAfter)
     const config = getCurrentConfig()
     const previousSnapshot = getCurrentSnapshot(value, config)
     const inputChangeResult = applyInputChangeToMentionsValue<Extra>(
@@ -375,11 +395,31 @@ export const useMentionsEditing = <Extra extends Record<string, unknown>>(
       config,
       selectionStartBefore,
       selectionEndBefore,
-      event.target.selectionEnd ?? selectionEndBefore,
-      stateRef.current.selectionEnd,
-      nativeEvent.data
+      selectionEndAfter,
+      trackedSelectionEnd,
+      insertedText
     )
     cacheSnapshot(inputChangeResult.value, config, inputChangeResult.snapshot)
+
+    if (isCompositionInput) {
+      compositionSelectionRef.current = {
+        start:
+          insertedText.length > 0
+            ? Math.max(0, inputChangeResult.nextSelectionStart - insertedText.length)
+            : selectionStartBefore,
+        end: inputChangeResult.nextSelectionEnd,
+      }
+
+      if (
+        inputChangeResult.shouldRestoreSelection &&
+        typeof event.target.setSelectionRange === 'function'
+      ) {
+        event.target.setSelectionRange(
+          inputChangeResult.nextSelectionStart,
+          inputChangeResult.nextSelectionEnd
+        )
+      }
+    }
 
     setState((prevState) => ({
       selectionStart: inputChangeResult.nextSelectionStart,
@@ -488,12 +528,25 @@ export const useMentionsEditing = <Extra extends Record<string, unknown>>(
     suggestionsMouseDownRef.current = true
   })
 
-  const handleCompositionStart = useEventCallback((): void => {
-    isComposingRef.current = true
-  })
+  const handleCompositionStart = useEventCallback(
+    (event?: ReactCompositionEvent<InputElement>): void => {
+      const input = event?.currentTarget ?? argsRef.current.inputElementRef.current
+      const selectionStart =
+        input?.selectionStart ?? argsRef.current.stateRef.current.selectionStart ?? 0
+      const selectionEnd =
+        input?.selectionEnd ?? argsRef.current.stateRef.current.selectionEnd ?? selectionStart
+
+      compositionSelectionRef.current = {
+        start: selectionStart,
+        end: selectionEnd,
+      }
+      isComposingRef.current = true
+    }
+  )
 
   const handleCompositionEnd = useEventCallback((): void => {
     isComposingRef.current = false
+    compositionSelectionRef.current = null
   })
 
   const clearSuggestions = useEventCallback((): void => {

--- a/tests/browser/MentionsInput.browser.test.tsx
+++ b/tests/browser/MentionsInput.browser.test.tsx
@@ -54,6 +54,23 @@ interface ControlledMentionsFixtureProps {
   readonly initialValue?: string
 }
 
+interface CompositionInputChange {
+  readonly data: string
+  readonly nextPlainTextValue: string
+  readonly selectionEndAfter: number
+  readonly selectionStartBefore: number
+}
+
+interface CompositionBoundaryCase extends CompositionInputChange {
+  readonly expectedMarkupValue: string
+  readonly expectedMentionId?: string
+  readonly expectedPlainTextValue: string
+  readonly expectedSelectionStart: number
+  readonly expectedTriggerType: string
+  readonly initialValue: string
+  readonly name: string
+}
+
 interface LastChangeState {
   readonly triggerType: string
   readonly plainTextValue: string
@@ -167,6 +184,23 @@ const dispatchComposingInput = (input: HTMLTextAreaElement, data: string): void 
       isComposing: true,
     })
   )
+}
+
+const dispatchCompositionInputChange = async (
+  input: HTMLTextAreaElement,
+  { data, nextPlainTextValue, selectionEndAfter, selectionStartBefore }: CompositionInputChange
+): Promise<void> => {
+  input.focus()
+  input.setSelectionRange(selectionStartBefore, selectionStartBefore)
+  dispatchSelect(input)
+
+  await expectSelection(selectionStartBefore)
+
+  input.dispatchEvent(new CompositionEvent('compositionstart', { bubbles: true, data: '' }))
+  setNativeValue(input, nextPlainTextValue)
+  input.setSelectionRange(selectionEndAfter, selectionEndAfter)
+  dispatchComposingInput(input, data)
+  input.dispatchEvent(new CompositionEvent('compositionend', { bubbles: true, data }))
 }
 
 describe('MentionsInput browser caret and IME behavior', () => {
@@ -283,34 +317,90 @@ describe('MentionsInput browser caret and IME behavior', () => {
     await expectSelection('Hello '.length + 'x'.length)
   })
 
-  it('preserves mention markup while composing a dead-key character near a mention', async () => {
-    await renderBrowser(<ControlledMentionsFixture initialValue="Hi @[First entry](first) cafe" />)
+  it.each([
+    {
+      name: 'before a mention start',
+      initialValue: 'Hi @[First entry](first)!',
+      data: '\u65B0',
+      nextPlainTextValue: 'Hi \u65B0First entry!',
+      selectionStartBefore: 'Hi '.length,
+      selectionEndAfter: 'Hi \u65B0'.length,
+      expectedMarkupValue: 'Hi \u65B0@[First entry](first)!',
+      expectedPlainTextValue: 'Hi \u65B0First entry!',
+      expectedSelectionStart: 'Hi \u65B0'.length,
+      expectedTriggerType: 'input',
+    },
+    {
+      name: 'after a mention end',
+      initialValue: 'Hi @[First entry](first)!',
+      data: '\u65B0',
+      nextPlainTextValue: 'Hi First entry\u65B0!',
+      selectionStartBefore: 'Hi First entry'.length,
+      selectionEndAfter: 'Hi First entry\u65B0'.length,
+      expectedMarkupValue: 'Hi @[First entry](first)\u65B0!',
+      expectedPlainTextValue: 'Hi First entry\u65B0!',
+      expectedSelectionStart: 'Hi First entry\u65B0'.length,
+      expectedTriggerType: 'input',
+    },
+    {
+      name: 'inside mention display text',
+      initialValue: 'Hi @[First entry](first)!',
+      data: '\u65B0',
+      nextPlainTextValue: 'Hi Fi\u65B0rst entry!',
+      selectionStartBefore: 'Hi Fi'.length,
+      selectionEndAfter: 'Hi Fi\u65B0'.length,
+      expectedMarkupValue: 'Hi \u65B0!',
+      expectedMentionId: 'first',
+      expectedPlainTextValue: 'Hi \u65B0!',
+      expectedSelectionStart: 'Hi \u65B0'.length,
+      expectedTriggerType: 'mention-remove',
+    },
+    {
+      name: 'near an existing mention with decomposed text',
+      initialValue: 'Hi @[First entry](first) cafe',
+      data: '\u0301',
+      nextPlainTextValue: 'Hi First entry cafe\u0301',
+      selectionStartBefore: 'Hi First entry cafe'.length,
+      selectionEndAfter: 'Hi First entry cafe\u0301'.length,
+      expectedMarkupValue: 'Hi @[First entry](first) cafe\u0301',
+      expectedPlainTextValue: 'Hi First entry cafe\u0301',
+      expectedSelectionStart: 'Hi First entry cafe\u0301'.length,
+      expectedTriggerType: 'input',
+    },
+  ] satisfies CompositionBoundaryCase[])(
+    'applies composition input at mention boundaries: $name',
+    async ({
+      data,
+      expectedMarkupValue,
+      expectedMentionId = '',
+      expectedPlainTextValue,
+      expectedSelectionStart,
+      expectedTriggerType,
+      initialValue,
+      nextPlainTextValue,
+      selectionEndAfter,
+      selectionStartBefore,
+    }) => {
+      await renderBrowser(<ControlledMentionsFixture initialValue={initialValue} />)
 
-    const composer = await getComposer()
-    const basePlainText = 'Hi First entry cafe'
-    const composedPlainText = `${basePlainText}\u0301`
-    composer.focus()
-    composer.setSelectionRange(basePlainText.length, basePlainText.length)
-    dispatchSelect(composer)
+      const composer = await getComposer()
+      await dispatchCompositionInputChange(composer, {
+        data,
+        nextPlainTextValue,
+        selectionEndAfter,
+        selectionStartBefore,
+      })
 
-    await expectSelection(basePlainText.length)
-
-    composer.dispatchEvent(new CompositionEvent('compositionstart', { bubbles: true, data: '' }))
-    setNativeValue(composer, composedPlainText)
-    composer.setSelectionRange(composedPlainText.length, composedPlainText.length)
-    dispatchComposingInput(composer, '\u0301')
-    composer.dispatchEvent(
-      new CompositionEvent('compositionend', { bubbles: true, data: '\u0301' })
-    )
-
-    await expect.element(page.getByTestId('trigger-type')).toHaveTextContent('input')
-    await expect
-      .element(page.getByTestId('markup-value'))
-      .toHaveTextContent('Hi @[First entry](first) cafe\u0301')
-    await expect.element(page.getByTestId('plain-value')).toHaveTextContent(composedPlainText)
-    await expect
-      .element(page.getByRole('combobox', { name: 'Composer' }))
-      .toHaveValue(composedPlainText)
-    await expectSelection(composedPlainText.length)
-  })
+      await expect.element(page.getByTestId('trigger-type')).toHaveTextContent(expectedTriggerType)
+      await expect.element(page.getByTestId('markup-value')).toHaveTextContent(expectedMarkupValue)
+      await expect
+        .element(page.getByTestId('plain-value'))
+        .toHaveTextContent(expectedPlainTextValue)
+      await expect.element(page.getByTestId('mention-id')).toHaveTextContent(expectedMentionId)
+      await expect
+        .element(page.getByRole('combobox', { name: 'Composer' }))
+        .toHaveValue(expectedPlainTextValue)
+      await expectSelection(expectedSelectionStart)
+    }
+  )
 })


### PR DESCRIPTION
new browser matrix exposed a real composition selection bug, so I fixed useMentionsEditing to preserve the pre-composition selection range and restore caret placement when composition removes a mention.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed trailing mention caret position recalculation when mention markup changes.

* **New Features**
  * Enhanced IME (Input Method Editor) and composition support for improved international text input handling.

* **Documentation**
  * Added tree-shaking verification documentation and workflow guide to README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `tree-shake:report` script and fix trailing caret remeasurement and IME composition at mention boundaries
> - Adds a new `tree-shake:report` npm script that builds the package, runs publint, and executes [scripts/tree-shake-report.mjs](https://github.com/hbmartin/react-mentions-ts/pull/207/files#diff-fbbc232649047bc69d225384121283691eb7bfa6aea4a662f01ba7d90c3052f2) to verify `sideEffects:false`, check tarball metrics, and assert that feature markers are correctly included or excluded in Vite-bundled fixtures.
> - Fixes a bug in [src/Highlighter.tsx](https://github.com/hbmartin/react-mentions-ts/pull/207/files#diff-2d8fdc86aaeb8d7adcdd60631f48110e3e6cce38d17b7e31828f5c0088eadcc2) where the trailing caret `measureKey` used value length instead of value content, causing `onCaretPositionChange` to not re-fire when mention markup changed while the overall length stayed the same.
> - Fixes IME composition handling in [src/useMentionsEditing.ts](https://github.com/hbmartin/react-mentions-ts/pull/207/files#diff-63bf779a02261de859b0357c9969bb4217d1df9f29dff97e4ee2ed9be6415416) by tracking selection bounds via a `compositionSelectionRef`, so mentions are correctly preserved or removed at boundaries and the caret is restored when needed.
> - Risk: [src/MentionsInput.tsx](https://github.com/hbmartin/react-mentions-ts/pull/207/files#diff-5324a6e48c1ed3e0637605dab500fd0e512b7917d46884c35cba8e68698b5473) no longer uses `React.forwardRef`; external code relying on a forwarded `MentionsInputHandle` ref will silently stop receiving it at runtime.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f26128e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->