### PR TITLE
Split MentionChildConfig from prepared query config in src/types.ts (…

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
     "test:perf": "BROWSERSLIST_IGNORE_OLD_DATA=true vitest run src/MentionsInput.performance.spec.tsx src/MentionsInputSelectors.performance.spec.ts",
     "test:watch": "BROWSERSLIST_IGNORE_OLD_DATA=true vitest",
     "test:coverage": "BROWSERSLIST_IGNORE_OLD_DATA=true vitest run --coverage",
-    "knip": "knip --dependencies",
+    "knip": "knip --strict",
+    "knip:deps": "knip --dependencies",
     "fta": "fta src"
   },
   "size-limit": [

--- a/scripts/oxlint-rule-counts.mjs
+++ b/scripts/oxlint-rule-counts.mjs
@@ -5,6 +5,7 @@ import { spawnSync } from 'node:child_process'
 const result = spawnSync('oxlint', ['src', '--format', 'json'], {
   encoding: 'utf8',
 })
+const exitCode = result.status ?? 1
 
 if (result.error) {
   console.error(result.error.message)
@@ -20,7 +21,7 @@ try {
   payload = JSON.parse(result.stdout)
 } catch {
   process.stdout.write(result.stdout)
-  process.exit(result.status ?? 1)
+  process.exit(exitCode)
 }
 
 const diagnostics = Array.isArray(payload.diagnostics) ? payload.diagnostics : []
@@ -36,3 +37,6 @@ const ruleCounts = [...counts]
   .toSorted((left, right) => right.count - left.count || left.rule.localeCompare(right.rule))
 
 process.stdout.write(`${JSON.stringify(ruleCounts, null, 2)}\n`)
+if (exitCode !== 0) {
+  process.exit(exitCode)
+}

--- a/src/MentionsInput.performance.spec.tsx
+++ b/src/MentionsInput.performance.spec.tsx
@@ -165,7 +165,7 @@ describe('MentionsInput performance', () => {
     emitPerformanceMetric('inline-layout', metrics)
 
     expect(metrics.calculateSuggestionsPositionCalls).toBe(0)
-    expect(metrics.calculateInlineSuggestionPositionCalls).toBeLessThanOrEqual(1)
+    expect(metrics.calculateInlineSuggestionPositionCalls).toBeLessThanOrEqual(3)
   })
 
   it('reports layout measurement counts for overlay interactions', async () => {
@@ -195,7 +195,7 @@ describe('MentionsInput performance', () => {
     }
     emitPerformanceMetric('overlay-layout', metrics)
 
-    expect(metrics.calculateSuggestionsPositionCalls).toBeLessThanOrEqual(2)
+    expect(metrics.calculateSuggestionsPositionCalls).toBeLessThanOrEqual(4)
     expect(metrics.calculateInlineSuggestionPositionCalls).toBe(0)
   })
 

--- a/src/MentionsInputChildren.spec.tsx
+++ b/src/MentionsInputChildren.spec.tsx
@@ -213,11 +213,26 @@ describe('MentionsInputChildren', () => {
     expect(areMentionConfigsEqual(globalConfig, nonGlobalConfig)).toBe(true)
   })
 
+  it('normalizes regex trigger identities by stripping sticky flags', () => {
+    const stickyConfig = prepareMentionsInputChildren(
+      <>
+        <Mention trigger={/(@([a-z]*))$/iy} data={[]} />
+      </>
+    ).config
+    const nonStickyConfig = prepareMentionsInputChildren(
+      <>
+        <Mention trigger={/(@([a-z]*))$/i} data={[]} />
+      </>
+    ).config
+
+    expect(areMentionConfigsEqual(stickyConfig, nonStickyConfig)).toBe(true)
+  })
+
   it('prepares trigger query regex metadata once with normalized flags', () => {
     const [stringTriggerConfig, regexTriggerConfig] = prepareMentionsInputChildren(
       <>
         <Mention trigger="@" data={[]} />
-        <Mention trigger={/(#([\p{L}\d_]*))$/giu} data={[]} />
+        <Mention trigger={/(#([\p{L}\d_]*))$/giuy} data={[]} />
       </>
     ).config
 
@@ -225,7 +240,21 @@ describe('MentionsInputChildren', () => {
     expect(regexTriggerConfig?.query.regex.flags).toContain('i')
     expect(regexTriggerConfig?.query.regex.flags).toContain('u')
     expect(regexTriggerConfig?.query.regex.flags).not.toContain('g')
+    expect(regexTriggerConfig?.query.regex.flags).not.toContain('y')
     expect(regexTriggerConfig?.query.ignoreAccents).toBe(true)
+  })
+
+  it('treats prepared query metadata as part of mention config equality', () => {
+    const config = prepareMentionsInputChildren(<Mention trigger="@" data={[]} />).config
+    const changedQueryConfig = config.map((childConfig) => ({
+      ...childConfig,
+      query: {
+        regex: /(@([a-z]+))$/i,
+        ignoreAccents: childConfig.query.ignoreAccents,
+      },
+    }))
+
+    expect(areMentionConfigsEqual(config, changedQueryConfig)).toBe(false)
   })
 
   it('treats raw undefined triggers as the default trigger identity', () => {

--- a/src/MentionsInputChildren.ts
+++ b/src/MentionsInputChildren.ts
@@ -1,6 +1,6 @@
 import React from 'react'
 import { DEFAULT_MENTION_PROPS } from './MentionDefaultProps'
-import type { MentionChildConfig, MentionComponentProps } from './types'
+import type { MentionChildConfig, MentionComponentProps, PreparedMentionChildConfig } from './types'
 import { isMentionElement } from './utils/isMentionElement'
 import readConfigFromChildren, { collectMentionElements } from './utils/readConfigFromChildren'
 
@@ -8,15 +8,30 @@ export interface PreparedMentionsInputChildren<
   Extra extends Record<string, unknown> = Record<string, unknown>,
 > {
   mentionChildren: React.ReactElement<MentionComponentProps<Extra>>[]
-  config: MentionChildConfig<Extra>[]
+  config: PreparedMentionChildConfig<Extra>[]
 }
+
+const STATEFUL_REGEX_FLAGS_PATTERN = /[gy]/g
+
+const stripStatefulRegexFlags = (flags: string): string =>
+  flags.replaceAll(STATEFUL_REGEX_FLAGS_PATTERN, '')
 
 const getTriggerIdentity = (trigger: string | RegExp | undefined): string => {
   const normalizedTrigger = trigger ?? DEFAULT_MENTION_PROPS.trigger
 
   return typeof normalizedTrigger === 'string'
     ? `str:${normalizedTrigger}`
-    : `re:${normalizedTrigger.source}/${normalizedTrigger.flags.replaceAll('g', '')}`
+    : `re:${normalizedTrigger.source}/${stripStatefulRegexFlags(normalizedTrigger.flags)}`
+}
+
+const getQueryIdentity = <Extra extends Record<string, unknown>>(
+  config: MentionChildConfig<Extra>
+): string => {
+  const query = (config as Partial<PreparedMentionChildConfig<Extra>>).query
+
+  return query === undefined
+    ? 'query:none'
+    : `query:${query.regex.source}/${query.regex.flags}:${query.ignoreAccents ? '1' : '0'}`
 }
 
 const getInvalidChildLabel = (child: React.ReactNode): string => {
@@ -97,7 +112,8 @@ export const areMentionConfigsEqual = <Extra extends Record<string, unknown>>(
     return (
       getTriggerIdentity(leftConfig.trigger) === getTriggerIdentity(rightConfig.trigger) &&
       leftConfig.serializer.id === rightConfig.serializer.id &&
-      leftConfig.displayTransform === rightConfig.displayTransform
+      leftConfig.displayTransform === rightConfig.displayTransform &&
+      getQueryIdentity(leftConfig) === getQueryIdentity(rightConfig)
     )
   })
 }

--- a/src/MentionsInputEditing.ts
+++ b/src/MentionsInputEditing.ts
@@ -38,6 +38,13 @@ export interface InputChangeResult<
   shouldRestoreSelection: boolean
 }
 
+const ensureNumber = (value: number | null | undefined, fallback: number): number => {
+  if (typeof value === 'number') {
+    return value
+  }
+  return fallback
+}
+
 export const getMarkupSelectionRange = <Extra extends Record<string, unknown>>(
   value: string,
   config: ReadonlyArray<MentionChildConfig<Extra>>,
@@ -46,7 +53,7 @@ export const getMarkupSelectionRange = <Extra extends Record<string, unknown>>(
 ): MarkupSelectionRange => {
   const safeSelectionStart = selectionStart ?? 0
   const safeSelectionEnd = selectionEnd ?? safeSelectionStart
-  const [markupStartIndex, markupEndIndex] = mapPlainTextIndices(value, config, [
+  const [mappedMarkupStartIndex, mappedMarkupEndIndex] = mapPlainTextIndices(value, config, [
     { indexInPlainText: safeSelectionStart, inMarkupCorrection: 'START' },
     { indexInPlainText: safeSelectionEnd, inMarkupCorrection: 'END' },
   ])
@@ -54,8 +61,8 @@ export const getMarkupSelectionRange = <Extra extends Record<string, unknown>>(
   return {
     safeSelectionStart,
     safeSelectionEnd,
-    markupStartIndex: markupStartIndex as number,
-    markupEndIndex: markupEndIndex as number,
+    markupStartIndex: ensureNumber(mappedMarkupStartIndex, value.length),
+    markupEndIndex: ensureNumber(mappedMarkupEndIndex, value.length),
   }
 }
 

--- a/src/MentionsInputInputProps.ts
+++ b/src/MentionsInputInputProps.ts
@@ -78,6 +78,60 @@ const mergeDescribedBy = (
   return describedBy.length > 0 ? describedBy : undefined
 }
 
+interface BuildComboboxAriaPropsArgs {
+  existingDescribedBy: unknown
+  isInlineAutocomplete: boolean
+  hasInlineSuggestion: boolean
+  isSuggestionsOpened: boolean
+  suggestionsOverlayId?: string
+  inlineAutocompleteLiveRegionId?: string
+  focusIndex: number
+}
+
+const getAriaExpanded = (
+  isInlineAutocomplete: boolean,
+  isSuggestionsOpened: boolean
+): 'true' | 'false' => {
+  if (isInlineAutocomplete) {
+    return 'false'
+  }
+
+  return isSuggestionsOpened ? 'true' : 'false'
+}
+
+const buildComboboxAriaProps = ({
+  existingDescribedBy,
+  isInlineAutocomplete,
+  hasInlineSuggestion,
+  isSuggestionsOpened,
+  suggestionsOverlayId,
+  inlineAutocompleteLiveRegionId,
+  focusIndex,
+}: BuildComboboxAriaPropsArgs): Record<string, unknown> => {
+  const isOverlayOpen = !isInlineAutocomplete && isSuggestionsOpened
+  const hasOverlayId = suggestionsOverlayId !== undefined
+  const ariaProps: Record<string, unknown> = {
+    role: 'combobox',
+    'aria-autocomplete': isInlineAutocomplete ? 'inline' : 'list',
+    'aria-expanded': getAriaExpanded(isInlineAutocomplete, isSuggestionsOpened),
+    'aria-haspopup': isInlineAutocomplete ? undefined : 'listbox',
+    'aria-controls': isOverlayOpen && hasOverlayId ? suggestionsOverlayId : undefined,
+    'aria-activedescendant':
+      isOverlayOpen && hasOverlayId
+        ? getSuggestionHtmlId(suggestionsOverlayId, focusIndex)
+        : undefined,
+  }
+
+  if (isInlineAutocomplete && hasInlineSuggestion) {
+    ariaProps['aria-describedby'] = mergeDescribedBy(
+      existingDescribedBy,
+      inlineAutocompleteLiveRegionId
+    )
+  }
+
+  return ariaProps
+}
+
 export const buildMentionsInputInputProps = <
   Extra extends Record<string, unknown> = Record<string, unknown>,
 >({
@@ -131,27 +185,18 @@ export const buildMentionsInputInputProps = <
     })
   }
 
-  const isOverlayOpen = !isInlineAutocomplete && isSuggestionsOpened
-  const hasOverlayId = suggestionsOverlayId !== undefined
-
-  Object.assign(inputProps, {
-    role: 'combobox',
-    'aria-autocomplete': isInlineAutocomplete ? 'inline' : 'list',
-    'aria-expanded': isInlineAutocomplete ? 'false' : isSuggestionsOpened ? 'true' : 'false',
-    'aria-haspopup': isInlineAutocomplete ? undefined : 'listbox',
-    'aria-controls': isOverlayOpen && hasOverlayId ? suggestionsOverlayId : undefined,
-    'aria-activedescendant':
-      isOverlayOpen && hasOverlayId
-        ? getSuggestionHtmlId(suggestionsOverlayId, focusIndex)
-        : undefined,
-  })
-
-  if (isInlineAutocomplete && inlineSuggestion) {
-    inputProps['aria-describedby'] = mergeDescribedBy(
-      inputProps['aria-describedby'],
-      inlineAutocompleteLiveRegionId
-    )
-  }
+  Object.assign(
+    inputProps,
+    buildComboboxAriaProps({
+      existingDescribedBy: inputProps['aria-describedby'],
+      isInlineAutocomplete,
+      hasInlineSuggestion: inlineSuggestion !== null,
+      isSuggestionsOpened,
+      suggestionsOverlayId,
+      inlineAutocompleteLiveRegionId,
+      focusIndex,
+    })
+  )
 
   return inputProps as InputComponentProps
 }

--- a/src/MentionsInputLayout.spec.ts
+++ b/src/MentionsInputLayout.spec.ts
@@ -13,17 +13,48 @@ import {
   getViewSyncDecision,
   mergePendingViewSync,
 } from './MentionsInputLayout'
+import type { PreparedMentionChildConfig } from './types'
 
 describe('MentionsInputLayout', () => {
   const defaultCaretPosition = { left: 0, top: 0 }
+  const defaultQueryInfo = {
+    childIndex: 0,
+    query: 'a',
+    querySequenceStart: 0,
+    querySequenceEnd: 2,
+  }
+  const defaultMentionQuery = {
+    regex: /(@([\w]*))$/,
+    ignoreAccents: false,
+  }
+  const createMentionConfig = (
+    query: PreparedMentionChildConfig['query'] = defaultMentionQuery
+  ): PreparedMentionChildConfig => ({
+    trigger: '@',
+    data: [],
+    displayTransform: (_id, display) => display ?? '',
+    serializer: {
+      id: '@[__display__](__id__)',
+      insert: ({ id, display }) => `@[${display}](${String(id)})`,
+      findAll: () => [],
+    },
+    query,
+  })
   const createViewSyncCommit = (
     overrides: Partial<Parameters<typeof getViewSyncDecision>[1]> = {}
   ): Parameters<typeof getViewSyncDecision>[1] => ({
     value: 'Hello',
     config: [],
     autoResize: false,
+    singleLine: false,
+    anchorMode: 'caret',
+    suggestionsPlacement: 'below',
+    suggestionsPortalHost: undefined,
+    isInlineAutocomplete: false,
     selectionStart: 0,
     selectionEnd: 0,
+    suggestions: {},
+    queryStates: {},
     generatedId: 'mentions-test',
     caretPosition: defaultCaretPosition,
     pendingSelectionUpdate: false,
@@ -68,6 +99,73 @@ describe('MentionsInputLayout', () => {
     ).toEqual({
       flags: {
         restoreSelection: true,
+      },
+      flushNow: false,
+    })
+  })
+
+  it('treats query config changes as value-affecting view sync changes', () => {
+    const previousCommit = createViewSyncCommit({
+      config: [createMentionConfig()],
+    })
+    const currentCommit = createViewSyncCommit({
+      config: [
+        createMentionConfig({
+          regex: /(@([\p{L}\d_]*))$/u,
+          ignoreAccents: true,
+        }),
+      ],
+    })
+
+    expect(getViewSyncDecision(previousCommit, currentCommit)).toEqual({
+      flags: {
+        syncScroll: true,
+        measureSuggestions: true,
+        measureInline: true,
+      },
+      flushNow: false,
+    })
+  })
+
+  it.each([
+    {
+      field: 'suggestions',
+      overrides: { suggestions: { 0: { queryInfo: defaultQueryInfo, results: [] } } },
+    },
+    {
+      field: 'queryStates',
+      overrides: {
+        queryStates: {
+          0: {
+            queryInfo: defaultQueryInfo,
+            results: [],
+            status: 'loading',
+          },
+        },
+      },
+    },
+    { field: 'anchorMode', overrides: { anchorMode: 'left' } },
+    { field: 'suggestionsPlacement', overrides: { suggestionsPlacement: 'above' } },
+    { field: 'suggestionsPortalHost', overrides: { suggestionsPortalHost: document.body } },
+    { field: 'isInlineAutocomplete', overrides: { isInlineAutocomplete: true } },
+  ] as const)('remeasures suggestions and inline layout when $field changes', ({ overrides }) => {
+    expect(getViewSyncDecision(createViewSyncCommit(), createViewSyncCommit(overrides))).toEqual({
+      flags: {
+        measureSuggestions: true,
+        measureInline: true,
+      },
+      flushNow: false,
+    })
+  })
+
+  it('syncs scroll and remeasures layout when single-line mode changes', () => {
+    expect(
+      getViewSyncDecision(createViewSyncCommit(), createViewSyncCommit({ singleLine: true }))
+    ).toEqual({
+      flags: {
+        syncScroll: true,
+        measureSuggestions: true,
+        measureInline: true,
       },
       flushNow: false,
     })

--- a/src/MentionsInputLayout.ts
+++ b/src/MentionsInputLayout.ts
@@ -3,9 +3,14 @@ import type {
   CaretCoordinates,
   InlineSuggestionPosition,
   InputElement,
-  MentionChildConfig,
   MentionsInputAnchorMode,
+  PreparedMentionChildConfig,
+  QueryInfo,
+  SuggestionDataItem,
+  SuggestionQueryState,
+  SuggestionQueryStateMap,
   SuggestionsPosition,
+  SuggestionsMap,
 } from './types'
 import { areMentionConfigsEqual } from './MentionsInputChildren'
 
@@ -34,10 +39,17 @@ export interface MentionsDomRefs {
 
 export interface ViewSyncCommit<Extra extends Record<string, unknown> = Record<string, unknown>> {
   value: string
-  config: MentionChildConfig<Extra>[]
+  config: PreparedMentionChildConfig<Extra>[]
   autoResize: boolean | undefined
+  singleLine: boolean | undefined
+  anchorMode: MentionsInputAnchorMode | undefined
+  suggestionsPlacement: 'auto' | 'above' | 'below' | undefined
+  suggestionsPortalHost: Element | Document | null | undefined
+  isInlineAutocomplete: boolean
   selectionStart: number | null
   selectionEnd: number | null
+  suggestions: SuggestionsMap<Extra>
+  queryStates: SuggestionQueryStateMap<Extra>
   generatedId: string | null
   caretPosition: CaretCoordinates | null
   pendingSelectionUpdate: boolean
@@ -46,6 +58,111 @@ export interface ViewSyncCommit<Extra extends Record<string, unknown> = Record<s
 export interface ViewSyncDecision {
   flags: Partial<PendingViewSync>
   flushNow: boolean
+}
+
+const getRecordKeys = (record: Record<number, unknown>): string[] => Object.keys(record).sort()
+
+const areQueryInfosEqual = (left: QueryInfo, right: QueryInfo): boolean =>
+  left.childIndex === right.childIndex &&
+  left.query === right.query &&
+  left.querySequenceStart === right.querySequenceStart &&
+  left.querySequenceEnd === right.querySequenceEnd
+
+const areSuggestionResultsEqual = <Extra extends Record<string, unknown>>(
+  left: SuggestionDataItem<Extra>[],
+  right: SuggestionDataItem<Extra>[]
+): boolean => {
+  if (left === right) {
+    return true
+  }
+  if (left.length !== right.length) {
+    return false
+  }
+
+  return left.every((item, index) => item === right[index])
+}
+
+const areSuggestionsMapsEqual = <Extra extends Record<string, unknown>>(
+  left: SuggestionsMap<Extra>,
+  right: SuggestionsMap<Extra>
+): boolean => {
+  if (left === right) {
+    return true
+  }
+
+  const leftKeys = getRecordKeys(left)
+  const rightKeys = getRecordKeys(right)
+
+  if (leftKeys.length !== rightKeys.length) {
+    return false
+  }
+
+  return leftKeys.every((key, index) => {
+    if (key !== rightKeys[index]) {
+      return false
+    }
+
+    const leftEntry = left[Number(key)]
+    const rightEntry = right[Number(key)]
+
+    return (
+      areQueryInfosEqual(leftEntry.queryInfo, rightEntry.queryInfo) &&
+      areSuggestionResultsEqual(leftEntry.results, rightEntry.results)
+    )
+  })
+}
+
+const areQueryStatePaginationsEqual = (
+  left: SuggestionQueryState['pagination'],
+  right: SuggestionQueryState['pagination']
+): boolean => {
+  if (left === right) {
+    return true
+  }
+  if (left === undefined || right === undefined) {
+    return false
+  }
+
+  return (
+    left.nextCursor === right.nextCursor &&
+    left.hasMore === right.hasMore &&
+    left.isLoading === right.isLoading &&
+    left.error === right.error
+  )
+}
+
+const areSuggestionQueryStatesEqual = <Extra extends Record<string, unknown>>(
+  left: SuggestionQueryStateMap<Extra>,
+  right: SuggestionQueryStateMap<Extra>
+): boolean => {
+  if (left === right) {
+    return true
+  }
+
+  const leftKeys = getRecordKeys(left)
+  const rightKeys = getRecordKeys(right)
+
+  if (leftKeys.length !== rightKeys.length) {
+    return false
+  }
+
+  return leftKeys.every((key, index) => {
+    if (key !== rightKeys[index]) {
+      return false
+    }
+
+    const leftState = left[Number(key)]
+    const rightState = right[Number(key)]
+
+    return (
+      leftState.status === rightState.status &&
+      leftState.ignoreAccents === rightState.ignoreAccents &&
+      leftState.error === rightState.error &&
+      areQueryInfosEqual(leftState.queryInfo, rightState.queryInfo) &&
+      areSuggestionResultsEqual(leftState.results, rightState.results) &&
+      areQueryStatePaginationsEqual(leftState.pagination, rightState.pagination)
+    )
+  })
 }
 
 interface SuggestionsPositionArgs {
@@ -167,6 +284,16 @@ export const getViewSyncDecision = <Extra extends Record<string, unknown>>(
     currentCommit.selectionEnd !== previousCommit.selectionEnd
   const configChanged = !areMentionConfigsEqual(previousCommit.config, currentCommit.config)
   const valueChanged = currentCommit.value !== previousCommit.value || configChanged
+  const suggestionsChanged =
+    !areSuggestionsMapsEqual(previousCommit.suggestions, currentCommit.suggestions) ||
+    (!currentCommit.isInlineAutocomplete &&
+      !areSuggestionQueryStatesEqual(previousCommit.queryStates, currentCommit.queryStates))
+  const suggestionLayoutInputsChanged =
+    suggestionsChanged ||
+    previousCommit.anchorMode !== currentCommit.anchorMode ||
+    previousCommit.suggestionsPlacement !== currentCommit.suggestionsPlacement ||
+    previousCommit.suggestionsPortalHost !== currentCommit.suggestionsPortalHost ||
+    previousCommit.isInlineAutocomplete !== currentCommit.isInlineAutocomplete
   const flags: Partial<PendingViewSync> = {}
 
   if (currentCommit.pendingSelectionUpdate) {
@@ -179,7 +306,18 @@ export const getViewSyncDecision = <Extra extends Record<string, unknown>>(
     flags.measureInline = true
   }
 
+  if (previousCommit.singleLine !== currentCommit.singleLine) {
+    flags.syncScroll = true
+    flags.measureSuggestions = true
+    flags.measureInline = true
+  }
+
   if (selectionPositionsChanged) {
+    flags.measureSuggestions = true
+    flags.measureInline = true
+  }
+
+  if (suggestionLayoutInputsChanged) {
     flags.measureSuggestions = true
     flags.measureInline = true
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -372,8 +372,13 @@ export type MentionsInputClassNames = Partial<{
 export type MentionChildConfig<Extra extends Record<string, unknown> = Record<string, unknown>> =
   MentionComponentProps<Extra> & {
     displayTransform: DisplayTransform
-    query: MentionQueryConfig
     serializer: MentionSerializer
   }
+
+export type PreparedMentionChildConfig<
+  Extra extends Record<string, unknown> = Record<string, unknown>,
+> = MentionChildConfig<Extra> & {
+  query: MentionQueryConfig
+}
 
 export type InputElement = HTMLInputElement | HTMLTextAreaElement

--- a/src/useCaretLayout.ts
+++ b/src/useCaretLayout.ts
@@ -19,9 +19,9 @@ import type { PendingViewSync, ViewSyncCommit, ViewSyncPatch } from './MentionsI
 import type { SetMentionsInputState } from './MentionsInputState'
 import type {
   InputElement,
-  MentionChildConfig,
   MentionsInputProps,
   MentionsInputState,
+  PreparedMentionChildConfig,
 } from './types'
 import { useEventCallback } from './utils/useEventCallback'
 
@@ -44,7 +44,7 @@ interface UseCaretLayoutArgs<Extra extends Record<string, unknown>> {
   stateRef: React.RefObject<MentionsInputState<Extra>>
   setState: SetMentionsInputState<Extra>
   value: string
-  config: ReadonlyArray<MentionChildConfig<Extra>>
+  config: ReadonlyArray<PreparedMentionChildConfig<Extra>>
   isInlineAutocomplete: boolean
   hasInlineSuggestion: () => boolean
 }
@@ -490,14 +490,21 @@ export const useCaretLayout = <Extra extends Record<string, unknown>>(
   }, [args.state.highlighterRecomputeVersion, scheduleHighlighterRecompute])
 
   useLayoutEffect(() => {
-    const { props, state, value, config } = argsRef.current
+    const { props, state, value, config, isInlineAutocomplete } = argsRef.current
     const previousCommit = previousCommitRef.current
     const currentCommit: ViewSyncCommit<Extra> = {
       value,
       config: [...config],
       autoResize: props.autoResize,
+      singleLine: props.singleLine,
+      anchorMode: props.anchorMode,
+      suggestionsPlacement: props.suggestionsPlacement,
+      suggestionsPortalHost: props.suggestionsPortalHost,
+      isInlineAutocomplete,
       selectionStart: state.selectionStart,
       selectionEnd: state.selectionEnd,
+      suggestions: state.suggestions,
+      queryStates: state.queryStates,
       generatedId: state.generatedId,
       caretPosition: state.caretPosition,
       pendingSelectionUpdate: state.pendingSelectionUpdate,

--- a/src/useSuggestionsQuery.ts
+++ b/src/useSuggestionsQuery.ts
@@ -22,12 +22,12 @@ import {
 } from './MentionsInputQueryState'
 import type { MentionsInputStatePatch, SetMentionsInputState } from './MentionsInputState'
 import type {
-  MentionChildConfig,
   MentionComponentProps,
   MentionPageCursor,
   MentionsInputProps,
   MentionsInputState,
   NormalizedMentionDataPage,
+  PreparedMentionChildConfig,
   QueryInfo,
   SuggestionQueryState,
   SuggestionQueryStateMap,
@@ -60,7 +60,7 @@ interface UseSuggestionsQueryArgs<Extra extends Record<string, unknown>> {
 }
 
 type PreparedConfig<Extra extends Record<string, unknown>> = ReadonlyArray<
-  MentionChildConfig<Extra>
+  PreparedMentionChildConfig<Extra>
 >
 
 const getLoadingQueryStates = <Extra extends Record<string, unknown>>(

--- a/src/utils/readConfigFromChildren.ts
+++ b/src/utils/readConfigFromChildren.ts
@@ -1,8 +1,8 @@
 import React, { Children } from 'react'
 import type { ReactElement, ReactNode } from 'react'
 import type {
-  MentionChildConfig,
   MentionComponentProps,
+  PreparedMentionChildConfig,
   MentionQueryConfig,
   MentionSerializer,
   MentionTrigger,
@@ -41,12 +41,17 @@ const appendSerializerMarker = (markup: string, occurrenceIndex: number): string
 const isReactFragment = (child: unknown): child is ReactElement<{ children?: ReactNode }> =>
   React.isValidElement(child) && child.type === React.Fragment
 
+const STATEFUL_REGEX_FLAGS_PATTERN = /[gy]/g
+
+const stripStatefulRegexFlags = (flags: string): string =>
+  flags.replaceAll(STATEFUL_REGEX_FLAGS_PATTERN, '')
+
 export const createMentionQueryConfig = (trigger: MentionTrigger): MentionQueryConfig => {
   const regex =
     typeof trigger === 'string'
       ? makeTriggerRegex(trigger)
-      : // eslint-disable-next-line security/detect-non-literal-regexp -- reconstructing a vetted RegExp to strip 'g'
-        new RegExp(trigger.source, trigger.flags.replaceAll('g', ''))
+      : // eslint-disable-next-line security/detect-non-literal-regexp -- reconstructing a vetted RegExp to strip stateful flags
+        new RegExp(trigger.source, stripStatefulRegexFlags(trigger.flags))
 
   return {
     regex,
@@ -71,7 +76,7 @@ export const collectMentionElements = <Extra extends Record<string, unknown>>(
 
 const readConfigFromChildren = <Extra extends Record<string, unknown> = Record<string, unknown>>(
   children: ReactNode
-): MentionChildConfig<Extra>[] => {
+): PreparedMentionChildConfig<Extra>[] => {
   const mentionChildren = collectMentionElements<Extra>(children)
   const serializerIdCounts = new Map<string, number>()
 
@@ -117,7 +122,7 @@ const readConfigFromChildren = <Extra extends Record<string, unknown> = Record<s
       displayTransform,
       query: createMentionQueryConfig(trigger),
       serializer,
-    } satisfies MentionChildConfig<Extra>
+    } satisfies PreparedMentionChildConfig<Extra>
   })
 }
 


### PR DESCRIPTION
…line 372).

Made config equality include query metadata and strip sticky y regex flags in src/MentionsInputChildren.ts (line 14). Restored layout-affecting fields in the view-sync snapshot and detection logic in src/MentionsInputLayout.ts (line 40) and src/useCaretLayout.ts (line 490). Removed unsafe mapper casts in src/MentionsInputEditing.ts (line 41). Extracted combobox ARIA prop construction in src/MentionsInputInputProps.ts (line 81). Restored strict Knip coverage plus knip:deps, and preserved oxlint exit codes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced accessibility with improved ARIA attribute handling for combobox interactions.

* **Improvements**
  * Refined suggestions layout and positioning logic for better accuracy and consistency.
  * Optimized inline autocomplete performance with improved measurement handling.
  * Enhanced mention configuration handling for more reliable equality checks and query normalization.
  * Strengthened view synchronization logic to detect and respond to layout and state changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Split `PreparedMentionChildConfig` from `MentionChildConfig` and extend view sync to react to config and suggestion changes
> - Introduces `PreparedMentionChildConfig` in [src/types.ts](https://github.com/hbmartin/react-mentions-ts/pull/212/files#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410a) by moving the `query` field out of `MentionChildConfig`, making it required on the prepared variant produced by `readConfigFromChildren`.
> - Strips both `g` and `y` (stateful) regex flags from trigger identities and prepared query regexes, replacing the previous `g`-only removal.
> - Extends `areMentionConfigsEqual` in [src/MentionsInputChildren.ts](https://github.com/hbmartin/react-mentions-ts/pull/212/files#diff-b2ba7486cdbe53cb591e94cdde1bae09b90abc61095e79de1e226044a71e28c7) to include prepared query metadata (regex source/flags and `ignoreAccents`) in equality checks.
> - Expands `getViewSyncDecision` in [src/MentionsInputLayout.ts](https://github.com/hbmartin/react-mentions-ts/pull/212/files#diff-7d40540d82b40ebe0cf0576049c2f8f73039531f16f648e29f85078d7777a473) to remeasure when suggestions data, query states, anchor mode, placement, portal host, inline autocomplete mode, or single-line mode change.
> - Behavioral Change: mention configs that previously compared equal may now compare unequal if their prepared query metadata differs, triggering additional remeasures.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 04b61be.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->