### PR TITLE
Implemented the bundle-size budget CI.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,8 @@ jobs:
         run: pnpm test
       - name: Build package
         run: pnpm build
+      - name: Check bundle size
+        run: pnpm size
       - name: Verify publish artifacts
         run: npm pack
       - name: Verify package exports

--- a/.github/workflows/size-limit.yml
+++ b/.github/workflows/size-limit.yml
@@ -1,0 +1,28 @@
+name: Bundle Size
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+jobs:
+  size-limit:
+    name: Size Limit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v5
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22.x
+          cache: 'pnpm'
+          cache-dependency-path: pnpm-lock.yaml
+      - run: corepack enable
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm size:check

--- a/codemods/react-mentions-to-react-mentions-ts.cjs
+++ b/codemods/react-mentions-to-react-mentions-ts.cjs
@@ -1,0 +1,874 @@
+const REACT_MENTIONS_PACKAGE = 'react-mentions'
+const REACT_MENTIONS_TS_PACKAGE = 'react-mentions-ts'
+
+const COMPONENT_EXPORTS = new Set(['MentionsInput', 'Mention'])
+const HELPER_EXPORTS = new Set(['makeTriggerRegex', 'createMarkupSerializer'])
+const CHANGE_WRAPPER_PARAM = 'change'
+const ADD_WRAPPER_PARAM = 'addition'
+
+const CHANGE_PAYLOAD_FIELDS = [
+  { legacyIndex: 1, payloadName: 'value' },
+  { legacyIndex: 2, payloadName: 'plainTextValue' },
+  { legacyIndex: 3, payloadName: 'mentions' },
+]
+
+const ADD_PAYLOAD_FIELDS = [
+  { legacyIndex: 0, payloadName: 'id' },
+  { legacyIndex: 1, payloadName: 'display' },
+  { legacyIndex: 2, payloadName: 'startPos' },
+  { legacyIndex: 3, payloadName: 'endPos' },
+]
+
+const createState = () => ({
+  mentionInputNames: new Set(),
+  mentionNames: new Set(),
+  namespaceNames: new Set(),
+  helperLocals: new Map(),
+  requiredHelpers: new Map(),
+  hasReactMentionsReference: false,
+  hasReactMentionsImport: false,
+  hasReactMentionsRequire: false,
+})
+
+const isReactMentionsSource = (node) =>
+  node?.value === REACT_MENTIONS_PACKAGE || node?.value === REACT_MENTIONS_TS_PACKAGE
+
+const getStringLiteralValue = (node) => {
+  if (!node) {
+    return null
+  }
+
+  if (node.type === 'Literal' || node.type === 'StringLiteral') {
+    return typeof node.value === 'string' ? node.value : null
+  }
+
+  return null
+}
+
+const setStringLiteralValue = (node, value) => {
+  node.value = value
+  if ('raw' in node) {
+    node.raw = `'${value}'`
+  }
+}
+
+const getJSXAttributeName = (attribute) =>
+  attribute?.type === 'JSXAttribute' && attribute.name?.type === 'JSXIdentifier'
+    ? attribute.name.name
+    : null
+
+const findJSXAttribute = (openingElement, name) =>
+  openingElement.attributes?.find((attribute) => getJSXAttributeName(attribute) === name) ?? null
+
+const removeJSXAttribute = (openingElement, name) => {
+  openingElement.attributes = (openingElement.attributes ?? []).filter(
+    (attribute) => getJSXAttributeName(attribute) !== name
+  )
+}
+
+const upsertJSXAttribute = (openingElement, attribute) => {
+  removeJSXAttribute(openingElement, attribute.name.name)
+  openingElement.attributes = [...(openingElement.attributes ?? []), attribute]
+}
+
+const getJSXExpression = (attribute) => {
+  if (!attribute?.value || attribute.value.type !== 'JSXExpressionContainer') {
+    return null
+  }
+
+  return attribute.value.expression.type === 'JSXEmptyExpression'
+    ? null
+    : attribute.value.expression
+}
+
+const getBooleanAttributeValue = (attribute) => {
+  if (!attribute) {
+    return { kind: 'missing' }
+  }
+
+  if (!attribute.value) {
+    return { kind: 'static', value: true }
+  }
+
+  if (attribute.value.type === 'Literal' || attribute.value.type === 'StringLiteral') {
+    if (attribute.value.value === 'true') {
+      return { kind: 'static', value: true }
+    }
+
+    if (attribute.value.value === 'false') {
+      return { kind: 'static', value: false }
+    }
+  }
+
+  const expression = getJSXExpression(attribute)
+
+  if (!expression) {
+    return { kind: 'dynamic', expression: null }
+  }
+
+  if (expression.type === 'BooleanLiteral') {
+    return { kind: 'static', value: expression.value }
+  }
+
+  if (expression.type === 'Literal' && typeof expression.value === 'boolean') {
+    return { kind: 'static', value: expression.value }
+  }
+
+  return { kind: 'dynamic', expression }
+}
+
+const getStaticStringAttributeValue = (attribute) => {
+  if (!attribute?.value) {
+    return null
+  }
+
+  if (attribute.value.type === 'Literal' || attribute.value.type === 'StringLiteral') {
+    return typeof attribute.value.value === 'string' ? attribute.value.value : null
+  }
+
+  const expression = getJSXExpression(attribute)
+
+  if (expression?.type === 'Literal' || expression?.type === 'StringLiteral') {
+    return typeof expression.value === 'string' ? expression.value : null
+  }
+
+  if (expression?.type === 'TemplateLiteral' && expression.expressions.length === 0) {
+    return expression.quasis[0]?.value.cooked ?? null
+  }
+
+  return null
+}
+
+const getRequireSource = (callExpression) => {
+  if (
+    callExpression?.type !== 'CallExpression' ||
+    callExpression.callee.type !== 'Identifier' ||
+    callExpression.callee.name !== 'require'
+  ) {
+    return null
+  }
+
+  return getStringLiteralValue(callExpression.arguments[0])
+}
+
+const isRequireFromReactMentions = (callExpression) =>
+  getRequireSource(callExpression) === REACT_MENTIONS_PACKAGE ||
+  getRequireSource(callExpression) === REACT_MENTIONS_TS_PACKAGE
+
+const createRequireCall = (j) =>
+  j.callExpression(j.identifier('require'), [j.literal(REACT_MENTIONS_TS_PACKAGE)])
+
+const report = (api, fileInfo, message) => {
+  api.report(`[react-mentions-ts codemod] ${fileInfo.path}: ${message}`)
+}
+
+const collectImportBindings = (declaration, state) => {
+  state.hasReactMentionsReference = true
+  state.hasReactMentionsImport = true
+
+  for (const specifier of declaration.specifiers ?? []) {
+    if (specifier.type === 'ImportNamespaceSpecifier' && specifier.local?.name) {
+      state.namespaceNames.add(specifier.local.name)
+      continue
+    }
+
+    if (specifier.type !== 'ImportSpecifier') {
+      continue
+    }
+
+    const exportedName = specifier.imported?.name ?? specifier.imported?.value
+    const localName = specifier.local?.name ?? exportedName
+
+    if (exportedName === 'MentionsInput') {
+      state.mentionInputNames.add(localName)
+    }
+
+    if (exportedName === 'Mention') {
+      state.mentionNames.add(localName)
+    }
+
+    if (HELPER_EXPORTS.has(exportedName)) {
+      state.helperLocals.set(exportedName, localName)
+    }
+  }
+}
+
+const collectRequireBindings = (declarator, state) => {
+  state.hasReactMentionsReference = true
+  state.hasReactMentionsRequire = true
+
+  if (declarator.id.type === 'Identifier') {
+    state.namespaceNames.add(declarator.id.name)
+    return
+  }
+
+  if (declarator.id.type !== 'ObjectPattern') {
+    return
+  }
+
+  for (const property of declarator.id.properties) {
+    if (property.type !== 'Property' && property.type !== 'ObjectProperty') {
+      continue
+    }
+
+    const exportedName = property.key.name ?? property.key.value
+    const localName = property.value?.name ?? exportedName
+
+    if (exportedName === 'MentionsInput') {
+      state.mentionInputNames.add(localName)
+    }
+
+    if (exportedName === 'Mention') {
+      state.mentionNames.add(localName)
+    }
+
+    if (HELPER_EXPORTS.has(exportedName)) {
+      state.helperLocals.set(exportedName, localName)
+    }
+  }
+}
+
+const rewritePackageReferences = (root, j, state) => {
+  root.find(j.ImportDeclaration).forEach((path) => {
+    if (!isReactMentionsSource(path.value.source)) {
+      return
+    }
+
+    collectImportBindings(path.value, state)
+    setStringLiteralValue(path.value.source, REACT_MENTIONS_TS_PACKAGE)
+  })
+
+  root.find(j.CallExpression).forEach((path) => {
+    if (getRequireSource(path.value) !== REACT_MENTIONS_PACKAGE) {
+      return
+    }
+
+    setStringLiteralValue(path.value.arguments[0], REACT_MENTIONS_TS_PACKAGE)
+
+    const parent = path.parent?.value
+    if (parent?.type === 'VariableDeclarator') {
+      collectRequireBindings(parent, state)
+    } else {
+      state.hasReactMentionsReference = true
+      state.hasReactMentionsRequire = true
+    }
+  })
+}
+
+const getJSXRole = (name, state) => {
+  if (name.type === 'JSXIdentifier') {
+    if (state.mentionInputNames.has(name.name)) {
+      return 'MentionsInput'
+    }
+
+    if (state.mentionNames.has(name.name)) {
+      return 'Mention'
+    }
+
+    return null
+  }
+
+  if (
+    name.type === 'JSXMemberExpression' &&
+    name.object.type === 'JSXIdentifier' &&
+    name.property.type === 'JSXIdentifier' &&
+    state.namespaceNames.has(name.object.name) &&
+    COMPONENT_EXPORTS.has(name.property.name)
+  ) {
+    return name.property.name
+  }
+
+  return null
+}
+
+const nodeContainsIdentifier = (j, node, name) => j(node).find(j.Identifier, { name }).size() > 0
+
+const fileContainsIdentifier = (root, j, name) => root.find(j.Identifier, { name }).size() > 0
+
+const chooseLocalName = (root, j, baseName) => {
+  if (!fileContainsIdentifier(root, j, baseName)) {
+    return baseName
+  }
+
+  const fallback =
+    baseName === 'makeTriggerRegex'
+      ? 'reactMentionsMakeTriggerRegex'
+      : 'reactMentionsCreateMarkupSerializer'
+
+  if (!fileContainsIdentifier(root, j, fallback)) {
+    return fallback
+  }
+
+  let index = 2
+  while (fileContainsIdentifier(root, j, `${fallback}${index}`)) {
+    index += 1
+  }
+
+  return `${fallback}${index}`
+}
+
+const getHelperIdentifier = (root, j, state, exportedName) => {
+  if (!state.helperLocals.has(exportedName)) {
+    const localName = chooseLocalName(root, j, exportedName)
+    state.helperLocals.set(exportedName, localName)
+    state.requiredHelpers.set(exportedName, localName)
+  }
+
+  return j.identifier(state.helperLocals.get(exportedName))
+}
+
+const createImportSpecifier = (j, exportedName, localName) => {
+  const specifier = j.importSpecifier(j.identifier(exportedName))
+
+  if (localName !== exportedName) {
+    specifier.local = j.identifier(localName)
+  }
+
+  return specifier
+}
+
+const createObjectPatternProperty = (j, exportedName, localName) => {
+  const property = j.property('init', j.identifier(exportedName), j.identifier(localName))
+  property.shorthand = exportedName === localName
+  return property
+}
+
+const addHelperImports = (root, j, state) => {
+  if (state.requiredHelpers.size === 0) {
+    return
+  }
+
+  const importDeclarations = root
+    .find(j.ImportDeclaration)
+    .filter((path) => path.value.source.value === REACT_MENTIONS_TS_PACKAGE)
+
+  const importPaths = importDeclarations.paths()
+  const firstImportPath = importPaths.find(
+    (path) =>
+      (path.value.specifiers ?? []).length > 0 &&
+      !(path.value.specifiers ?? []).some(
+        (specifier) => specifier.type === 'ImportNamespaceSpecifier'
+      )
+  )
+
+  if (firstImportPath) {
+    firstImportPath.value.specifiers = firstImportPath.value.specifiers ?? []
+
+    for (const [exportedName, localName] of state.requiredHelpers) {
+      firstImportPath.value.specifiers.push(createImportSpecifier(j, exportedName, localName))
+    }
+
+    return
+  }
+
+  if (importPaths.length > 0) {
+    const helperImport = j.importDeclaration(
+      [...state.requiredHelpers].map(([exportedName, localName]) =>
+        createImportSpecifier(j, exportedName, localName)
+      ),
+      j.literal(REACT_MENTIONS_TS_PACKAGE)
+    )
+    const body = root.get().node.program.body
+    const lastImportIndex = body.reduce(
+      (lastIndex, statement, index) => (statement.type === 'ImportDeclaration' ? index : lastIndex),
+      -1
+    )
+
+    body.splice(lastImportIndex + 1, 0, helperImport)
+    return
+  }
+
+  const requireDeclarators = root
+    .find(j.VariableDeclarator)
+    .filter((path) => isRequireFromReactMentions(path.value.init))
+
+  const objectPatternRequirePath = requireDeclarators
+    .paths()
+    .find((path) => path.value.id.type === 'ObjectPattern')
+
+  if (objectPatternRequirePath) {
+    objectPatternRequirePath.value.id.properties =
+      objectPatternRequirePath.value.id.properties ?? []
+
+    for (const [exportedName, localName] of state.requiredHelpers) {
+      objectPatternRequirePath.value.id.properties.push(
+        createObjectPatternProperty(j, exportedName, localName)
+      )
+    }
+
+    return
+  }
+
+  const helperPattern = j.objectPattern(
+    [...state.requiredHelpers].map(([exportedName, localName]) =>
+      createObjectPatternProperty(j, exportedName, localName)
+    )
+  )
+
+  const helperDeclaration = j.variableDeclaration('const', [
+    j.variableDeclarator(helperPattern, createRequireCall(j)),
+  ])
+
+  const body = root.get().node.program.body
+  const insertIndex = body.reduce((lastIndex, statement, index) => {
+    if (statement.type === 'ImportDeclaration') {
+      return index
+    }
+
+    if (
+      statement.type === 'VariableDeclaration' &&
+      statement.declarations.some((declaration) => isRequireFromReactMentions(declaration.init))
+    ) {
+      return index
+    }
+
+    return lastIndex
+  }, -1)
+
+  body.splice(insertIndex + 1, 0, helperDeclaration)
+}
+
+const createPayloadProperty = (j, payloadName, localName) => {
+  const property = j.property('init', j.identifier(payloadName), j.identifier(localName))
+  property.shorthand = payloadName === localName
+  return property
+}
+
+const getIdentifierParam = (param) => (param?.type === 'Identifier' ? param : null)
+
+const prependEventAlias = (j, body, eventName, triggerName) => {
+  const eventAlias = j.variableDeclaration('const', [
+    j.variableDeclarator(
+      j.identifier(eventName),
+      j.memberExpression(j.identifier(triggerName), j.identifier('nativeEvent'))
+    ),
+  ])
+
+  body.body.unshift(eventAlias)
+}
+
+const ensureBlockBody = (j, functionNode) => {
+  if (functionNode.body.type === 'BlockStatement') {
+    return functionNode.body
+  }
+
+  const expression = functionNode.body
+  functionNode.body = j.blockStatement([j.returnStatement(expression)])
+  functionNode.expression = false
+
+  return functionNode.body
+}
+
+const convertInlineFunction = ({ j, functionNode, payloadFields, eventParamIndex = null }) => {
+  if (
+    functionNode.params.some(
+      (param) => param.type !== 'Identifier' && param.type !== 'AssignmentPattern'
+    )
+  ) {
+    return false
+  }
+
+  const body = functionNode.body
+  const properties = []
+  let eventAlias = null
+  let triggerLocalName = null
+
+  if (eventParamIndex !== null) {
+    const eventParam = getIdentifierParam(functionNode.params[eventParamIndex])
+    if (eventParam && nodeContainsIdentifier(j, body, eventParam.name)) {
+      eventAlias = eventParam.name
+      triggerLocalName = nodeContainsIdentifier(j, body, 'trigger') ? 'changeTrigger' : 'trigger'
+      properties.push(createPayloadProperty(j, 'trigger', triggerLocalName))
+    }
+  }
+
+  for (const { legacyIndex, payloadName } of payloadFields) {
+    const param = getIdentifierParam(functionNode.params[legacyIndex])
+    if (param) {
+      properties.push(createPayloadProperty(j, payloadName, param.name))
+    }
+  }
+
+  functionNode.params = properties.length === 0 ? [] : [j.objectPattern(properties)]
+
+  if (eventAlias && triggerLocalName) {
+    prependEventAlias(j, ensureBlockBody(j, functionNode), eventAlias, triggerLocalName)
+  }
+
+  return true
+}
+
+const createWrapperParam = (j, root, expression, baseName) => {
+  let localName = baseName
+
+  if (nodeContainsIdentifier(j, expression, localName)) {
+    localName = `legacy${baseName[0].toUpperCase()}${baseName.slice(1)}`
+  }
+
+  if (fileContainsIdentifier(root, j, localName)) {
+    let index = 2
+    while (fileContainsIdentifier(root, j, `${localName}${index}`)) {
+      index += 1
+    }
+
+    localName = `${localName}${index}`
+  }
+
+  return j.identifier(localName)
+}
+
+const createLegacyChangeWrapper = (j, root, handlerExpression) => {
+  const param = createWrapperParam(j, root, handlerExpression, CHANGE_WRAPPER_PARAM)
+  const paramName = param.name
+
+  return j.arrowFunctionExpression(
+    [param],
+    j.callExpression(handlerExpression, [
+      j.memberExpression(
+        j.memberExpression(j.identifier(paramName), j.identifier('trigger')),
+        j.identifier('nativeEvent')
+      ),
+      j.memberExpression(j.identifier(paramName), j.identifier('value')),
+      j.memberExpression(j.identifier(paramName), j.identifier('plainTextValue')),
+      j.memberExpression(j.identifier(paramName), j.identifier('mentions')),
+    ])
+  )
+}
+
+const createLegacyAddWrapper = (j, root, handlerExpression) => {
+  const param = createWrapperParam(j, root, handlerExpression, ADD_WRAPPER_PARAM)
+  const paramName = param.name
+
+  return j.arrowFunctionExpression(
+    [param],
+    j.callExpression(handlerExpression, [
+      j.memberExpression(j.identifier(paramName), j.identifier('id')),
+      j.memberExpression(j.identifier(paramName), j.identifier('display')),
+      j.memberExpression(j.identifier(paramName), j.identifier('startPos')),
+      j.memberExpression(j.identifier(paramName), j.identifier('endPos')),
+    ])
+  )
+}
+
+const isWrappableExpression = (expression) =>
+  expression?.type === 'Identifier' ||
+  expression?.type === 'MemberExpression' ||
+  expression?.type === 'OptionalMemberExpression'
+
+const migrateCallbackAttribute = ({
+  api,
+  fileInfo,
+  j,
+  root,
+  attribute,
+  nextName,
+  payloadFields,
+  eventParamIndex = null,
+  createWrapper,
+}) => {
+  attribute.name.name = nextName
+
+  const expression = getJSXExpression(attribute)
+  if (!expression) {
+    report(api, fileInfo, `Could not inspect ${nextName}; verify its callback signature manually.`)
+    return
+  }
+
+  if (expression.type === 'ArrowFunctionExpression' || expression.type === 'FunctionExpression') {
+    const converted = convertInlineFunction({
+      j,
+      functionNode: expression,
+      payloadFields,
+      eventParamIndex,
+    })
+
+    if (!converted) {
+      report(
+        api,
+        fileInfo,
+        `Could not rewrite ${nextName}; verify its callback signature manually.`
+      )
+    }
+
+    return
+  }
+
+  if (isWrappableExpression(expression)) {
+    attribute.value = j.jsxExpressionContainer(createWrapper(j, root, expression))
+    return
+  }
+
+  report(api, fileInfo, `Could not rewrite ${nextName}; verify its callback signature manually.`)
+}
+
+const migrateSuggestionPlacement = (api, fileInfo, j, openingElement) => {
+  if (findJSXAttribute(openingElement, 'suggestionsPlacement')) {
+    removeJSXAttribute(openingElement, 'allowSuggestionsAboveCursor')
+    removeJSXAttribute(openingElement, 'forceSuggestionsAboveCursor')
+    return
+  }
+
+  const allowAttribute = findJSXAttribute(openingElement, 'allowSuggestionsAboveCursor')
+  const forceAttribute = findJSXAttribute(openingElement, 'forceSuggestionsAboveCursor')
+  const allowValue = getBooleanAttributeValue(allowAttribute)
+  const forceValue = getBooleanAttributeValue(forceAttribute)
+
+  removeJSXAttribute(openingElement, 'allowSuggestionsAboveCursor')
+  removeJSXAttribute(openingElement, 'forceSuggestionsAboveCursor')
+
+  if (forceValue.kind === 'static' && forceValue.value === true) {
+    upsertJSXAttribute(
+      openingElement,
+      j.jsxAttribute(j.jsxIdentifier('suggestionsPlacement'), j.literal('above'))
+    )
+    return
+  }
+
+  if (allowValue.kind === 'static' && allowValue.value === true) {
+    upsertJSXAttribute(
+      openingElement,
+      j.jsxAttribute(j.jsxIdentifier('suggestionsPlacement'), j.literal('auto'))
+    )
+    return
+  }
+
+  const dynamicForce = forceValue.kind === 'dynamic' ? forceValue.expression : null
+  const dynamicAllow = allowValue.kind === 'dynamic' ? allowValue.expression : null
+
+  if (dynamicForce || dynamicAllow) {
+    report(
+      api,
+      fileInfo,
+      'Converted dynamic suggestion placement props; verify the resulting suggestionsPlacement behavior.'
+    )
+
+    const below = j.literal('below')
+    const auto = j.literal('auto')
+    const above = j.literal('above')
+    const expression = dynamicForce
+      ? j.conditionalExpression(
+          dynamicForce,
+          above,
+          dynamicAllow ? j.conditionalExpression(dynamicAllow, auto, below) : below
+        )
+      : j.conditionalExpression(dynamicAllow, auto, below)
+
+    upsertJSXAttribute(
+      openingElement,
+      j.jsxAttribute(j.jsxIdentifier('suggestionsPlacement'), j.jsxExpressionContainer(expression))
+    )
+  }
+}
+
+const createTriggerOptions = (j, options) =>
+  j.objectExpression(
+    Object.entries(options)
+      .filter(([, value]) => value === true)
+      .map(([key]) => {
+        const property = j.property('init', j.identifier(key), j.literal(true))
+        property.shorthand = false
+        return property
+      })
+  )
+
+const createMakeTriggerRegexCall = (root, j, state, triggerValue, options) =>
+  j.callExpression(getHelperIdentifier(root, j, state, 'makeTriggerRegex'), [
+    j.literal(triggerValue),
+    createTriggerOptions(j, options),
+  ])
+
+const migrateMentionTrigger = ({ api, fileInfo, j, root, state, openingElement, options }) => {
+  const triggerAttribute = findJSXAttribute(openingElement, 'trigger')
+  const triggerValue = triggerAttribute ? getStaticStringAttributeValue(triggerAttribute) : '@'
+
+  if (triggerValue === null) {
+    report(
+      api,
+      fileInfo,
+      'Could not move allowSpaceInQuery/ignoreAccents onto a dynamic Mention trigger; verify this Mention manually.'
+    )
+    return
+  }
+
+  const nextTriggerAttribute = j.jsxAttribute(
+    j.jsxIdentifier('trigger'),
+    j.jsxExpressionContainer(createMakeTriggerRegexCall(root, j, state, triggerValue, options))
+  )
+
+  upsertJSXAttribute(openingElement, nextTriggerAttribute)
+}
+
+const visitMentionChildren = (element, state, callback) => {
+  for (const child of element.children ?? []) {
+    if (child.type !== 'JSXElement') {
+      continue
+    }
+
+    if (getJSXRole(child.openingElement.name, state) === 'Mention') {
+      callback(child)
+    }
+
+    visitMentionChildren(child, state, callback)
+  }
+}
+
+const migrateQueryOptions = ({ api, fileInfo, j, root, state, element, openingElement }) => {
+  const allowAttribute = findJSXAttribute(openingElement, 'allowSpaceInQuery')
+  const ignoreAttribute = findJSXAttribute(openingElement, 'ignoreAccents')
+  const allowValue = getBooleanAttributeValue(allowAttribute)
+  const ignoreValue = getBooleanAttributeValue(ignoreAttribute)
+
+  removeJSXAttribute(openingElement, 'allowSpaceInQuery')
+  removeJSXAttribute(openingElement, 'ignoreAccents')
+
+  if (allowValue.kind === 'dynamic' || ignoreValue.kind === 'dynamic') {
+    report(
+      api,
+      fileInfo,
+      'Removed dynamic allowSpaceInQuery/ignoreAccents props; move equivalent trigger regex options manually.'
+    )
+    return
+  }
+
+  const options = {
+    allowSpaceInQuery: allowValue.kind === 'static' && allowValue.value === true,
+    ignoreAccents: ignoreValue.kind === 'static' && ignoreValue.value === true,
+  }
+
+  if (!options.allowSpaceInQuery && !options.ignoreAccents) {
+    return
+  }
+
+  visitMentionChildren(element, state, (mentionElement) => {
+    migrateMentionTrigger({
+      api,
+      fileInfo,
+      j,
+      root,
+      state,
+      openingElement: mentionElement.openingElement,
+      options,
+    })
+  })
+}
+
+const isStaticMarkupAttribute = (attribute) => getStaticStringAttributeValue(attribute) !== null
+
+const migrateRegexAttribute = ({ api, fileInfo, j, root, state, openingElement }) => {
+  const regexAttribute = findJSXAttribute(openingElement, 'regex')
+  if (!regexAttribute) {
+    return
+  }
+
+  const markupAttribute = findJSXAttribute(openingElement, 'markup')
+  if (!isStaticMarkupAttribute(markupAttribute)) {
+    report(
+      api,
+      fileInfo,
+      'Mention regex prop requires manual migration because markup is missing or dynamic.'
+    )
+    return
+  }
+
+  const markup = getStaticStringAttributeValue(markupAttribute)
+  removeJSXAttribute(openingElement, 'regex')
+
+  markupAttribute.value = j.jsxExpressionContainer(
+    j.callExpression(getHelperIdentifier(root, j, state, 'createMarkupSerializer'), [
+      j.literal(markup),
+    ])
+  )
+}
+
+const inspectAsyncDataProvider = (api, fileInfo, openingElement) => {
+  const dataAttribute = findJSXAttribute(openingElement, 'data')
+  const expression = getJSXExpression(dataAttribute)
+
+  if (
+    (expression?.type === 'ArrowFunctionExpression' || expression?.type === 'FunctionExpression') &&
+    expression.params.length >= 2
+  ) {
+    report(
+      api,
+      fileInfo,
+      'Mention data provider still appears to use callback-style async results; migrate it to return an array or promise.'
+    )
+  }
+}
+
+const migrateMentionsInputElement = ({ api, fileInfo, j, root, state, element }) => {
+  const openingElement = element.openingElement
+  const onChangeAttribute = findJSXAttribute(openingElement, 'onChange')
+  if (onChangeAttribute) {
+    migrateCallbackAttribute({
+      api,
+      fileInfo,
+      j,
+      root,
+      attribute: onChangeAttribute,
+      nextName: 'onMentionsChange',
+      payloadFields: CHANGE_PAYLOAD_FIELDS,
+      eventParamIndex: 0,
+      createWrapper: createLegacyChangeWrapper,
+    })
+  }
+
+  const onBlurAttribute = findJSXAttribute(openingElement, 'onBlur')
+  if (onBlurAttribute) {
+    onBlurAttribute.name.name = 'onMentionBlur'
+  }
+
+  migrateSuggestionPlacement(api, fileInfo, j, openingElement)
+  migrateQueryOptions({ api, fileInfo, j, root, state, element, openingElement })
+}
+
+const migrateMentionElement = ({ api, fileInfo, j, root, state, element }) => {
+  const openingElement = element.openingElement
+  const onAddAttribute = findJSXAttribute(openingElement, 'onAdd')
+
+  if (onAddAttribute) {
+    migrateCallbackAttribute({
+      api,
+      fileInfo,
+      j,
+      root,
+      attribute: onAddAttribute,
+      nextName: 'onAdd',
+      payloadFields: ADD_PAYLOAD_FIELDS,
+      createWrapper: createLegacyAddWrapper,
+    })
+  }
+
+  migrateRegexAttribute({ api, fileInfo, j, root, state, openingElement })
+  inspectAsyncDataProvider(api, fileInfo, openingElement)
+}
+
+module.exports = function transform(fileInfo, api) {
+  const j = api.jscodeshift
+  const root = j(fileInfo.source)
+  const state = createState()
+
+  rewritePackageReferences(root, j, state)
+
+  if (!state.hasReactMentionsReference) {
+    return fileInfo.source
+  }
+
+  root.find(j.JSXElement).forEach((path) => {
+    const role = getJSXRole(path.value.openingElement.name, state)
+
+    if (role === 'MentionsInput') {
+      migrateMentionsInputElement({ api, fileInfo, j, root, state, element: path.value })
+    }
+
+    if (role === 'Mention') {
+      migrateMentionElement({ api, fileInfo, j, root, state, element: path.value })
+    }
+  })
+
+  addHelperImports(root, j, state)
+
+  return root.toSource({ quote: 'single', lineTerminator: '\n' })
+}
+
+module.exports.parser = 'tsx'

--- a/package.json
+++ b/package.json
@@ -42,9 +42,11 @@
     "lint:rule-counts": "oxlint src --format json | jq '[.diagnostics[].code] | group_by(.) | map({ rule: .[0], count: length }) | sort_by(-.count)'",
     "lint:all-rules": "node ./scripts/write-oxlint-all-rules.mjs",
     "publint": "npx publint --pack npm",
+    "size": "size-limit",
+    "size:check": "pnpm build && pnpm size",
     "tree-shake:report": "pnpm build && npx publint --pack npm && node ./scripts/tree-shake-report.mjs",
     "types:lint": "npm_config_cache=.npm-cache attw --pack .",
-    "ci:verify": "pnpm lint && pnpm typecheck && pnpm build && npx publint --pack npm && pnpm types:lint",
+    "ci:verify": "pnpm lint && pnpm typecheck && pnpm build && pnpm size && npx publint --pack npm && pnpm types:lint",
     "dev": "node ./scripts/dev-with-wdyr.mjs",
     "demo": "vite --config demo/vite.config.ts",
     "preview": "vite preview --config demo/vite.config.ts",
@@ -58,6 +60,20 @@
     "knip": "knip --strict",
     "fta": "fta src"
   },
+  "size-limit": [
+    {
+      "name": "esm",
+      "path": "dist/index.js",
+      "limit": "30 kB",
+      "gzip": true
+    },
+    {
+      "name": "cjs",
+      "path": "dist/index.cjs",
+      "limit": "30 kB",
+      "gzip": true
+    }
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/hbmartin/react-mentions-ts.git"
@@ -100,6 +116,7 @@
     "@eslint/eslintrc": "^3.3.5",
     "@eslint/js": "^10.0.1",
     "@microsoft/api-extractor": "^7.58.6",
+    "@size-limit/file": "12.1.0",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
@@ -145,6 +162,7 @@
     "react": "19.2.5",
     "react-dom": "19.2.5",
     "rimraf": "^6.1.3",
+    "size-limit": "12.1.0",
     "tailwind-merge": "^3.5.0",
     "ts-node": "^10.9.2",
     "tsdown": "^0.21.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@microsoft/api-extractor':
         specifier: ^7.58.6
         version: 7.58.6(@types/node@24.12.2)
+      '@size-limit/file':
+        specifier: 12.1.0
+        version: 12.1.0(size-limit@12.1.0(jiti@2.6.1))
       '@testing-library/dom':
         specifier: ^10.4.1
         version: 10.4.1
@@ -158,6 +161,9 @@ importers:
       rimraf:
         specifier: ^6.1.3
         version: 6.1.3
+      size-limit:
+        specifier: 12.1.0
+        version: 12.1.0(jiti@2.6.1)
       tailwind-merge:
         specifier: ^3.5.0
         version: 3.5.0
@@ -1441,6 +1447,12 @@ packages:
     resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
     engines: {node: '>=10'}
 
+  '@size-limit/file@12.1.0':
+    resolution: {integrity: sha512-eGwDcIufnNnvJRzv3liDOn6MAOGgmOTUdpeGQ2KuRTlgIgO54AJH1ilvktlJc6PIjNfwpYY0dOGyap1QgM1swQ==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    peerDependencies:
+      size-limit: 12.1.0
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -1968,6 +1980,10 @@ packages:
   builtin-modules@5.1.0:
     resolution: {integrity: sha512-c5JxaDrzwRjq3WyJkI1AGR5xy6Gr6udlt7sQPbl09+3ckB+Zo2qqQ2KhCTBr7Q8dHB43bENGYEk4xddrFH/b7A==}
     engines: {node: '>=18.20'}
+
+  bytes-iec@3.1.1:
+    resolution: {integrity: sha512-fey6+4jDK7TFtFg/klGSvNKJctyU7n2aQdnM+CO0ruLPbqqMOM8Tio0Pc+deqUeVKX1tL5DQep1zQ7+37aTAsA==}
+    engines: {node: '>= 0.8'}
 
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
@@ -3048,6 +3064,10 @@ packages:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
+  lilconfig@3.1.3:
+    resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
+    engines: {node: '>=14'}
+
   locate-path@3.0.0:
     resolution: {integrity: sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==}
     engines: {node: '>=6'}
@@ -3156,6 +3176,9 @@ packages:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+
+  nanospinner@1.2.2:
+    resolution: {integrity: sha512-Zt/AmG6qRU3e+WnzGGLuMCEAO/dAu45stNbHY223tUxldaDAeE+FxSPsd9Q+j+paejmm0ZbrNVs5Sraqy3dRxA==}
 
   napi-postinstall@0.3.4:
     resolution: {integrity: sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==}
@@ -3592,6 +3615,16 @@ packages:
   sirv@3.0.2:
     resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
     engines: {node: '>=18'}
+
+  size-limit@12.1.0:
+    resolution: {integrity: sha512-VnDS2fycANrJFVPQwjaD+h+hkISY7EB3LsPsYWje4lBCjQwwsZLxjwwRwVJKHrcj2ZqyG+DdXykWm9mbZklZrw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      jiti: ^2.0.0
+    peerDependenciesMeta:
+      jiti:
+        optional: true
 
   skin-tone@2.0.0:
     resolution: {integrity: sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==}
@@ -5142,6 +5175,10 @@ snapshots:
 
   '@sindresorhus/is@4.6.0': {}
 
+  '@size-limit/file@12.1.0(size-limit@12.1.0(jiti@2.6.1))':
+    dependencies:
+      size-limit: 12.1.0(jiti@2.6.1)
+
   '@standard-schema/spec@1.1.0': {}
 
   '@testing-library/dom@10.4.1':
@@ -5701,6 +5738,8 @@ snapshots:
   builtin-modules@3.3.0: {}
 
   builtin-modules@5.1.0: {}
+
+  bytes-iec@3.1.1: {}
 
   bytes@3.1.2: {}
 
@@ -6926,6 +6965,8 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
+  lilconfig@3.1.3: {}
+
   locate-path@3.0.0:
     dependencies:
       p-locate: 3.0.0
@@ -7025,6 +7066,10 @@ snapshots:
       thenify-all: 1.6.0
 
   nanoid@3.3.11: {}
+
+  nanospinner@1.2.2:
+    dependencies:
+      picocolors: 1.1.1
 
   napi-postinstall@0.3.4: {}
 
@@ -7582,6 +7627,16 @@ snapshots:
       '@polka/url': 1.0.0-next.29
       mrmime: 2.0.1
       totalist: 3.0.1
+
+  size-limit@12.1.0(jiti@2.6.1):
+    dependencies:
+      bytes-iec: 3.1.1
+      lilconfig: 3.1.3
+      nanospinner: 1.2.2
+      picocolors: 1.1.1
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      jiti: 2.6.1
 
   skin-tone@2.0.0:
     dependencies:

--- a/scripts/tree-shake-report.mjs
+++ b/scripts/tree-shake-report.mjs
@@ -4,6 +4,7 @@ import { execFileSync } from 'node:child_process'
 import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
 import { build } from 'vite'
 
 const root = process.cwd()
@@ -119,18 +120,19 @@ const main = async () => {
 
   const packReport = readPackReport()
   const tmp = await mkdtemp(join(tmpdir(), 'react-mentions-ts-tree-shake-'))
+  const distEntrySpecifier = pathToFileURL(distEntry).href
   const fixtures = [
     {
       name: 'mention-utility-only',
       description: 'Mention + utility only',
-      source: `import { Mention, getSubstringIndex } from ${JSON.stringify(distEntry)}
+      source: `import { Mention, getSubstringIndex } from ${JSON.stringify(distEntrySpecifier)}
 console.log(Mention, getSubstringIndex('abc', 'b', 0))
 `,
     },
     {
       name: 'mentions-input',
       description: 'MentionsInput shell',
-      source: `import { Mention, MentionsInput } from ${JSON.stringify(distEntry)}
+      source: `import { Mention, MentionsInput } from ${JSON.stringify(distEntrySpecifier)}
 console.log(Mention, MentionsInput)
 `,
     },

--- a/src/Highlighter.tsx
+++ b/src/Highlighter.tsx
@@ -370,7 +370,7 @@ function Highlighter<Extra extends Record<string, unknown> = Record<string, unkn
       <HighlighterCaret
         className={caretClass}
         key="caret:trailing-mention"
-        measureKey={`trailing:${value}`}
+        measureKey={value}
         onCaretPositionChange={onCaretPositionChange}
         recomputeVersion={recomputeVersion}
         singleLine={singleLine}

--- a/src/useMentionsEditing.ts
+++ b/src/useMentionsEditing.ts
@@ -56,6 +56,12 @@ interface SelectionRange {
   end: number
 }
 
+interface NativeInputEvent {
+  data?: string | null
+  inputType?: string
+  isComposing?: boolean
+}
+
 const getMentionDiffKey = <Extra extends Record<string, unknown>>(
   mention: MentionOccurrence<Extra>
 ): string => JSON.stringify([mention.childIndex, String(mention.id), mention.display])
@@ -352,19 +358,14 @@ export const useMentionsEditing = <Extra extends Record<string, unknown>>(
       clearSuggestions,
       requestHighlighterScrollSync,
     } = argsRef.current
-    const native = event.nativeEvent
+    const nativeEvent = event.nativeEvent as NativeInputEvent
     const wasComposing = isComposingRef.current
-    if ('isComposing' in native && typeof native.isComposing === 'boolean') {
-      isComposingRef.current = native.isComposing
+    if (typeof nativeEvent.isComposing === 'boolean') {
+      isComposingRef.current = nativeEvent.isComposing
     }
     const value = props.value ?? ''
     const newPlainTextValue = event.target.value
 
-    const nativeEvent = event.nativeEvent as unknown as ReactCompositionEvent<InputElement> & {
-      data?: string | null
-      inputType?: string
-      isComposing?: boolean
-    }
     const isCompositionInput =
       wasComposing ||
       nativeEvent.isComposing === true ||


### PR DESCRIPTION
src/useMentionsEditing.ts (line 56): added a narrow NativeInputEvent shape and removed the incorrect ReactCompositionEvent cast in the change handler.
scripts/tree-shake-report.mjs (line 7): switched generated fixture imports to a file:// specifier via pathToFileURL.
src/Highlighter.tsx (line 373): changed trailing mention caret measureKey to use value directly.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add bundle-size budget CI using size-limit
> - Adds a new GitHub Actions workflow ([size-limit.yml](.github/workflows/size-limit.yml)) that runs `pnpm size:check` on PRs and pushes to master, failing if either bundle exceeds 30 kB (gzip).
> - Adds `size` and `size:check` scripts to [package.json](https://github.com/hbmartin/react-mentions-ts/pull/208/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) and integrates the check into `ci:verify`; the Release workflow also runs `pnpm size` before publishing.
> - Fixes fixture imports in [scripts/tree-shake-report.mjs](https://github.com/hbmartin/react-mentions-ts/pull/208/files#diff-fbbc232649047bc69d225384121283691eb7bfa6aea4a662f01ba7d90c3052f2) to use `file://` URLs for more reliable module resolution during the Vite build.
> - Behavioral Change: `ci:verify` now fails if the ESM (`dist/index.js`) or CJS (`dist/index.cjs`) bundle exceeds the 30 kB limit.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized d9b5a65. 6 files reviewed, 5 issues evaluated, 3 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>codemods/react-mentions-to-react-mentions-ts.cjs — 1 comment posted, 5 evaluated, 3 filtered</summary>
>
> - [line 215](https://github.com/hbmartin/react-mentions-ts/blob/d9b5a65a2be78367afd24e7022c453e1f7e31aff/codemods/react-mentions-to-react-mentions-ts.cjs#L215): When destructuring with both a rename and a default value (e.g., `const { MentionsInput: MI = null } = require('react-mentions')`), `property.value` is an `AssignmentPattern` node which lacks a `.name` property. Line 215 falls back to `exportedName` instead of extracting the actual local binding from `property.value.left.name`, causing the codemod to track the wrong identifier and miss JSX elements using the renamed component. <b>[ Out of scope (triage) ]</b>
> - [line 556](https://github.com/hbmartin/react-mentions-ts/blob/d9b5a65a2be78367afd24e7022c453e1f7e31aff/codemods/react-mentions-to-react-mentions-ts.cjs#L556): Including `OptionalMemberExpression` in `isWrappableExpression` can cause behavioral changes. For input like `onChange={obj?.handler}`, the original passes `undefined` to React (which doesn't call it) if `obj` is nullish. After transformation to `(change) => obj?.handler(...)`, React always receives a function and calls it. If `obj` exists but `handler` is undefined, the wrapper will throw `TypeError` when attempting to call `undefined(...)`. The safer approach would be to exclude `OptionalMemberExpression` and let it fall through to the manual verification report. <b>[ Out of scope (triage) ]</b>
> - [line 703](https://github.com/hbmartin/react-mentions-ts/blob/d9b5a65a2be78367afd24e7022c453e1f7e31aff/codemods/react-mentions-to-react-mentions-ts.cjs#L703): `visitMentionChildren` skips `JSXFragment` elements because the check `child.type !== 'JSXElement'` causes fragments to be skipped via `continue`. If a `Mention` component is nested inside a JSX fragment within the `MentionsInput`, it won't be visited and won't receive the migrated `allowSpaceInQuery`/`ignoreAccents` options on its trigger. For example, `<MentionsInput><><Mention /></></MentionsInput>` would not have the `Mention` processed by the callback. <b>[ Out of scope (triage) ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added migration tool for upgrading to TypeScript-oriented API.

* **Chores**
  * Enforced bundle size limits at 30 kB (gzip) via automated quality checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->