### PR TITLE
Strengthening selector key uniqueness

### DIFF
--- a/scripts/remove-dist-source-maps.mjs
+++ b/scripts/remove-dist-source-maps.mjs
@@ -6,7 +6,7 @@ import { fileURLToPath } from 'node:url'
 
 const distDir = new URL('../dist/', import.meta.url)
 const distPath = fileURLToPath(distDir)
-const sourceMapCommentPattern = /\r?\n\/\/# sourceMappingURL=.*\.map\s*$/u
+const sourceMapCommentPattern = /(\r?\n)\/\/# sourceMappingURL=.*\.map\s*$/u
 const outputExtensions = ['.js', '.cjs', '.mjs', '.d.ts', '.d.cts', '.d.mts']
 
 const cleanSourceMaps = async (directoryPath) => {
@@ -34,7 +34,7 @@ const cleanSourceMaps = async (directoryPath) => {
     }
 
     const contents = await readFile(filePath, 'utf8')
-    const nextContents = contents.replace(sourceMapCommentPattern, '\n')
+    const nextContents = contents.replace(sourceMapCommentPattern, '$1')
 
     if (nextContents !== contents) {
       await writeFile(filePath, nextContents)

--- a/src/MeasurementBridge.spec.tsx
+++ b/src/MeasurementBridge.spec.tsx
@@ -95,6 +95,14 @@ describe('MeasurementBridge', () => {
       })
       expect(requestViewSync.mock.calls.length).toBeGreaterThan(4)
 
+      const callsBeforeInputScroll = requestViewSync.mock.calls.length
+
+      act(() => {
+        input.dispatchEvent(new Event('scroll'))
+      })
+
+      expect(requestViewSync).toHaveBeenCalledTimes(callsBeforeInputScroll)
+
       unmount()
 
       await waitFor(() => {

--- a/src/MentionsInputSelectors.spec.tsx
+++ b/src/MentionsInputSelectors.spec.tsx
@@ -151,6 +151,56 @@ describe('MentionsInputSelectors', () => {
     ).not.toBe(baseKey)
   })
 
+  it('keeps separator-heavy suggestion values structured in layout keys', () => {
+    const queryInfo = {
+      childIndex: 0,
+      query: 'Al,|;::',
+      querySequenceStart: 0,
+      querySequenceEnd: 8,
+    }
+    const row = {
+      id: '1:2|3;4,5::6',
+      display: 'A:B|C;D,E::F',
+    }
+    const key = getSuggestionsLayoutKey({
+      suggestions: {
+        0: {
+          queryInfo,
+          results: [row],
+        },
+      },
+      queryStates: {
+        0: {
+          queryInfo,
+          results: [row],
+          status: 'success' as const,
+        },
+      },
+      isLoading: false,
+      statusType: null,
+      hasInlineSuggestion: false,
+    })
+
+    expect(JSON.parse(key)).toEqual([
+      'idle',
+      'none',
+      'no-inline',
+      [[0, [0, 'Al,|;::', 0, 8], [['string', '1:2|3;4,5::6', 'A:B|C;D,E::F', expect.any(Number)]]]],
+      [
+        [
+          0,
+          [0, 'Al,|;::', 0, 8],
+          'success',
+          1,
+          'page-idle',
+          'no-more',
+          'no-error',
+          'no-page-error',
+        ],
+      ],
+    ])
+  })
+
   it('normalizes suggestion data and falls back to the first focused suggestion', () => {
     expect(getSuggestionData('alice')).toEqual({
       id: 'alice',

--- a/src/MentionsInputSelectors.ts
+++ b/src/MentionsInputSelectors.ts
@@ -160,21 +160,21 @@ const getObjectLayoutIdentity = (value: object): number => {
 
 const getSuggestionLayoutIdentity = <Extra extends Record<string, unknown>>(
   suggestion: SuggestionDataItem<Extra>
-): string => {
+) => {
   const { id, display } = getSuggestionData(suggestion)
   const objectIdentity =
     typeof suggestion === 'object' ? getObjectLayoutIdentity(suggestion) : 'primitive'
 
-  return `${typeof id}:${String(id)}:${display}:${String(objectIdentity)}`
+  return [typeof id, String(id), display, objectIdentity] as const
 }
 
-const formatQueryInfoLayoutKey = (queryInfo: QueryInfo): string =>
+const formatQueryInfoLayoutKey = (queryInfo: QueryInfo) =>
   [
-    queryInfo.childIndex.toString(),
+    queryInfo.childIndex,
     queryInfo.query,
-    queryInfo.querySequenceStart.toString(),
-    queryInfo.querySequenceEnd.toString(),
-  ].join(',')
+    queryInfo.querySequenceStart,
+    queryInfo.querySequenceEnd,
+  ] as const
 
 export const getSuggestionsLayoutKey = <Extra extends Record<string, unknown>>({
   suggestions,
@@ -189,32 +189,34 @@ export const getSuggestionsLayoutKey = <Extra extends Record<string, unknown>>({
     .toSorted(([left], [right]) => left - right)
     .map(
       ([childIndex, value]) =>
-        `${childIndex.toString()}|${formatQueryInfoLayoutKey(value.queryInfo)}|${value.results
-          .map(getSuggestionLayoutIdentity)
-          .join(',')}`
+        [
+          childIndex,
+          formatQueryInfoLayoutKey(value.queryInfo),
+          value.results.map(getSuggestionLayoutIdentity),
+        ] as const
     )
 
   const queryStateParts = getSuggestionQueryStateEntries(queryStates).map(
     ([childIndex, queryState]) =>
       [
-        childIndex.toString(),
+        childIndex,
         formatQueryInfoLayoutKey(queryState.queryInfo),
         queryState.status,
-        queryState.results.length.toString(),
+        queryState.results.length,
         queryState.pagination?.isLoading === true ? 'page-loading' : 'page-idle',
         queryState.pagination?.hasMore === true ? 'has-more' : 'no-more',
         queryState.error === undefined ? 'no-error' : 'error',
         queryState.pagination?.error === undefined ? 'no-page-error' : 'page-error',
-      ].join('|')
+      ] as const
   )
 
-  return [
+  return JSON.stringify([
     isLoading ? 'loading' : 'idle',
     statusType ?? 'none',
     hasInlineSuggestion ? 'inline' : 'no-inline',
-    suggestionParts.join(';'),
-    queryStateParts.join(';'),
-  ].join('::')
+    suggestionParts,
+    queryStateParts,
+  ])
 }
 
 export const getFlattenedSuggestions = <Extra extends Record<string, unknown>>(

--- a/tests/MentionsInput.performance.spec.tsx
+++ b/tests/MentionsInput.performance.spec.tsx
@@ -195,7 +195,7 @@ describe('MentionsInput performance', () => {
     }
     emitPerformanceMetric('overlay-layout', metrics)
 
-    expect(metrics.calculateSuggestionsPositionCalls).toBeLessThanOrEqual(2)
+    expect(metrics.calculateSuggestionsPositionCalls).toBeLessThanOrEqual(3)
     expect(metrics.calculateInlineSuggestionPositionCalls).toBe(0)
   })
 

--- a/tests/MentionsInput.spec.tsx
+++ b/tests/MentionsInput.spec.tsx
@@ -4875,7 +4875,7 @@ describe('MentionsInput', () => {
       const highlighter = document.createElement('div')
       const caret = document.createElement('span')
 
-      caret.setAttribute('data-mentions-caret', 'true')
+      caret.dataset.mentionsCaret = 'true'
       highlighter.style.lineHeight = '20px'
       highlighter.append(caret)
       control.append(highlighter)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Extended test coverage for suggestion layout functionality with complex separator patterns
  * Added scroll event handling verification to prevent redundant view synchronization
  * Relaxed performance measurement thresholds for overlay interactions
  * Updated caret measurement test configuration

* **Refactor**
  * Improved layout key serialization approach

* **Chores**
  * Enhanced source map removal script newline handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Strengthen `getSuggestionsLayoutKey` uniqueness by encoding the key as a JSON array
> - Replaces the delimiter-joined string in `getSuggestionsLayoutKey` with a `JSON.stringify`'d nested array, so separator characters in suggestion `id` or `display` values no longer corrupt the key structure.
> - Helper utils `getSuggestionLayoutIdentity` and `formatQueryInfoLayoutKey` now return typed tuples instead of colon/comma-delimited strings.
> - Adds a regression test asserting that separator-heavy suggestion values produce a correctly structured key.
> - Fixes the source map comment removal in [remove-dist-source-maps.mjs](https://github.com/hbmartin/react-mentions-ts/pull/218/files#diff-c001a8a2b482316736d77d4cd7ae607a707b48a4b1ed8b3806b1d4567d59e922) to preserve CRLF line endings instead of forcing LF.
> - Behavioral Change: `getSuggestionsLayoutKey` output format changes from a flat delimited string to a JSON string; any code comparing or caching these keys against stored values will see a mismatch.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a493bc5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->