### PR TITLE
tsdown.config.ts: enables minify: true and disables source maps.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /node_modules
 /reports
+/report
 /coverage
 /demo/dist
 /demo/build

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 - never run publint with pnpm, instead always use `npx publint --pack npm`
 - use `pnpm` for all commands except `pack`
-- always run `pnpm fmt && pnpm lint && pnpm test` after completing work and fix findings
+- always run `pnpm fmt && pnpm lint && pnpm test && pnpm dupes` after completing work and fix findings
 
 ## Relevant best-practice guidance for this library
 

--- a/package.json
+++ b/package.json
@@ -196,13 +196,14 @@
       "**/node_modules/**",
       "**/dist/**",
       "**/coverage/**",
-      "**/tests/**",
-      "**/.next/**",
       "**/*.json",
-      "**/*.tsx",
-      "**/*.test.ts",
+      "**/*.spec.ts",
+      "**/*.spec.tsx",
       "**/*.css",
-      "**/*.md"
+      "**/*.yml",
+      "**/*.md",
+      "**/declaration/**/*",
+      "**/demo/**/*"
     ],
     "absolute": false
   }

--- a/scripts/remove-dist-source-maps.mjs
+++ b/scripts/remove-dist-source-maps.mjs
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+
+import { readdir, readFile, rm, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+const distDir = new URL('../dist/', import.meta.url)
+const sourceMapCommentPattern = /\n\/\/# sourceMappingURL=.*\.map\s*$/u
+
+for (const fileName of await readdir(distDir)) {
+  const filePath = join(distDir.pathname, fileName)
+
+  if (fileName.endsWith('.map')) {
+    await rm(filePath)
+    continue
+  }
+
+  if (
+    !fileName.endsWith('.js') &&
+    !fileName.endsWith('.cjs') &&
+    !fileName.endsWith('.d.ts') &&
+    !fileName.endsWith('.d.cts')
+  ) {
+    continue
+  }
+
+  const contents = await readFile(filePath, 'utf8')
+  const nextContents = contents.replace(sourceMapCommentPattern, '\n')
+
+  if (nextContents !== contents) {
+    await writeFile(filePath, nextContents)
+  }
+}

--- a/src/MentionsInput.spec.tsx
+++ b/src/MentionsInput.spec.tsx
@@ -115,7 +115,13 @@ const MentionsInputInternalsHarness = React.forwardRef<MentionsInputHandle, Ment
       value,
       config,
       isInlineAutocomplete,
-      hasInlineSuggestion: () => suggestionsQuery.getInlineSuggestionDetails() !== null,
+      hasInlineSuggestion: suggestionsQuery.inlineSuggestionDetails !== null,
+      suggestionsLayoutKey:
+        suggestionsDisplay === 'inline'
+          ? null
+          : `${utils.countSuggestions(state.suggestions).toString()}:${
+              suggestionsQuery.suggestionsStatusContent.statusType ?? 'none'
+            }`,
     })
     const editing = useMentionsEditing({
       props,

--- a/src/MentionsInput.tsx
+++ b/src/MentionsInput.tsx
@@ -106,7 +106,12 @@ const MentionsInput = <Extra extends Record<string, unknown> = Record<string, un
     value,
     config,
     isInlineAutocomplete,
-    hasInlineSuggestion: () => suggestionsQuery.getInlineSuggestionDetails() !== null,
+    hasInlineSuggestion: suggestionsQuery.inlineSuggestionDetails !== null,
+    suggestionsLayoutKey: isInlineAutocomplete
+      ? null
+      : `${countSuggestions(state.suggestions).toString()}:${
+          suggestionsQuery.suggestionsStatusContent.statusType ?? 'none'
+        }`,
   })
 
   const editing = useMentionsEditing<Extra>({

--- a/src/MentionsInputEditing.spec.tsx
+++ b/src/MentionsInputEditing.spec.tsx
@@ -104,6 +104,25 @@ describe('MentionsInputEditing', () => {
     expect(result.nextSelectionEnd).toBe(7)
   })
 
+  it('restores the caret to the mention start when editing inside one without inserted text', () => {
+    const value = 'Hello @[Walter White](user:walter)'
+    const plainTextValue = 'Hello W!'
+    const result = applyInputChangeToMentionsValue(
+      value,
+      plainTextValue,
+      config,
+      7,
+      7,
+      plainTextValue.length,
+      10,
+      undefined
+    )
+
+    expect(result.shouldRestoreSelection).toBe(true)
+    expect(result.nextSelectionStart).toBe(6)
+    expect(result.nextSelectionEnd).toBe(6)
+  })
+
   it('keeps the updated caret when there is no tracked mention range to restore', () => {
     const value = 'Hello @[Walter White](user:walter)'
     const plainTextValue = 'Hello Walter White!'

--- a/src/MentionsInputInlineSuggestion.spec.tsx
+++ b/src/MentionsInputInlineSuggestion.spec.tsx
@@ -1,0 +1,82 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import {
+  MentionsInputInlineLiveRegion,
+  MentionsInputInlineSuggestion,
+} from './MentionsInputInlineSuggestion'
+import type { InlineSuggestionDetails } from './MentionsInputSelectors'
+
+const inlineSuggestion: InlineSuggestionDetails = {
+  hiddenPrefix: '',
+  visibleText: 'ice',
+  queryInfo: {
+    childIndex: 0,
+    query: 'al',
+    querySequenceStart: 0,
+    querySequenceEnd: 3,
+  },
+  suggestion: { id: 'alice', display: 'Alice' },
+  announcement: 'Alice',
+}
+
+describe('MentionsInputInlineSuggestion', () => {
+  it('does not render until both suggestion data and a measured position are available', () => {
+    const { container, rerender } = render(
+      <MentionsInputInlineSuggestion
+        inlineSuggestion={null}
+        inlineSuggestionPosition={{ left: 1, top: 2 }}
+      />
+    )
+
+    expect(container.firstChild).toBeNull()
+
+    rerender(
+      <MentionsInputInlineSuggestion
+        inlineSuggestion={inlineSuggestion}
+        inlineSuggestionPosition={null}
+      />
+    )
+
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders visible inline text without a hidden prefix when the prefix is empty', () => {
+    const { container } = render(
+      <MentionsInputInlineSuggestion
+        inlineSuggestion={inlineSuggestion}
+        inlineSuggestionPosition={{ left: 12, top: 24 }}
+        classNames={{
+          inlineSuggestion: 'custom-inline',
+          inlineSuggestionText: 'custom-text',
+          inlineSuggestionPrefix: 'custom-prefix',
+          inlineSuggestionSuffix: 'custom-suffix',
+        }}
+      />
+    )
+
+    const wrapper = container.querySelector('[data-slot="inline-suggestion"]') as HTMLDivElement
+    expect(wrapper).not.toBeNull()
+    expect(wrapper).toHaveClass('custom-inline')
+    expect(wrapper.style.left).toBe('12px')
+    expect(wrapper.style.top).toBe('24px')
+    expect(container.querySelector('.custom-prefix')).toBeNull()
+    expect(container.querySelector('.custom-suffix')).toHaveTextContent('ice')
+  })
+
+  it('renders hidden prefix text and live region announcements', () => {
+    const { container } = render(
+      <>
+        <MentionsInputInlineSuggestion
+          inlineSuggestion={{ ...inlineSuggestion, hiddenPrefix: 'Al' }}
+          inlineSuggestionPosition={{ left: 0, top: 0 }}
+        />
+        <MentionsInputInlineLiveRegion id="inline-status" announcement="Alice suggested" />
+      </>
+    )
+
+    expect(container.querySelector('.sr-only')).toHaveTextContent('Al')
+    const liveRegion = container.querySelector('[data-slot="inline-suggestion-live-region"]')
+    expect(liveRegion).toHaveAttribute('id', 'inline-status')
+    expect(liveRegion).toHaveTextContent('Alice suggested')
+  })
+})

--- a/src/MentionsInputInputProps.spec.ts
+++ b/src/MentionsInputInputProps.spec.ts
@@ -1,0 +1,94 @@
+import type { InlineSuggestionDetails } from './MentionsInputSelectors'
+import type { buildMentionsInputInputProps } from './MentionsInputInputProps'
+
+type BuildInputPropsArgs = Parameters<typeof buildMentionsInputInputProps>[0]
+
+const inlineSuggestion: InlineSuggestionDetails = {
+  hiddenPrefix: 'Al',
+  visibleText: 'ice',
+  queryInfo: {
+    childIndex: 0,
+    query: 'al',
+    querySequenceStart: 0,
+    querySequenceEnd: 3,
+  },
+  suggestion: { id: 'alice', display: 'Alice' },
+  announcement: 'Alice',
+}
+
+const createBuildArgs = (overrides: Partial<BuildInputPropsArgs> = {}): BuildInputPropsArgs => ({
+  props: {},
+  inputClassName: 'mentions-input',
+  plainTextValue: 'Hello',
+  singleLine: false,
+  isInlineAutocomplete: false,
+  inlineSuggestion: null,
+  isSuggestionsOpened: false,
+  focusIndex: 0,
+  onScroll: vi.fn(),
+  onChange: vi.fn(),
+  onSelect: vi.fn(),
+  onKeyDown: vi.fn(),
+  onBlur: vi.fn(),
+  onCompositionStart: vi.fn(),
+  onCompositionEnd: vi.fn(),
+  ...overrides,
+})
+
+describe('MentionsInputInputProps', () => {
+  it('keeps default event handlers as no-op callbacks', async () => {
+    const { defaultMentionsInputProps } = await import('./MentionsInputInputProps')
+
+    expect(defaultMentionsInputProps.onKeyDown?.(undefined as never)).toBeNull()
+    expect(defaultMentionsInputProps.onSelect?.(undefined as never)).toBeNull()
+  })
+
+  it('omits aria-describedby for inline suggestions when there is no description source', async () => {
+    const { buildMentionsInputInputProps } = await import('./MentionsInputInputProps')
+
+    const inputProps = buildMentionsInputInputProps(
+      createBuildArgs({
+        isInlineAutocomplete: true,
+        inlineSuggestion,
+        inlineAutocompleteLiveRegionId: undefined,
+      })
+    )
+
+    expect(inputProps['aria-autocomplete']).toBe('inline')
+    expect(inputProps['aria-expanded']).toBe('false')
+    expect(inputProps['aria-describedby']).toBeUndefined()
+  })
+
+  it('preserves caller descriptions when inline suggestions add live region output', async () => {
+    const { buildMentionsInputInputProps } = await import('./MentionsInputInputProps')
+
+    const inputProps = buildMentionsInputInputProps(
+      createBuildArgs({
+        props: { 'aria-describedby': 'existing-description' },
+        isInlineAutocomplete: true,
+        inlineSuggestion,
+        inlineAutocompleteLiveRegionId: 'inline-live',
+      })
+    )
+
+    expect(inputProps['aria-describedby']).toBe('existing-description inline-live')
+  })
+
+  it('omits empty inline style objects', async () => {
+    vi.resetModules()
+    vi.doMock('./MentionsInputLayout', () => ({
+      getInputInlineStyle: () => ({}),
+    }))
+
+    try {
+      const { buildMentionsInputInputProps } = await import('./MentionsInputInputProps')
+
+      const inputProps = buildMentionsInputInputProps(createBuildArgs())
+
+      expect(inputProps.style).toBeUndefined()
+    } finally {
+      vi.doUnmock('./MentionsInputLayout')
+      vi.resetModules()
+    }
+  })
+})

--- a/src/MentionsInputLayout.spec.ts
+++ b/src/MentionsInputLayout.spec.ts
@@ -51,10 +51,10 @@ describe('MentionsInputLayout', () => {
     suggestionsPlacement: 'below',
     suggestionsPortalHost: undefined,
     isInlineAutocomplete: false,
+    hasInlineSuggestion: false,
+    suggestionsLayoutKey: '0:none',
     selectionStart: 0,
     selectionEnd: 0,
-    suggestions: {},
-    queryStates: {},
     generatedId: 'mentions-test',
     caretPosition: defaultCaretPosition,
     pendingSelectionUpdate: false,
@@ -128,22 +128,6 @@ describe('MentionsInputLayout', () => {
   })
 
   it.each([
-    {
-      field: 'suggestions',
-      overrides: { suggestions: { 0: { queryInfo: defaultQueryInfo, results: [] } } },
-    },
-    {
-      field: 'queryStates',
-      overrides: {
-        queryStates: {
-          0: {
-            queryInfo: defaultQueryInfo,
-            results: [],
-            status: 'loading',
-          },
-        },
-      },
-    },
     { field: 'anchorMode', overrides: { anchorMode: 'left' } },
     { field: 'suggestionsPlacement', overrides: { suggestionsPlacement: 'above' } },
     { field: 'suggestionsPortalHost', overrides: { suggestionsPortalHost: document.body } },
@@ -158,24 +142,57 @@ describe('MentionsInputLayout', () => {
     })
   })
 
-  it('keeps view sync stable when numeric suggestion keys match with different object insertion order', () => {
-    const secondResult = { id: '2', display: 'Second' }
-    const tenthResult = { id: '10', display: 'Tenth' }
-    const secondQueryInfo = { ...defaultQueryInfo, childIndex: 2, query: 'second' }
-    const tenthQueryInfo = { ...defaultQueryInfo, childIndex: 10, query: 'tenth' }
+  it('remeasures overlay layout when the rendered suggestions content shape changes', () => {
+    expect(
+      getViewSyncDecision(
+        createViewSyncCommit(),
+        createViewSyncCommit({ suggestionsLayoutKey: '2:none' })
+      )
+    ).toEqual({
+      flags: {
+        measureSuggestions: true,
+      },
+      flushNow: false,
+    })
+  })
 
-    const previousCommit = createViewSyncCommit({
-      suggestions: {
-        10: { queryInfo: tenthQueryInfo, results: [tenthResult] },
-        2: { queryInfo: secondQueryInfo, results: [secondResult] },
+  it('remeasures inline layout when an inline suggestion appears', () => {
+    expect(
+      getViewSyncDecision(
+        createViewSyncCommit({ isInlineAutocomplete: true, suggestionsLayoutKey: null }),
+        createViewSyncCommit({
+          isInlineAutocomplete: true,
+          hasInlineSuggestion: true,
+          suggestionsLayoutKey: null,
+        })
+      )
+    ).toEqual({
+      flags: {
+        measureInline: true,
       },
+      flushNow: false,
     })
-    const currentCommit = createViewSyncCommit({
+  })
+
+  it('does not remeasure layout for suggestion payload and query state changes alone', () => {
+    const previousCommit = {
+      ...createViewSyncCommit(),
+      suggestions: {},
+      queryStates: {},
+    }
+    const currentCommit = {
+      ...createViewSyncCommit(),
       suggestions: {
-        2: { queryInfo: secondQueryInfo, results: [secondResult] },
-        10: { queryInfo: tenthQueryInfo, results: [tenthResult] },
+        0: { queryInfo: defaultQueryInfo, results: [{ id: '1', display: 'Alice' }] },
       },
-    })
+      queryStates: {
+        0: {
+          queryInfo: defaultQueryInfo,
+          results: [{ id: '1', display: 'Alice' }],
+          status: 'success',
+        },
+      },
+    }
 
     expect(getViewSyncDecision(previousCommit, currentCommit)).toEqual({
       flags: {},

--- a/src/MentionsInputLayout.ts
+++ b/src/MentionsInputLayout.ts
@@ -41,6 +41,8 @@ export interface ViewSyncCommit<Extra extends Record<string, unknown> = Record<s
   suggestionsPlacement: 'auto' | 'above' | 'below' | undefined
   suggestionsPortalHost: Element | Document | null | undefined
   isInlineAutocomplete: boolean
+  hasInlineSuggestion: boolean
+  suggestionsLayoutKey: string | null
   selectionStart: number | null
   selectionEnd: number | null
   generatedId: string | null
@@ -177,6 +179,11 @@ export const getViewSyncDecision = <Extra extends Record<string, unknown>>(
     previousCommit.suggestionsPlacement !== currentCommit.suggestionsPlacement ||
     previousCommit.suggestionsPortalHost !== currentCommit.suggestionsPortalHost ||
     previousCommit.isInlineAutocomplete !== currentCommit.isInlineAutocomplete
+  const suggestionsContentLayoutChanged =
+    previousCommit.suggestionsLayoutKey !== currentCommit.suggestionsLayoutKey
+  const inlineSuggestionVisibilityChanged =
+    currentCommit.isInlineAutocomplete &&
+    previousCommit.hasInlineSuggestion !== currentCommit.hasInlineSuggestion
   const flags: Partial<PendingViewSync> = {}
 
   if (currentCommit.pendingSelectionUpdate) {
@@ -202,6 +209,14 @@ export const getViewSyncDecision = <Extra extends Record<string, unknown>>(
 
   if (suggestionLayoutInputsChanged) {
     flags.measureSuggestions = true
+    flags.measureInline = true
+  }
+
+  if (suggestionsContentLayoutChanged) {
+    flags.measureSuggestions = true
+  }
+
+  if (inlineSuggestionVisibilityChanged) {
     flags.measureInline = true
   }
 

--- a/src/Suggestion.spec.tsx
+++ b/src/Suggestion.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render } from '@testing-library/react'
+import { fireEvent, render } from '@testing-library/react'
 import Suggestion from './Suggestion'
 
 const queryInfo = {
@@ -174,5 +174,35 @@ describe('Suggestion', () => {
     expect(highlightedElements[0]).toHaveTextContent('Ada')
     expect(highlightedElements[1]).toHaveTextContent('Love')
     expect(container.textContent).toBe('Ada Lovelace')
+  })
+
+  it('selects suggestions with Enter and Space while ignoring other keys', () => {
+    const onSelect = vi.fn()
+    const { container } = render(
+      <Suggestion
+        id="suggestion-keyboard"
+        index={0}
+        query="test"
+        queryInfo={queryInfo}
+        suggestion={{ id: '1', display: 'Keyboard Suggestion' }}
+        onSelect={onSelect}
+        onMouseEnter={vi.fn()}
+      />
+    )
+
+    const suggestionItem = container.querySelector('li[role="option"]') as HTMLLIElement
+
+    fireEvent.keyDown(suggestionItem, { key: 'Escape' })
+    expect(onSelect).not.toHaveBeenCalled()
+
+    fireEvent.keyDown(suggestionItem, { key: 'Enter' })
+    expect(onSelect).toHaveBeenCalledTimes(1)
+    expect(onSelect).toHaveBeenLastCalledWith(
+      expect.objectContaining({ id: '1' }),
+      expect.objectContaining({ query: 'test' })
+    )
+
+    fireEvent.keyDown(suggestionItem, { key: ' ' })
+    expect(onSelect).toHaveBeenCalledTimes(2)
   })
 })

--- a/src/SuggestionsOverlay.spec.tsx
+++ b/src/SuggestionsOverlay.spec.tsx
@@ -831,6 +831,134 @@ describe('SuggestionsOverlay', () => {
     expect(onMouseEnter).toHaveBeenCalledWith(2)
   })
 
+  it('resets duplicate mouse enter suppression when the list mouse leaves', () => {
+    const suggestions = [
+      { id: '1', display: 'First' },
+      { id: '2', display: 'Second' },
+    ]
+    const onMouseEnter = vi.fn()
+
+    const { container } = render(
+      <SuggestionsOverlay
+        id="test-suggestions"
+        suggestions={createSuggestionsMap(suggestions)}
+        focusIndex={0}
+        isOpened
+        onMouseEnter={onMouseEnter}
+      >
+        <Mention trigger="@" data={[]} />
+      </SuggestionsOverlay>
+    )
+
+    const list = container.querySelector('ul[role="listbox"]') as HTMLUListElement
+    const listItems = container.querySelectorAll('li[role="option"]')
+
+    fireEvent.mouseEnter(listItems[1], { clientX: 20, clientY: 20 })
+    fireEvent.mouseEnter(listItems[1], { clientX: 20, clientY: 20 })
+    expect(onMouseEnter).toHaveBeenCalledTimes(1)
+
+    fireEvent.mouseLeave(list)
+    fireEvent.mouseEnter(listItems[1], { clientX: 20, clientY: 20 })
+
+    expect(onMouseEnter).toHaveBeenCalledTimes(2)
+    expect(onMouseEnter).toHaveBeenLastCalledWith(1)
+  })
+
+  it('clears scroll-induced mouse suppression when the pointer moves over the list', () => {
+    const suggestionsMap = createSuggestionsMap(
+      Array.from({ length: 6 }, (_, index) => ({
+        id: `item-${index}`,
+        display: `Item ${index}`,
+      }))
+    )
+    const onMouseEnter = vi.fn()
+    const getBoundingClientRectMock = vi
+      .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
+      .mockImplementation(function getBoundingRect(this: HTMLElement) {
+        if (this.dataset.slot === 'suggestions-list') {
+          return {
+            top: 0,
+            bottom: 100,
+            left: 0,
+            right: 0,
+            width: 0,
+            height: 100,
+            x: 0,
+            y: 0,
+          }
+        }
+
+        if (this.dataset.focused === 'true') {
+          return {
+            top: 150,
+            bottom: 170,
+            left: 0,
+            right: 0,
+            width: 0,
+            height: 20,
+            x: 0,
+            y: 150,
+          }
+        }
+
+        return {
+          top: 0,
+          bottom: 20,
+          left: 0,
+          right: 0,
+          width: 0,
+          height: 20,
+          x: 0,
+          y: 0,
+        }
+      })
+
+    try {
+      const { container, rerender } = render(
+        <SuggestionsOverlay
+          id="test-suggestions"
+          suggestions={suggestionsMap}
+          focusIndex={0}
+          isOpened
+          onMouseEnter={onMouseEnter}
+          scrollFocusedIntoView
+        >
+          <Mention trigger="@" data={[]} />
+        </SuggestionsOverlay>
+      )
+
+      const list = container.querySelector('ul[role="listbox"]') as HTMLUListElement
+      Object.defineProperty(list, 'offsetHeight', { configurable: true, value: 100 })
+      Object.defineProperty(list, 'scrollHeight', { configurable: true, value: 400 })
+      list.scrollTop = 0
+
+      fireEvent.mouseMove(list, { clientX: 20, clientY: 20 })
+
+      rerender(
+        <SuggestionsOverlay
+          id="test-suggestions"
+          suggestions={suggestionsMap}
+          focusIndex={4}
+          isOpened
+          onMouseEnter={onMouseEnter}
+          scrollFocusedIntoView
+        >
+          <Mention trigger="@" data={[]} />
+        </SuggestionsOverlay>
+      )
+
+      fireEvent.mouseMove(list, { clientX: 20, clientY: 40 })
+      fireEvent.mouseEnter(container.querySelectorAll('li[role="option"]')[2], {
+        clientX: 20,
+        clientY: 20,
+      })
+
+      expect(onMouseEnter).toHaveBeenCalledWith(2)
+    } finally {
+      getBoundingClientRectMock.mockRestore()
+    }
+  })
+
   it('resets cached mouse position after closing the overlay.', () => {
     const suggestions = [
       { id: '1', display: 'First' },
@@ -1083,6 +1211,79 @@ describe('SuggestionsOverlay', () => {
     )
 
     expect(handleLoadMore).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not flush deferred load more after loading when the list is no longer near the bottom', () => {
+    const handleLoadMore = vi.fn()
+    const { container, rerender } = render(
+      <SuggestionsOverlay
+        id="loading-load-more-overlay"
+        suggestions={createSuggestionsMap([{ id: '1', display: 'First' }])}
+        focusIndex={0}
+        isOpened
+        isLoading
+        onLoadMore={handleLoadMore}
+      >
+        <Mention trigger="@" data={[]} />
+      </SuggestionsOverlay>
+    )
+
+    const list = container.querySelector('ul[role="listbox"]') as HTMLUListElement
+    Object.defineProperty(list, 'scrollHeight', { value: 200, configurable: true })
+    Object.defineProperty(list, 'clientHeight', { value: 100, configurable: true })
+    list.scrollTop = 60
+    fireEvent.scroll(list)
+    list.scrollTop = 20
+
+    rerender(
+      <SuggestionsOverlay
+        id="loading-load-more-overlay"
+        suggestions={createSuggestionsMap([{ id: '1', display: 'First' }])}
+        focusIndex={0}
+        isOpened
+        onLoadMore={handleLoadMore}
+      >
+        <Mention trigger="@" data={[]} />
+      </SuggestionsOverlay>
+    )
+
+    expect(handleLoadMore).not.toHaveBeenCalled()
+  })
+
+  it('does not defer load more while loading if the list is not near the bottom', () => {
+    const handleLoadMore = vi.fn()
+    const { container, rerender } = render(
+      <SuggestionsOverlay
+        id="loading-load-more-overlay"
+        suggestions={createSuggestionsMap([{ id: '1', display: 'First' }])}
+        focusIndex={0}
+        isOpened
+        isLoading
+        onLoadMore={handleLoadMore}
+      >
+        <Mention trigger="@" data={[]} />
+      </SuggestionsOverlay>
+    )
+
+    const list = container.querySelector('ul[role="listbox"]') as HTMLUListElement
+    Object.defineProperty(list, 'scrollHeight', { value: 200, configurable: true })
+    Object.defineProperty(list, 'clientHeight', { value: 100, configurable: true })
+    list.scrollTop = 20
+    fireEvent.scroll(list)
+
+    rerender(
+      <SuggestionsOverlay
+        id="loading-load-more-overlay"
+        suggestions={createSuggestionsMap([{ id: '1', display: 'First' }])}
+        focusIndex={0}
+        isOpened
+        onLoadMore={handleLoadMore}
+      >
+        <Mention trigger="@" data={[]} />
+      </SuggestionsOverlay>
+    )
+
+    expect(handleLoadMore).not.toHaveBeenCalled()
   })
 
   it('passes mouse down events through to the supplied handler', () => {

--- a/src/useCaretLayout.ts
+++ b/src/useCaretLayout.ts
@@ -46,7 +46,8 @@ interface UseCaretLayoutArgs<Extra extends Record<string, unknown>> {
   value: string
   config: ReadonlyArray<PreparedMentionChildConfig<Extra>>
   isInlineAutocomplete: boolean
-  hasInlineSuggestion: () => boolean
+  hasInlineSuggestion: boolean
+  suggestionsLayoutKey: string | null
 }
 
 const getExplicitId = (id: unknown): string | null =>
@@ -238,7 +239,7 @@ export const useCaretLayout = <Extra extends Record<string, unknown>>(
       return true
     }
 
-    const nextPosition = argsRef.current.hasInlineSuggestion()
+    const nextPosition = argsRef.current.hasInlineSuggestion
       ? calculateInlineSuggestionPosition({ highlighter: highlighterElementRef.current })
       : null
 
@@ -490,7 +491,15 @@ export const useCaretLayout = <Extra extends Record<string, unknown>>(
   }, [args.state.highlighterRecomputeVersion, scheduleHighlighterRecompute])
 
   useLayoutEffect(() => {
-    const { props, state, value, config, isInlineAutocomplete } = argsRef.current
+    const {
+      props,
+      state,
+      value,
+      config,
+      isInlineAutocomplete,
+      hasInlineSuggestion,
+      suggestionsLayoutKey,
+    } = argsRef.current
     const previousCommit = previousCommitRef.current
     const currentCommit: ViewSyncCommit<Extra> = {
       value,
@@ -501,6 +510,8 @@ export const useCaretLayout = <Extra extends Record<string, unknown>>(
       suggestionsPlacement: props.suggestionsPlacement,
       suggestionsPortalHost: props.suggestionsPortalHost,
       isInlineAutocomplete,
+      hasInlineSuggestion,
+      suggestionsLayoutKey,
       selectionStart: state.selectionStart,
       selectionEnd: state.selectionEnd,
       generatedId: state.generatedId,
@@ -519,6 +530,7 @@ export const useCaretLayout = <Extra extends Record<string, unknown>>(
     previousCommitRef.current = currentCommit
   }, [
     args.config,
+    args.hasInlineSuggestion,
     args.isInlineAutocomplete,
     args.props.anchorMode,
     args.props.autoResize,
@@ -530,6 +542,7 @@ export const useCaretLayout = <Extra extends Record<string, unknown>>(
     args.state.pendingSelectionUpdate,
     args.state.selectionEnd,
     args.state.selectionStart,
+    args.suggestionsLayoutKey,
     args.value,
     ensureGeneratedId,
     flushPendingViewSync,


### PR DESCRIPTION
package.json: build now runs a source-map cleanup step.
remove-dist-source-maps.mjs: removes dist/*.map and strips stale sourceMappingURL comments.
MentionsInputEditing.ts and utils/index.ts: direct-imports the internal ensureNumber helper instead of re-exporting it through the utils barrel.
src/MentionsInputLayout.ts: removed suggestion/query-state payload diffing from view-sync decisions and added compact layout signals.
src/useCaretLayout.ts: tracks only inline-suggestion presence and overlay layout key, not raw suggestion state.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enable minification and remove source maps from dist build output
> - Adds [scripts/remove-dist-source-maps.mjs](https://github.com/hbmartin/react-mentions-ts/pull/214/files#diff-c001a8a2b482316736d77d4cd7ae607a707b48a4b1ed8b3806b1d4567d59e922), a Node.js script that deletes `*.map` files from `dist` and strips `//# sourceMappingURL` comments from `.js`, `.cjs`, `.d.ts`, and `.d.cts` files.
> - Updates `useCaretLayout` to accept `hasInlineSuggestion` as a boolean (instead of a callback) and a new `suggestionsLayoutKey` string; both feed into view sync decisions in [src/MentionsInputLayout.ts](https://github.com/hbmartin/react-mentions-ts/pull/214/files#diff-7d40540d82b40ebe0cf0576049c2f8f73039531f16f648e29f85078d7777a473) to trigger remeasurement when suggestion content or inline suggestion visibility changes.
> - Updates [package.json](https://github.com/hbmartin/react-mentions-ts/pull/214/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) glob patterns to include `*.yml`, `*.md`, `declaration/**/*`, and `demo/**/*`, and removes `tests/**` and `.next/**` patterns.
> - Behavioral Change: `getViewSyncDecision` no longer remeasures on raw `suggestions`/`queryStates` changes; remeasurement is now gated on `suggestionsLayoutKey` changes and inline suggestion visibility changes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7fe2c04.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced inline suggestion handling with improved layout calculations.

* **Build & Tooling**
  * Added source map removal for production builds.
  * Updated code duplication detection configuration and ignore patterns.

* **Tests**
  * Expanded test coverage for mentions input, inline suggestions, and suggestions overlay behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->