### PR TITLE
Scroll handling refactor

### DIFF
--- a/src/MeasurementBridge.spec.tsx
+++ b/src/MeasurementBridge.spec.tsx
@@ -4,7 +4,7 @@ import type { Mock } from 'vitest'
 import MeasurementBridge from './MeasurementBridge'
 
 describe('MeasurementBridge', () => {
-  it('requests view sync from mount, observers, scroll, and viewport listeners, then cleans up', async () => {
+  it('requests view sync from mount, observers, and viewport listeners, then cleans up', async () => {
     const requestViewSync = vi.fn()
     const container = document.createElement('div')
     const highlighter = document.createElement('div')
@@ -83,10 +83,6 @@ describe('MeasurementBridge', () => {
         for (const observer of observers) {
           observer.callback()
         }
-      })
-
-      act(() => {
-        input.dispatchEvent(new Event('scroll'))
       })
 
       act(() => {

--- a/src/MeasurementBridge.tsx
+++ b/src/MeasurementBridge.tsx
@@ -109,22 +109,6 @@ const MeasurementBridge = ({
     }
   }, [container, highlighter, input, requestAllMeasurements, suggestions])
 
-  useLayoutEffect(() => {
-    if (!input) {
-      return undefined
-    }
-
-    const handleScroll = () => {
-      requestAllMeasurements()
-    }
-
-    input.addEventListener('scroll', handleScroll, { passive: true })
-
-    return () => {
-      input.removeEventListener('scroll', handleScroll)
-    }
-  }, [input, requestAllMeasurements])
-
   return null
 }
 

--- a/src/useCaretLayout.ts
+++ b/src/useCaretLayout.ts
@@ -427,7 +427,11 @@ export const useCaretLayout = <Extra extends Record<string, unknown>>(
     )
   })
 
-  const handleDocumentScroll = useEventCallback((): void => {
+  const handleDocumentScroll = useEventCallback((event?: Event): void => {
+    if (event?.target === inputElementRef.current) {
+      return
+    }
+
     if (!shouldMeasureSuggestions() && !shouldMeasureInline()) {
       return
     }
@@ -448,12 +452,6 @@ export const useCaretLayout = <Extra extends Record<string, unknown>>(
 
   const setSuggestionsElement = useEventCallback((element: HTMLDivElement | null): void => {
     suggestionsElementRef.current = element
-
-    if (element !== null) {
-      requestViewSync({
-        measureSuggestions: true,
-      })
-    }
   })
 
   const setInputRef = useEventCallback((element: InputElement | null): void => {

--- a/src/useMentionsComposition.spec.ts
+++ b/src/useMentionsComposition.spec.ts
@@ -1,7 +1,47 @@
 import {
   getNextCompositionSelection,
   resolveMentionsCompositionChange,
+  useMentionsComposition,
 } from './useMentionsComposition'
+import { act, render } from '@testing-library/react'
+import React from 'react'
+import type { InputElement, MentionsInputState } from './types'
+
+const createCompositionState = (): MentionsInputState => ({
+  focusIndex: 0,
+  selectionStart: null,
+  selectionEnd: null,
+  suggestions: {},
+  queryStates: {},
+  caretPosition: null,
+  suggestionsPosition: {},
+  inlineSuggestionPosition: null,
+  pendingSelectionUpdate: false,
+  highlighterRecomputeVersion: 0,
+  generatedId: null,
+})
+
+type CompositionHarnessHandle = ReturnType<typeof useMentionsComposition> & {
+  inputElementRef: React.RefObject<InputElement | null>
+  stateRef: React.RefObject<MentionsInputState>
+}
+
+const CompositionHarness = React.forwardRef<CompositionHarnessHandle>((_props, ref) => {
+  const stateRef = React.useRef<MentionsInputState>(createCompositionState())
+  const inputElementRef = React.useRef<InputElement | null>(null)
+  const composition = useMentionsComposition({
+    stateRef,
+    inputElementRef,
+  })
+
+  React.useImperativeHandle(ref, () => ({
+    ...composition,
+    inputElementRef,
+    stateRef,
+  }))
+
+  return null
+})
 
 describe('useMentionsComposition helpers', () => {
   it('resolves composition input from the tracked composition selection', () => {
@@ -51,5 +91,48 @@ describe('useMentionsComposition helpers', () => {
       trackedSelectionEnd: null,
       insertedText: 'c',
     })
+  })
+
+  it('falls back through null selections and empty inserted text', () => {
+    const change = resolveMentionsCompositionChange({
+      nativeEvent: {},
+      wasComposing: true,
+      compositionSelection: null,
+      stateSelectionStart: null,
+      stateSelectionEnd: null,
+      targetSelectionStart: null,
+      targetSelectionEnd: null,
+      newPlainTextValue: 'abc',
+    })
+
+    expect(change).toEqual({
+      isCompositionInput: true,
+      selectionStartBefore: 0,
+      selectionEndBefore: 0,
+      selectionEndAfter: 0,
+      trackedSelectionEnd: null,
+      insertedText: '',
+    })
+    expect(getNextCompositionSelection(change, 8, 9)).toEqual({ start: 0, end: 9 })
+  })
+
+  it('starts composition from state fallbacks when no input event is available', () => {
+    const ref = React.createRef<CompositionHarnessHandle>()
+    const { unmount } = render(React.createElement(CompositionHarness, { ref }))
+
+    act(() => {
+      ref.current?.handleCompositionStart()
+    })
+
+    expect(ref.current?.isComposingRef.current).toBe(true)
+    expect(ref.current?.compositionSelectionRef.current).toEqual({ start: 0, end: 0 })
+
+    act(() => {
+      ref.current?.handleCompositionEnd()
+    })
+
+    expect(ref.current?.isComposingRef.current).toBe(false)
+    expect(ref.current?.compositionSelectionRef.current).toBeNull()
+    unmount()
   })
 })

--- a/src/useMentionsDocumentEvents.spec.tsx
+++ b/src/useMentionsDocumentEvents.spec.tsx
@@ -1,0 +1,99 @@
+import React from 'react'
+import { act } from '@testing-library/react'
+import { createRoot } from 'react-dom/client'
+import { useMentionsDocumentEvents } from './useMentionsDocumentEvents'
+import type { InputElement } from './types'
+
+interface DocumentEventsHarnessProps {
+  inputElementRef: React.RefObject<InputElement | null>
+  onCopy: (event: ClipboardEvent) => void
+  onCut: (event: ClipboardEvent) => void
+  onPaste: (event: ClipboardEvent) => void
+  onSelectionChange: () => void
+}
+
+const DocumentEventsHarness = (props: DocumentEventsHarnessProps) => {
+  useMentionsDocumentEvents(props)
+  return null
+}
+
+describe('useMentionsDocumentEvents', () => {
+  it('subscribes on the input owner document and cleans up listeners', () => {
+    const input = document.createElement('textarea')
+    const inputElementRef = { current: input }
+    const onCopy = vi.fn()
+    const onCut = vi.fn()
+    const onPaste = vi.fn()
+    const onSelectionChange = vi.fn()
+    const addEventListenerSpy = vi.spyOn(input.ownerDocument, 'addEventListener')
+    const removeEventListenerSpy = vi.spyOn(input.ownerDocument, 'removeEventListener')
+    const container = document.createElement('div')
+    const root = createRoot(container)
+
+    act(() => {
+      root.render(
+        <DocumentEventsHarness
+          inputElementRef={inputElementRef}
+          onCopy={onCopy}
+          onCut={onCut}
+          onPaste={onPaste}
+          onSelectionChange={onSelectionChange}
+        />
+      )
+    })
+
+    expect(addEventListenerSpy).toHaveBeenCalledWith('copy', onCopy)
+    expect(addEventListenerSpy).toHaveBeenCalledWith('cut', onCut)
+    expect(addEventListenerSpy).toHaveBeenCalledWith('paste', onPaste)
+    expect(addEventListenerSpy).toHaveBeenCalledWith('selectionchange', onSelectionChange)
+
+    act(() => {
+      root.unmount()
+    })
+
+    expect(removeEventListenerSpy).toHaveBeenCalledWith('copy', onCopy)
+    expect(removeEventListenerSpy).toHaveBeenCalledWith('cut', onCut)
+    expect(removeEventListenerSpy).toHaveBeenCalledWith('paste', onPaste)
+    expect(removeEventListenerSpy).toHaveBeenCalledWith('selectionchange', onSelectionChange)
+
+    addEventListenerSpy.mockRestore()
+    removeEventListenerSpy.mockRestore()
+  })
+
+  it('skips subscription when neither input nor global document is available', () => {
+    const originalDocument = globalThis.document
+    const inputElementRef = { current: null }
+    const container = originalDocument.createElement('div')
+    const root = createRoot(container)
+    const onCopy = vi.fn()
+    const onCut = vi.fn()
+    const onPaste = vi.fn()
+    const onSelectionChange = vi.fn()
+
+    vi.stubGlobal('document', undefined)
+
+    try {
+      act(() => {
+        root.render(
+          <DocumentEventsHarness
+            inputElementRef={inputElementRef}
+            onCopy={onCopy}
+            onCut={onCut}
+            onPaste={onPaste}
+            onSelectionChange={onSelectionChange}
+          />
+        )
+      })
+    } finally {
+      act(() => {
+        root.unmount()
+      })
+      vi.stubGlobal('document', originalDocument)
+    }
+
+    expect(onCopy).not.toHaveBeenCalled()
+    expect(onCut).not.toHaveBeenCalled()
+    expect(onPaste).not.toHaveBeenCalled()
+    expect(onSelectionChange).not.toHaveBeenCalled()
+  })
+})

--- a/src/useMentionsEditing.ts
+++ b/src/useMentionsEditing.ts
@@ -295,14 +295,11 @@ export const useMentionsEditing = <Extra extends Record<string, unknown>>(
   })
 
   const handleCopy = useEventCallback((event: ClipboardEvent): void => {
-    if (event.target !== argsRef.current.inputElementRef.current) {
-      return
-    }
-    if (!supportsClipboardActions(event)) {
+    const mutation = prepareClipboardMutation(event)
+    if (!mutation) {
       return
     }
 
-    event.preventDefault()
     saveSelectionToClipboard(event)
   })
 
@@ -449,6 +446,10 @@ export const useMentionsEditing = <Extra extends Record<string, unknown>>(
       const selectionChanged =
         selectionStart !== stateRef.current.selectionStart ||
         selectionEnd !== stateRef.current.selectionEnd
+
+      if (reason === 'selectionchange' && !selectionChanged) {
+        return
+      }
 
       if (selectionChanged) {
         setState({

--- a/tests/MentionsInput.performance.spec.tsx
+++ b/tests/MentionsInput.performance.spec.tsx
@@ -195,7 +195,7 @@ describe('MentionsInput performance', () => {
     }
     emitPerformanceMetric('overlay-layout', metrics)
 
-    expect(metrics.calculateSuggestionsPositionCalls).toBeLessThanOrEqual(4)
+    expect(metrics.calculateSuggestionsPositionCalls).toBeLessThanOrEqual(2)
     expect(metrics.calculateInlineSuggestionPositionCalls).toBe(0)
   })
 
@@ -695,7 +695,7 @@ describe('MentionsInput performance', () => {
       }
       emitPerformanceMetric('suggestions-measurement-events', metrics)
 
-      expect(metrics.updateSuggestionsPositionCalls).toBeLessThanOrEqual(3)
+      expect(metrics.updateSuggestionsPositionCalls).toBeLessThanOrEqual(2)
     } finally {
       overlayPositionSpy.mockRestore()
       requestAnimationFrameSpy.mockRestore()

--- a/tests/MentionsInput.spec.tsx
+++ b/tests/MentionsInput.spec.tsx
@@ -3,6 +3,7 @@ import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
 import { renderToString } from 'react-dom/server'
 import type { Mock, MockInstance } from 'vitest'
 import * as utils from '../src/utils'
+import * as mentionsInputEditing from '../src/MentionsInputEditing'
 import * as mentionsInputLayout from '../src/MentionsInputLayout'
 import * as readConfigFromChildrenModule from '../src/utils/readConfigFromChildren'
 import { makeTriggerRegex } from '../src/utils/makeTriggerRegex'
@@ -265,13 +266,17 @@ const MentionsInputInternalsHarness = React.forwardRef<MentionsInputHandle, Ment
           scheduleHighlighterRecompute: caretLayout.scheduleHighlighterRecompute,
           ensureGeneratedIdIfNeeded: caretLayout.ensureGeneratedIdIfNeeded,
           replaceSuggestions: suggestionsQuery.replaceSuggestions,
+          getActiveSuggestionQueries: suggestionsQuery.getActiveSuggestionQueries,
           scheduleSuggestionQuery: suggestionsQuery.scheduleSuggestionQuery,
           updateSuggestions: suggestionsQuery.updateSuggestions,
+          updatePageSuggestions: suggestionsQuery.updatePageSuggestions,
           updateMentionsQueries: suggestionsQuery.updateMentionsQueries,
           clearSuggestions: suggestionsQuery.clearSuggestions,
+          loadMoreSuggestions: suggestionsQuery.loadMoreSuggestions,
           shiftFocus: suggestionsQuery.shiftFocus,
           selectFocused,
           addMention: editing.addMention,
+          executeOnChange: editing.executeOnChange,
           canApplyInlineSuggestion: suggestionsQuery.canApplyInlineSuggestion,
           getPreferredQueryState: suggestionsQuery.getPreferredQueryState,
           handleKeyDown,
@@ -284,6 +289,7 @@ const MentionsInputInternalsHarness = React.forwardRef<MentionsInputHandle, Ment
           handleDocumentScroll: caretLayout.handleDocumentScroll,
           handleCompositionStart: editing.handleCompositionStart,
           handleCompositionEnd: editing.handleCompositionEnd,
+          handleSuggestionsMouseDown: editing.handleSuggestionsMouseDown,
         },
         {}
       ) as MentionsInputHandle & Record<string, unknown>
@@ -4270,6 +4276,105 @@ describe('MentionsInput', () => {
       unmount()
     })
 
+    it('falls back to state selections when inserting without a mounted input.', () => {
+      const ref = React.createRef<MentionsInputHandle>()
+      const onMentionsChange = vi.fn()
+      const { unmount } = render(
+        <MentionsInput ref={ref} value="Hello" onMentionsChange={onMentionsChange}>
+          <Mention trigger="@" data={data} />
+        </MentionsInput>
+      )
+
+      const instance = ref.current as unknown as any
+
+      act(() => {
+        instance.setState({ selectionStart: 5, selectionEnd: 5 })
+      })
+
+      act(() => {
+        instance.inputElement = null
+        instance.insertText('!')
+      })
+
+      const payload = getLastMentionsChange(onMentionsChange)
+      expect(payload.trigger.type).toBe('insert-text')
+      expect(payload.value).toBe('Hello!')
+      expect(instance.state.selectionStart).toBe(6)
+      expect(instance.state.selectionEnd).toBe(6)
+
+      unmount()
+    })
+
+    it('uses fallback clipboard selection bounds when DOM selection fields are null.', () => {
+      const ref = React.createRef<MentionsInputHandle>()
+      const { unmount } = render(
+        <MentionsInput ref={ref} value="Hello">
+          <Mention trigger="@" data={data} />
+        </MentionsInput>
+      )
+
+      const instance = ref.current as unknown as any
+      const setData = vi.fn()
+
+      instance.inputElement = {
+        value: 'Hello',
+        selectionStart: null,
+        selectionEnd: null,
+      }
+
+      act(() => {
+        instance.saveSelectionToClipboard({
+          clipboardData: { setData },
+        })
+      })
+
+      expect(setData).toHaveBeenCalledWith('text/plain', '')
+      expect(setData).toHaveBeenCalledWith('text/react-mentions', '')
+
+      unmount()
+    })
+
+    it('falls back when a removed mention has no matching child config.', () => {
+      const ref = React.createRef<MentionsInputHandle>()
+      const onMentionsChange = vi.fn()
+      const { unmount } = render(
+        <MentionsInput ref={ref} value="@[Ghost](ghost)" onMentionsChange={onMentionsChange}>
+          <Mention trigger="@" data={data} />
+        </MentionsInput>
+      )
+
+      const instance = ref.current as unknown as any
+
+      act(() => {
+        instance.executeOnChange(
+          { type: 'input' },
+          '',
+          { mentions: [], plainText: '', idValue: '' },
+          '@[Ghost](ghost)',
+          {
+            mentions: [
+              {
+                id: 'ghost',
+                display: 'Ghost',
+                childIndex: 99,
+                index: 0,
+                plainTextIndex: 0,
+              },
+            ],
+            plainText: 'Ghost',
+            idValue: 'ghost',
+          },
+          []
+        )
+      })
+
+      const payload = getLastMentionsChange(onMentionsChange)
+      expect(payload.trigger.type).toBe('mention-remove')
+      expect(payload.mentionId).toBe('ghost')
+
+      unmount()
+    })
+
     it('preserves composing diacritics when controlled reconciliation re-runs mismatch recovery', async () => {
       const ref = React.createRef<MentionsInputHandle>()
       const onMentionsChange = vi.fn()
@@ -4347,6 +4452,77 @@ describe('MentionsInput', () => {
           getPlainTextSpy.mockRestore()
         }
       } finally {
+        unmount()
+      }
+    })
+
+    it('restores composing selections and clears suggestions for range change results.', () => {
+      const ref = React.createRef<MentionsInputHandle>()
+      const onMentionsChange = vi.fn()
+      const inputChangeSpy = vi
+        .spyOn(mentionsInputEditing, 'applyInputChangeToMentionsValue')
+        .mockReturnValueOnce({
+          value: 'Hxllo',
+          snapshot: {
+            mentions: [],
+            plainText: 'Hxllo',
+            idValue: 'Hxllo',
+          },
+          nextSelectionStart: 1,
+          nextSelectionEnd: 2,
+          shouldRestoreSelection: true,
+        })
+      const { unmount } = render(
+        <MentionsInput ref={ref} value="Hello" onMentionsChange={onMentionsChange}>
+          <Mention trigger="@" data={data} />
+        </MentionsInput>
+      )
+
+      try {
+        const instance = ref.current as unknown as any
+        const textarea = screen.getByRole<HTMLTextAreaElement>('combobox')
+        const setSelectionRangeSpy = vi.spyOn(textarea, 'setSelectionRange')
+
+        textarea.value = 'Hxllo'
+        textarea.setSelectionRange(1, 2)
+
+        act(() => {
+          instance.setState({
+            selectionStart: 1,
+            selectionEnd: 1,
+            suggestions: {
+              0: {
+                queryInfo: {
+                  childIndex: 0,
+                  query: 'h',
+                  querySequenceStart: 0,
+                  querySequenceEnd: 2,
+                },
+                results: [{ id: 'hello', display: 'Hello' }],
+              },
+            },
+          })
+        })
+
+        act(() => {
+          instance.handleChange({
+            target: textarea,
+            currentTarget: textarea,
+            nativeEvent: {
+              isComposing: true,
+              data: 'x',
+            },
+          } as React.ChangeEvent<HTMLTextAreaElement>)
+        })
+
+        expect(inputChangeSpy).toHaveBeenCalled()
+        expect(setSelectionRangeSpy).toHaveBeenCalledWith(1, 2)
+        expect(instance.state.suggestions).toEqual({})
+        expect(getLastMentionsChange(onMentionsChange).value).toBe('Hxllo')
+
+        setSelectionRangeSpy.mockRestore()
+      } finally {
+        inputChangeSpy.mockRestore()
         unmount()
       }
     })
@@ -4659,6 +4835,33 @@ describe('MentionsInput', () => {
       unmount()
     })
 
+    it('preserves selection when blur follows a suggestions mouse down.', () => {
+      const ref = React.createRef<MentionsInputHandle>()
+      const onMentionBlur = vi.fn()
+      const onBlur = vi.fn()
+      const { unmount } = render(
+        <MentionsInput ref={ref} value="@a" onBlur={onBlur} onMentionBlur={onMentionBlur}>
+          <Mention trigger="@" data={data} />
+        </MentionsInput>
+      )
+
+      const instance = ref.current as unknown as any
+      const input = screen.getByRole('combobox')
+
+      act(() => {
+        instance.setState({ selectionStart: 1, selectionEnd: 1 })
+        instance.handleSuggestionsMouseDown({})
+      })
+      fireEvent.blur(input)
+
+      expect(instance.state.selectionStart).toBe(1)
+      expect(instance.state.selectionEnd).toBe(1)
+      expect(onMentionBlur).toHaveBeenCalledWith(expect.anything(), true)
+      expect(onBlur).toHaveBeenCalled()
+
+      unmount()
+    })
+
     it('measures inline suggestions from current state during a view-sync flush', () => {
       const ref = React.createRef<MentionsInputHandle>()
       const { unmount } = render(
@@ -4787,6 +4990,10 @@ describe('MentionsInput', () => {
           preventDefault,
         })
         instance.handlePaste({
+          target: textarea,
+          preventDefault,
+        })
+        instance.handleCopy({
           target: textarea,
           preventDefault,
         })
@@ -5014,6 +5221,152 @@ describe('MentionsInput', () => {
         vi.useRealTimers()
         unmount()
       }
+    })
+
+    it('ignores stale and aborted pagination updates.', async () => {
+      const ref = React.createRef<MentionsInputHandle>()
+      const { unmount } = render(
+        <MentionsInput ref={ref} value="@a">
+          <Mention trigger="@" data={data} />
+        </MentionsInput>
+      )
+
+      const instance = ref.current as unknown as any
+      const queryInfo = {
+        childIndex: 0,
+        query: 'a',
+        querySequenceStart: 0,
+        querySequenceEnd: 2,
+      }
+
+      act(() => {
+        instance.setState({
+          suggestions: {
+            0: {
+              queryInfo,
+              results: [{ id: 'alice', display: 'Alice' }],
+            },
+          },
+          queryStates: {
+            0: {
+              queryInfo,
+              results: [{ id: 'alice', display: 'Alice' }],
+              status: 'success',
+              pagination: {
+                nextCursor: 'next',
+                hasMore: true,
+                isLoading: false,
+              },
+            },
+          },
+        })
+      })
+
+      // eslint-disable-next-line require-atomic-updates -- this intentionally forces the pending page result stale.
+      instance._queryId = 2
+      await act(async () => {
+        await instance.updatePageSuggestions(
+          1,
+          0,
+          queryInfo,
+          Promise.resolve({
+            items: [{ id: 'bob', display: 'Bob' }],
+            nextCursor: null,
+            hasMore: false,
+            paginated: true,
+          }),
+          new AbortController()
+        )
+      })
+      expect(instance.state.suggestions[0].results).toHaveLength(1)
+
+      await act(async () => {
+        await instance.updatePageSuggestions(
+          2,
+          0,
+          queryInfo,
+          Promise.resolve().then(() => {
+            throw new DOMException('stale page', 'AbortError')
+          }),
+          new AbortController()
+        )
+      })
+      expect(instance.state.queryStates[0].pagination.error).toBeUndefined()
+
+      unmount()
+    })
+
+    it('skips load-more pagination for inline mode and invalid query states.', () => {
+      const inlineRef = React.createRef<MentionsInputHandle>()
+      const overlayRef = React.createRef<MentionsInputHandle>()
+      const pageProvider = vi.fn(() => new Promise<never>(() => {}))
+      const { unmount } = render(
+        <>
+          <MentionsInput ref={inlineRef} value="@a" suggestionsDisplay="inline">
+            <Mention trigger="@" data={data} />
+          </MentionsInput>
+          <MentionsInput ref={overlayRef} value="@a">
+            <Mention trigger="@" data={pageProvider} />
+          </MentionsInput>
+        </>
+      )
+
+      const queryInfo = {
+        childIndex: 0,
+        query: 'a',
+        querySequenceStart: 0,
+        querySequenceEnd: 2,
+      }
+      const inlineInstance = inlineRef.current as unknown as any
+      const overlayInstance = overlayRef.current as unknown as any
+      const validQueryState = {
+        queryInfo,
+        results: [{ id: 'alice', display: 'Alice' }],
+        status: 'success',
+        pagination: {
+          nextCursor: 'next',
+          hasMore: true,
+          isLoading: false,
+        },
+      }
+
+      act(() => {
+        inlineInstance.setState({
+          queryStates: {
+            0: validQueryState,
+          },
+        })
+        inlineInstance.loadMoreSuggestions()
+      })
+      expect(inlineInstance._queryAbortControllers.size).toBe(0)
+
+      act(() => {
+        overlayInstance.setState({
+          queryStates: {
+            0: { ...validQueryState, status: 'loading' },
+            1: { ...validQueryState, pagination: undefined },
+            5: { ...validQueryState, queryInfo: { ...queryInfo, childIndex: 5 } },
+          },
+        })
+        overlayInstance.loadMoreSuggestions()
+      })
+      expect(overlayInstance._queryAbortControllers.size).toBe(0)
+
+      act(() => {
+        overlayInstance.setState({
+          queryStates: {
+            0: validQueryState,
+          },
+        })
+      })
+
+      act(() => {
+        overlayInstance.loadMoreSuggestions()
+        overlayInstance.loadMoreSuggestions()
+      })
+      expect(pageProvider).toHaveBeenCalledTimes(1)
+
+      unmount()
     })
 
     it('clears suggestions with no active queries and covers addMention guard branches', () => {


### PR DESCRIPTION
  - src/MeasurementBridge.tsx — removes the input scroll listener that triggered requestAllMeasurements on every scroll.
  - src/useCaretLayout.ts — handleDocumentScroll now ignores events targeted at the input element, and the suggestions ref setter no longer requests a view sync on mount.
  - src/MeasurementBridge.spec.tsx — drops the scroll dispatch from the mount/observer test to match.

Editing tweaks (src/useMentionsEditing.ts)
  - handleCopy delegates the guard+preventDefault to prepareClipboardMutation (dedup with cut/paste paths) instead of open-coding them.
  - Selection-change handling now early-returns when reason === 'selectionchange' and nothing actually changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Optimized scroll event handling to reduce unnecessary measurements
  * Improved selection state synchronization and composition handling
  * Enhanced clipboard operations and robustness for edge cases

* **Performance**
  * Reduced measurement calculation calls for faster interactions

* **Tests**
  * Expanded test coverage for document events and edge case scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refactor scroll handling to remove input scroll-driven measurements
> - Removes the `useLayoutEffect` scroll listener from [MeasurementBridge.tsx](https://github.com/hbmartin/react-mentions-ts/pull/217/files#diff-f05f418c2b64673088d3968a6d394b6f13b7dc48a13f8e0a4b7088f5a3635787) so measurements are no longer triggered by input scroll events; ResizeObserver and viewport change listeners remain.
> - Updates `useCaretLayout.handleDocumentScroll` in [useCaretLayout.ts](https://github.com/hbmartin/react-mentions-ts/pull/217/files#diff-fbc5d5b9cdf51e43d4fcf59fb092303fadb9b6f458b15745ac16f5e1e66cf739) to ignore document scroll events that originate from the input element.
> - Removes the immediate `requestViewSync` call when a suggestions element is set in `useCaretLayout.setSuggestionsElement`.
> - Tightens performance test thresholds for `calculateSuggestionsPositionCalls` (≤2) and `updateSuggestionsPositionCalls` (≤2) to reflect reduced measurement frequency.
> - Adds broad test coverage across composition, clipboard, pagination, and blur/selection interactions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 90dc86e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->