### PR TITLE
Changed codemods/react-mentions-to-react-mentions-ts.cjs (line 242) s…

### DIFF
--- a/codemods/react-mentions-to-react-mentions-ts.cjs
+++ b/codemods/react-mentions-to-react-mentions-ts.cjs
@@ -239,7 +239,7 @@ const rewritePackageReferences = (root, j, state) => {
   })
 
   root.find(j.CallExpression).forEach((path) => {
-    if (getRequireSource(path.value) !== REACT_MENTIONS_PACKAGE) {
+    if (!isRequireFromReactMentions(path.value)) {
       return
     }
 

--- a/src/MentionsInput.spec.tsx
+++ b/src/MentionsInput.spec.tsx
@@ -385,6 +385,16 @@ describe('MentionsInput', () => {
     expect(textarea.tagName).toBe('TEXTAREA')
   })
 
+  it('defaults to an empty input value when value is omitted.', () => {
+    render(
+      <MentionsInput>
+        <Mention trigger="@" data={data} />
+      </MentionsInput>
+    )
+
+    expect(screen.getByRole('combobox')).toHaveValue('')
+  })
+
   it('should disable spell checking on the textarea by default.', () => {
     render(
       <MentionsInput value="">
@@ -421,6 +431,36 @@ describe('MentionsInput', () => {
 
     const textarea = screen.getByDisplayValue('')
     expect(textarea).toHaveAttribute('spellcheck', 'true')
+  })
+
+  it('omits editing handlers when the input is read-only or disabled.', () => {
+    const onChange = vi.fn()
+    const onMentionsChange = vi.fn()
+    const { rerender } = render(
+      <MentionsInput value="fixed" readOnly onChange={onChange} onMentionsChange={onMentionsChange}>
+        <Mention trigger="@" data={data} />
+      </MentionsInput>
+    )
+
+    const readOnlyInput = screen.getByRole('combobox')
+    fireEvent.change(readOnlyInput, { target: { value: 'changed' } })
+
+    expect(readOnlyInput).toHaveAttribute('readonly')
+    expect(onChange).not.toHaveBeenCalled()
+    expect(onMentionsChange).not.toHaveBeenCalled()
+
+    rerender(
+      <MentionsInput value="fixed" disabled onChange={onChange} onMentionsChange={onMentionsChange}>
+        <Mention trigger="@" data={data} />
+      </MentionsInput>
+    )
+
+    const disabledInput = screen.getByRole('combobox')
+    fireEvent.change(disabledInput, { target: { value: 'changed' } })
+
+    expect(disabledInput).toBeDisabled()
+    expect(onChange).not.toHaveBeenCalled()
+    expect(onMentionsChange).not.toHaveBeenCalled()
   })
 
   it('should render a regular input when singleLine is set to true.', () => {
@@ -681,6 +721,20 @@ describe('MentionsInput', () => {
     })
 
     fireEvent.keyDown(textarea, { key: 'a' })
+
+    expect(onKeyDown).toHaveBeenCalledTimes(1)
+  })
+
+  it('passes through handled overlay keys while suggestions are closed.', () => {
+    const onKeyDown = vi.fn()
+    render(
+      <MentionsInput value="plain" onKeyDown={onKeyDown}>
+        <Mention trigger="@" data={data} />
+      </MentionsInput>
+    )
+
+    const textarea = screen.getByRole('combobox')
+    fireEvent.keyDown(textarea, { key: 'Enter', keyCode: 13 })
 
     expect(onKeyDown).toHaveBeenCalledTimes(1)
   })
@@ -3723,6 +3777,19 @@ describe('MentionsInput', () => {
       expect(combobox).not.toHaveAttribute('aria-describedby')
     })
 
+    it('passes inline keydown through when no inline suggestion is available', async () => {
+      const onKeyDown = vi.fn()
+      const combobox = renderInlineMentionsInput({ onKeyDown }, '@zz')
+
+      await waitFor(() => {
+        expect(screen.getByRole('status')).toHaveTextContent('No inline suggestions available')
+      })
+
+      fireEvent.keyDown(combobox, { key: 'ArrowRight', keyCode: 39 })
+
+      expect(onKeyDown).toHaveBeenCalledTimes(1)
+    })
+
     it('keeps inline completion visible while the next async query loads.', async () => {
       interface DeferredResult {
         resolve: (value: Array<{ id: string; display: string }>) => void
@@ -3809,6 +3876,57 @@ describe('MentionsInput', () => {
       expect(payload.mentions).toHaveLength(1)
       expect(payload.mentions[0]).toMatchObject({ id: 'alice' })
       expect(payload.mentionId).toBe('alice')
+      expect(payload.trigger.type).toBe('mention-add')
+    })
+
+    it('passes Shift+Tab through instead of accepting the inline suggestion', async () => {
+      const onKeyDown = vi.fn()
+      const onMentionsChange = vi.fn()
+      const textbox = renderInlineMentionsInput({ onKeyDown, onMentionsChange })
+
+      await waitFor(() => {
+        expect(screen.getByText('ce')).toBeInTheDocument()
+      })
+
+      fireEvent.keyDown(textbox, { key: 'Tab', keyCode: 9, shiftKey: true })
+
+      expect(onKeyDown).toHaveBeenCalledTimes(1)
+      expect(onMentionsChange).not.toHaveBeenCalled()
+      expect(textbox).toHaveValue('@ali')
+    })
+
+    it('passes default inline keys through while an inline suggestion is available', async () => {
+      const onKeyDown = vi.fn()
+      const textbox = renderInlineMentionsInput({ onKeyDown })
+
+      await waitFor(() => {
+        expect(screen.getByText('ce')).toBeInTheDocument()
+      })
+
+      fireEvent.keyDown(textbox, { key: 'a', keyCode: 65 })
+
+      expect(onKeyDown).toHaveBeenCalledTimes(1)
+    })
+
+    it.each([
+      ['Enter', 13],
+      ['ArrowRight', 39],
+    ])('can accept the inline suggestion with %s', async (key, keyCode) => {
+      const onMentionsChange = vi.fn()
+      const textbox = renderInlineMentionsInput({ onMentionsChange })
+
+      await waitFor(() => {
+        expect(screen.getByText('ce')).toBeInTheDocument()
+      })
+
+      fireEvent.keyDown(textbox, { key, keyCode })
+
+      await waitFor(() => {
+        expect(onMentionsChange).toHaveBeenCalled()
+      })
+
+      const payload = getLastMentionsChange(onMentionsChange)
+      expect(payload.value).toBe('@[Alice](alice)')
       expect(payload.trigger.type).toBe('mention-add')
     })
 

--- a/src/MentionsInputQueryState.spec.ts
+++ b/src/MentionsInputQueryState.spec.ts
@@ -235,6 +235,46 @@ describe('MentionsInputQueryState', () => {
     expect(nextState.queryStates[0]?.pagination?.isLoading).toBe(true)
   })
 
+  it('ignores page lifecycle updates before pagination exists for the current query', () => {
+    const suggestions = {
+      0: {
+        queryInfo,
+        results: [{ id: 'first', display: 'First' }],
+      },
+    }
+    const queryStates = {
+      0: {
+        queryInfo,
+        results: [{ id: 'first', display: 'First' }],
+        status: 'success' as const,
+        ignoreAccents: false,
+      },
+    }
+    const page = {
+      items: [{ id: 'stale', display: 'Stale' }],
+      nextCursor: null,
+      hasMore: false,
+      paginated: true,
+    }
+    const error = new Error('stale')
+
+    expect(applyLoadingPageResult(suggestions, queryStates, 0, 2)).toEqual({
+      suggestions,
+      queryStates,
+      focusIndex: 2,
+    })
+    expect(applySuccessfulPageResult(suggestions, queryStates, 0, queryInfo, page, 2)).toEqual({
+      suggestions,
+      queryStates,
+      focusIndex: 2,
+    })
+    expect(applyErroredPageResult(suggestions, queryStates, 0, error, 2)).toEqual({
+      suggestions,
+      queryStates,
+      focusIndex: 2,
+    })
+  })
+
   it('appends page results and records the next cursor', () => {
     const nextState = applySuccessfulPageResult(
       {
@@ -277,6 +317,82 @@ describe('MentionsInputQueryState', () => {
       hasMore: false,
       isLoading: false,
     })
+  })
+
+  it('starts paginated page results from an empty suggestion bucket when needed', () => {
+    const nextState = applySuccessfulPageResult(
+      {},
+      {
+        0: {
+          queryInfo,
+          results: [],
+          status: 'success',
+          ignoreAccents: false,
+          pagination: {
+            nextCursor: 'cursor-2',
+            hasMore: true,
+            isLoading: true,
+          },
+        },
+      },
+      0,
+      queryInfo,
+      {
+        items: [{ id: 'first', display: 'First' }],
+        nextCursor: null,
+        hasMore: false,
+        paginated: true,
+      },
+      0
+    )
+
+    expect(nextState.suggestions[0]?.results).toEqual([{ id: 'first', display: 'First' }])
+    expect(nextState.focusIndex).toBe(0)
+  })
+
+  it('defaults failed query metadata when no current query state exists', () => {
+    const nextState = applyErroredQueryResult(
+      {
+        1: {
+          queryInfo: { ...queryInfo, childIndex: 1 },
+          results: [{ id: 'preserved', display: 'Preserved' }],
+        },
+      },
+      {},
+      0,
+      queryInfo,
+      new Error('boom'),
+      0
+    )
+
+    expect(nextState.suggestions[1]?.results).toHaveLength(1)
+    expect(nextState.focusIndex).toBe(0)
+    expect(nextState.queryStates[0]?.ignoreAccents).toBe(false)
+  })
+
+  it('defaults failed query accent metadata when the current query state omits it', () => {
+    const nextState = applyErroredQueryResult(
+      {
+        0: {
+          queryInfo,
+          results: [{ id: 'first', display: 'First' }],
+        },
+      },
+      {
+        0: {
+          queryInfo,
+          results: [],
+          status: 'loading',
+        },
+      },
+      0,
+      queryInfo,
+      new Error('boom'),
+      0
+    )
+
+    expect(nextState.suggestions[0]).toBeUndefined()
+    expect(nextState.queryStates[0]?.ignoreAccents).toBe(false)
   })
 
   it('ignores page lifecycle updates after query state has been cleared', () => {

--- a/src/codemods/reactMentionsMigrationCodemod.spec.ts
+++ b/src/codemods/reactMentionsMigrationCodemod.spec.ts
@@ -137,6 +137,41 @@ describe('react-mentions-to-react-mentions-ts codemod', () => {
     expect(output).toContain('allowSpaceInQuery: true')
   })
 
+  it('collects existing react-mentions-ts CommonJS bindings before migrating JSX', () => {
+    const { output, reports } = applyCodemod(`
+      const { MentionsInput, Mention } = require('react-mentions-ts')
+      const ReactMentions = require('react-mentions-ts')
+
+      exports.Destructured = function Destructured({ users }) {
+        return (
+          <MentionsInput value="" allowSpaceInQuery>
+            <Mention data={users} />
+          </MentionsInput>
+        )
+      }
+
+      exports.Namespaced = function Namespaced({ users }) {
+        return (
+          <ReactMentions.MentionsInput value="" ignoreAccents>
+            <ReactMentions.Mention trigger="#" data={users} />
+          </ReactMentions.MentionsInput>
+        )
+      }
+    `)
+
+    const compactOutput = output.replaceAll(/\s+/g, ' ')
+
+    expect(reports).toEqual([])
+    expect(compactOutput).toContain(
+      "const { MentionsInput, Mention, makeTriggerRegex } = require('react-mentions-ts')"
+    )
+    expect(output).toContain("const ReactMentions = require('react-mentions-ts')")
+    expect(output).toContain("trigger={makeTriggerRegex('@', {")
+    expect(output).toContain("trigger={makeTriggerRegex('#', {")
+    expect(output).toContain('allowSpaceInQuery: true')
+    expect(output).toContain('ignoreAccents: true')
+  })
+
   it('adds a separate helper import for namespace ESM imports', () => {
     const { output, reports } = applyCodemod(`
       import * as ReactMentions from 'react-mentions'

--- a/src/useMentionValueSnapshot.spec.tsx
+++ b/src/useMentionValueSnapshot.spec.tsx
@@ -1,0 +1,109 @@
+import React from 'react'
+import { act, render } from '@testing-library/react'
+import { Mention } from './index'
+import type { MentionValueSnapshot } from './MentionsInputDerived'
+import type { MentionsInputProps } from './types'
+import { useMentionValueSnapshot } from './useMentionValueSnapshot'
+
+type SnapshotApi = ReturnType<typeof useMentionValueSnapshot>
+
+interface SnapshotHarnessProps {
+  readonly children: MentionsInputProps['children']
+  readonly value?: string
+  readonly onApi: (api: SnapshotApi) => void
+}
+
+function SnapshotHarness({ children, value, onApi }: SnapshotHarnessProps) {
+  const api = useMentionValueSnapshot(children, value)
+  onApi(api)
+  return null
+}
+
+const userMention = <Mention trigger="@" data={[]} />
+const tagMention = <Mention trigger="#" data={[]} />
+
+const renderSnapshotHarness = ({
+  children = userMention,
+  value,
+}: {
+  readonly children?: MentionsInputProps['children']
+  readonly value?: string
+} = {}) => {
+  let currentApi: SnapshotApi | null = null
+  const onApi = (api: SnapshotApi) => {
+    currentApi = api
+  }
+  const view = render(
+    <SnapshotHarness value={value} onApi={onApi}>
+      {children}
+    </SnapshotHarness>
+  )
+  const getApi = (): SnapshotApi => {
+    if (currentApi === null) {
+      throw new Error('Snapshot harness did not render')
+    }
+    return currentApi
+  }
+
+  return { ...view, getApi, onApi }
+}
+
+describe('useMentionValueSnapshot', () => {
+  it('uses cached snapshots when the value and mention config still match', () => {
+    const cachedSnapshot: MentionValueSnapshot = {
+      plainText: 'cached plain text',
+      idValue: 'cached id value',
+      mentions: [],
+    }
+    const { getApi, rerender, onApi } = renderSnapshotHarness({ value: 'seed' })
+
+    act(() => {
+      getApi().cacheSnapshot('', getApi().getCurrentConfig(), cachedSnapshot)
+    })
+
+    rerender(
+      <SnapshotHarness value={undefined} onApi={onApi}>
+        {userMention}
+      </SnapshotHarness>
+    )
+
+    expect(getApi().currentSnapshot).toBe(cachedSnapshot)
+    expect(getApi().getCurrentSnapshot()).toBe(cachedSnapshot)
+  })
+
+  it('prepares replacement children and derives snapshots for uncached values or configs', () => {
+    const { getApi } = renderSnapshotHarness({ value: '@[Ada](1)' })
+
+    expect(getApi().getPreparedChildren()).toBe(getApi().preparedChildren)
+
+    const replacementChildren = getApi().getPreparedChildren(tagMention)
+    expect(replacementChildren).not.toBe(getApi().preparedChildren)
+    expect(replacementChildren.config[0]?.trigger).toBe('#')
+
+    const uncachedByValue = getApi().getCurrentSnapshot('@[Grace](2)')
+    expect(uncachedByValue.plainText).toBe('Grace')
+    expect(uncachedByValue.idValue).toBe('2')
+
+    const uncachedByConfig = getApi().getCurrentSnapshot('@[Ada](1)', replacementChildren.config)
+    expect(uncachedByConfig.plainText).toBe('@[Ada](1)')
+    expect(uncachedByConfig.mentions).toEqual([])
+  })
+
+  it('returns a cached snapshot only when both requested value and config match', () => {
+    const cachedSnapshot: MentionValueSnapshot = {
+      plainText: 'cached',
+      idValue: 'cached',
+      mentions: [],
+    }
+    const { getApi } = renderSnapshotHarness({ value: '@[Ada](1)' })
+    const currentConfig = getApi().getCurrentConfig()
+    const replacementConfig = getApi().getPreparedChildren(tagMention).config
+
+    act(() => {
+      getApi().cacheSnapshot('@[Grace](2)', currentConfig, cachedSnapshot)
+    })
+
+    expect(getApi().getCurrentSnapshot('@[Grace](2)', currentConfig)).toBe(cachedSnapshot)
+    expect(getApi().getCurrentSnapshot('@[Grace](2)', replacementConfig)).not.toBe(cachedSnapshot)
+  })
+})


### PR DESCRIPTION
…o CommonJS handling uses isRequireFromReactMentions, which catches both react-mentions and existing react-mentions-ts requires.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace direct string comparison with `isRequireFromReactMentions` in react-mentions codemod
> - Replaces `getRequireSource(path.value) !== REACT_MENTIONS_PACKAGE` with `!isRequireFromReactMentions(path.value)` in [react-mentions-to-react-mentions-ts.cjs](https://github.com/hbmartin/react-mentions-ts/pull/209/files#diff-325dc4fc2f74d52c84675a49833188220328e45ff04c4471edfb7f1eb02825c7) to standardize how require calls are identified during CallExpression traversal.
> - Adds tests across `MentionsInput`, `MentionsInputQueryState`, `reactMentionsMigrationCodemod`, and `useMentionValueSnapshot` covering inline suggestions keyboard behavior, paginated query state edge cases, CommonJS binding collection before JSX migration, and snapshot caching logic.
> - Behavioral Change: the set of nodes considered as react-mentions require calls may differ if `isRequireFromReactMentions` applies different matching logic than the prior string comparison.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d577b4d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->