### PR TITLE
Wrap suggestion layout map callback and tighten overlay perf assertions

### DIFF
--- a/src/MentionsInputSelectors.ts
+++ b/src/MentionsInputSelectors.ts
@@ -192,7 +192,7 @@ export const getSuggestionsLayoutKey = <Extra extends Record<string, unknown>>({
         [
           childIndex,
           formatQueryInfoLayoutKey(value.queryInfo),
-          value.results.map(getSuggestionLayoutIdentity),
+          value.results.map((item) => getSuggestionLayoutIdentity(item)),
         ] as const
     )
 

--- a/tests/MentionsInput.performance.spec.tsx
+++ b/tests/MentionsInput.performance.spec.tsx
@@ -187,6 +187,8 @@ describe('MentionsInput performance', () => {
       expect(options.length).toBeGreaterThan(0)
     })
 
+    const openedOverlayPositionCalls = overlayPositionSpy.mock.calls.length
+
     fireEvent.keyDown(combobox, { key: 'ArrowDown' })
 
     const metrics = {
@@ -195,7 +197,9 @@ describe('MentionsInput performance', () => {
     }
     emitPerformanceMetric('overlay-layout', metrics)
 
-    expect(metrics.calculateSuggestionsPositionCalls).toBeLessThanOrEqual(3)
+    expect(openedOverlayPositionCalls).toBeLessThanOrEqual(2)
+    expect(metrics.calculateSuggestionsPositionCalls).toBe(openedOverlayPositionCalls)
+    expect(metrics.calculateSuggestionsPositionCalls).toBeLessThanOrEqual(2)
     expect(metrics.calculateInlineSuggestionPositionCalls).toBe(0)
   })
 


### PR DESCRIPTION
…lback explicitly, satisfying the lint concern.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Wrap `getSuggestionLayoutIdentity` in arrow function in `getSuggestionsLayoutKey` selector
> - Changes `value.results.map(getSuggestionLayoutIdentity)` to `value.results.map((item) => getSuggestionLayoutIdentity(item))` in [MentionsInputSelectors.ts](https://github.com/hbmartin/react-mentions-ts/pull/219/files#diff-c90f618868bcc692e4549e3767f3a52a01f42df6a8d6d2767a705efbb5cf574b) to avoid passing extra `.map` callback arguments to the function.
> - Updates the overlay-layout performance test in [MentionsInput.performance.spec.tsx](https://github.com/hbmartin/react-mentions-ts/pull/219/files#diff-a684ec6d039d752da2b7594f88c0a3ab2520383b53f93f0ecdb53d2202bab016) to capture overlay position calls before and after the ArrowDown event, tightening the assertion from `<= 3` to `<= 2` calls.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f259575.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal callback handling in suggestion layout computations.

* **Tests**
  * Enhanced performance test assertions for overlay position calculations to enforce stricter measurement bounds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->