### PR TITLE
Duplicate Traversal And Hot-Path Cleanup

### DIFF
--- a/src/Highlighter.tsx
+++ b/src/Highlighter.tsx
@@ -100,6 +100,18 @@ interface HighlighterCaretProps {
   readonly singleLine: boolean
 }
 
+const measureCaretOffset = (caretElement: HTMLSpanElement): CaretCoordinates => {
+  const previousElement = caretElement.previousElementSibling as HTMLSpanElement | null
+
+  return {
+    left: caretElement.offsetLeft,
+    top:
+      previousElement === null
+        ? caretElement.offsetTop
+        : previousElement.offsetTop + previousElement.offsetHeight,
+  }
+}
+
 const HighlighterCaret = React.memo(function HighlighterCaret({
   className,
   measureKey,
@@ -128,14 +140,8 @@ const HighlighterCaret = React.memo(function HighlighterCaret({
     }
 
     const measure = () => {
-      const offsetLeft = caretElement.offsetLeft
-      const offsetTop =
-        caretElement.previousElementSibling === null
-          ? caretElement.offsetTop
-          : (caretElement.previousElementSibling as HTMLSpanElement).offsetTop +
-            (caretElement.previousElementSibling as HTMLSpanElement).offsetHeight
-
-      updatePosition(offsetLeft, offsetTop)
+      const { left, top } = measureCaretOffset(caretElement)
+      updatePosition(left, top)
     }
 
     const rafId =
@@ -302,7 +308,7 @@ function Highlighter<Extra extends Record<string, unknown> = Record<string, unkn
   mentionSelectionMap,
 }: HighlighterProps<Extra>) {
   const mentionChildren = useMemo(
-    () => mentionChildrenProp ?? collectMentionElements(children),
+    () => mentionChildrenProp ?? collectMentionElements<Extra>(children),
     [children, mentionChildrenProp]
   )
   const config: MentionChildConfig<Extra>[] = useMemo(

--- a/src/MentionsInputLayout.ts
+++ b/src/MentionsInputLayout.ts
@@ -452,11 +452,14 @@ export const getHighlighterViewPatch = (
   let typography: Array<{ property: string; value: string }> = []
   if (typeof globalThis.getComputedStyle === 'function') {
     const computed = globalThis.getComputedStyle(input)
+    const getStyleValue =
+      typeof computed.getPropertyValue === 'function'
+        ? computed.getPropertyValue.bind(computed)
+        : (property: string) =>
+            (computed as unknown as Record<string, string | undefined>)[property] ?? ''
+
     typography = TYPOGRAPHIC_STYLE_PROPS.flatMap((property) => {
-      const value =
-        typeof computed.getPropertyValue === 'function'
-          ? computed.getPropertyValue(property)
-          : ((computed as unknown as Record<string, string | undefined>)[property] ?? '')
+      const value = getStyleValue(property)
 
       return value ? [{ property, value }] : []
     })

--- a/src/MentionsInputSelectors.ts
+++ b/src/MentionsInputSelectors.ts
@@ -125,11 +125,19 @@ export const getMentionChild = <Extra extends Record<string, unknown>>(
 
 export const getSuggestionQueryStateEntries = <Extra extends Record<string, unknown>>(
   queryStates: SuggestionQueryStateMap<Extra>
-): ReadonlyArray<readonly [number, SuggestionQueryState<Extra>]> =>
-  Object.entries(queryStates)
-    .map(([key, value]) => [Number(key), value] as const)
-    .filter(([key]) => Number.isInteger(key))
-    .toSorted(([left], [right]) => left - right)
+): ReadonlyArray<readonly [number, SuggestionQueryState<Extra>]> => {
+  const entries: Array<readonly [number, SuggestionQueryState<Extra>]> = []
+
+  for (const key of Object.keys(queryStates)) {
+    const childIndex = Number(key)
+    if (Number.isInteger(childIndex)) {
+      entries.push([childIndex, queryStates[childIndex]] as const)
+    }
+  }
+
+  entries.sort(([left], [right]) => left - right)
+  return entries
+}
 
 export const getSuggestionData = <Extra extends Record<string, unknown>>(
   suggestion: SuggestionDataItem<Extra>
@@ -183,22 +191,43 @@ export const getSuggestionsLayoutKey = <Extra extends Record<string, unknown>>({
   statusType,
   hasInlineSuggestion,
 }: SuggestionsLayoutKeyArgs<Extra>): string => {
-  const suggestionParts = Object.entries(suggestions)
-    .map(([key, value]) => [Number(key), value] as const)
-    .filter(([key]) => Number.isInteger(key))
-    .toSorted(([left], [right]) => left - right)
-    .map(
-      ([childIndex, value]) =>
-        [
-          childIndex,
-          formatQueryInfoLayoutKey(value.queryInfo),
-          value.results.map((item) => getSuggestionLayoutIdentity(item)),
-        ] as const
-    )
+  const suggestionParts: Array<
+    readonly [
+      number,
+      ReturnType<typeof formatQueryInfoLayoutKey>,
+      Array<ReturnType<typeof getSuggestionLayoutIdentity>>,
+    ]
+  > = []
+  for (const key of Object.keys(suggestions)) {
+    const childIndex = Number(key)
+    if (Number.isInteger(childIndex)) {
+      const value = suggestions[childIndex]
+      suggestionParts.push([
+        childIndex,
+        formatQueryInfoLayoutKey(value.queryInfo),
+        value.results.map((item) => getSuggestionLayoutIdentity(item)),
+      ] as const)
+    }
+  }
+  suggestionParts.sort(([left], [right]) => left - right)
 
-  const queryStateParts = getSuggestionQueryStateEntries(queryStates).map(
-    ([childIndex, queryState]) =>
-      [
+  const queryStateParts: Array<
+    readonly [
+      number,
+      ReturnType<typeof formatQueryInfoLayoutKey>,
+      SuggestionQueryState<Extra>['status'],
+      number,
+      'page-loading' | 'page-idle',
+      'has-more' | 'no-more',
+      'no-error' | 'error',
+      'no-page-error' | 'page-error',
+    ]
+  > = []
+  for (const key of Object.keys(queryStates)) {
+    const childIndex = Number(key)
+    if (Number.isInteger(childIndex)) {
+      const queryState = queryStates[childIndex]
+      queryStateParts.push([
         childIndex,
         formatQueryInfoLayoutKey(queryState.queryInfo),
         queryState.status,
@@ -207,8 +236,10 @@ export const getSuggestionsLayoutKey = <Extra extends Record<string, unknown>>({
         queryState.pagination?.hasMore === true ? 'has-more' : 'no-more',
         queryState.error === undefined ? 'no-error' : 'error',
         queryState.pagination?.error === undefined ? 'no-page-error' : 'page-error',
-      ] as const
-  )
+      ] as const)
+    }
+  }
+  queryStateParts.sort(([left], [right]) => left - right)
 
   return JSON.stringify([
     isLoading ? 'loading' : 'idle',

--- a/src/Suggestion.tsx
+++ b/src/Suggestion.tsx
@@ -72,25 +72,21 @@ function SuggestionComponent<Extra extends Record<string, unknown> = Record<stri
   }
 
   const renderHighlightedDisplay = (display: string): React.ReactNode => {
-    return suggestion.highlights === undefined || suggestion.highlights.length === 0 ? (
+    const highlights = suggestion.highlights
+
+    return highlights === undefined || highlights.length === 0 ? (
       <span className={displayClassNameResolved}>{display}</span>
     ) : (
       <span className={displayClassNameResolved} key={`highlighted-display-${id}`}>
-        {suggestion.highlights.map((highlight, index) => (
+        {highlights.map((highlight, index) => (
           <React.Fragment key={`highlight-${highlight.start}-${highlight.end}`}>
-            {
-              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-              display.slice(index > 0 ? suggestion.highlights![index - 1].end : 0, highlight.start)
-            }
+            {display.slice(index > 0 ? highlights[index - 1].end : 0, highlight.start)}
             <b className={highlightClassNameResolved}>
               {display.slice(highlight.start, highlight.end)}
             </b>
           </React.Fragment>
         ))}
-        {
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-          display.slice(suggestion.highlights.at(-1)!.end)
-        }
+        {display.slice(highlights.at(-1)?.end ?? 0)}
       </span>
     )
   }

--- a/src/SuggestionsOverlay.tsx
+++ b/src/SuggestionsOverlay.tsx
@@ -153,6 +153,14 @@ function SuggestionsOverlay<Extra extends Record<string, unknown> = Record<strin
     }
   }, [isOpened])
 
+  const suppressStationaryMouseEnter = useEventCallback((): void => {
+    const currentMousePosition = lastMousePosition.current ?? lastMouseEnterPosition.current
+
+    if (currentMousePosition !== null) {
+      suppressedMouseEnterPosition.current = currentMousePosition
+    }
+  })
+
   useLayoutEffect(() => {
     if (!ulElement || ulElement.offsetHeight >= ulElement.scrollHeight || !scrollFocusedIntoView) {
       return
@@ -168,13 +176,6 @@ function SuggestionsOverlay<Extra extends Record<string, unknown> = Record<strin
     const scrollTop = ulElement.scrollTop
     const childTop = childRect.top - topContainer + scrollTop
     const childBottom = childRect.bottom - topContainer + scrollTop
-    const suppressStationaryMouseEnter = (): void => {
-      const currentMousePosition = lastMousePosition.current ?? lastMouseEnterPosition.current
-
-      if (currentMousePosition !== null) {
-        suppressedMouseEnterPosition.current = currentMousePosition
-      }
-    }
 
     if (childTop < scrollTop) {
       suppressStationaryMouseEnter()
@@ -183,7 +184,7 @@ function SuggestionsOverlay<Extra extends Record<string, unknown> = Record<strin
       suppressStationaryMouseEnter()
       ulElement.scrollTop = childBottom - ulElement.offsetHeight
     }
-  }, [focusIndex, scrollFocusedIntoView, ulElement])
+  }, [focusIndex, scrollFocusedIntoView, suppressStationaryMouseEnter, ulElement])
 
   const overlayClassName = cn(overlayStyles(), className)
   const listClassNameResolved = cn(listStyles, listClassName)
@@ -366,20 +367,18 @@ function SuggestionsOverlay<Extra extends Record<string, unknown> = Record<strin
     )
   }
 
-  const mergedStyle = useMemo<CSSProperties>(() => {
-    const overlayStyle: CSSProperties = {
-      position: position ?? 'absolute',
-      ...(left === undefined ? {} : { left }),
-      ...(right === undefined ? {} : { right }),
-      ...(top === undefined ? {} : { top }),
-      ...(width === undefined ? {} : { width }),
-    }
-
-    return styleProp === undefined ? overlayStyle : { ...overlayStyle, ...styleProp }
-  }, [left, position, right, styleProp, top, width])
-
   if (!isOpened) {
     return null
+  }
+
+  // eslint-disable-next-line react-perf/jsx-no-new-object-as-prop -- overlay div is not memoized; useMemo is unnecessary for this primitive style object.
+  const mergedStyle: CSSProperties = {
+    position: position ?? 'absolute',
+    ...(left === undefined ? {} : { left }),
+    ...(right === undefined ? {} : { right }),
+    ...(top === undefined ? {} : { top }),
+    ...(width === undefined ? {} : { width }),
+    ...(styleProp === undefined ? {} : styleProp),
   }
 
   return (

--- a/src/utils/mapPlainTextIndex.ts
+++ b/src/utils/mapPlainTextIndex.ts
@@ -24,18 +24,19 @@ export const mapPlainTextIndices = <
   const results: Array<number | null | undefined> = requests.map(({ indexInPlainText }) =>
     typeof indexInPlainText === 'number' ? undefined : indexInPlainText
   )
-  const pendingMappings = requests
-    .map(({ indexInPlainText, inMarkupCorrection }, resultIndex) =>
+  const pendingMappings: PendingPlainTextIndexMapping[] = requests.flatMap(
+    ({ indexInPlainText, inMarkupCorrection }, resultIndex) =>
       typeof indexInPlainText === 'number'
-        ? {
-            indexInPlainText,
-            inMarkupCorrection: inMarkupCorrection ?? 'START',
-            resultIndex,
-          }
-        : null
-    )
-    .filter((mapping): mapping is PendingPlainTextIndexMapping => mapping !== null)
-    .toSorted((left, right) => left.indexInPlainText - right.indexInPlainText)
+        ? [
+            {
+              indexInPlainText,
+              inMarkupCorrection: inMarkupCorrection ?? 'START',
+              resultIndex,
+            },
+          ]
+        : []
+  )
+  pendingMappings.sort((left, right) => left.indexInPlainText - right.indexInPlainText)
 
   if (pendingMappings.length === 0) {
     return results

--- a/src/utils/readConfigFromChildren.ts
+++ b/src/utils/readConfigFromChildren.ts
@@ -39,6 +39,18 @@ const appendSerializerMarker = (markup: string, occurrenceIndex: number): string
   return `${markup}|${occurrenceIndex.toString()}`
 }
 
+const resolveSerializerKey = <Extra extends Record<string, unknown>>(
+  child: ReactElement<MentionComponentProps<Extra>>
+): string => {
+  const { markup, trigger } = child.props
+
+  if (markup === undefined) {
+    return generateMarkupForTrigger(trigger)
+  }
+
+  return typeof markup === 'string' ? markup : markup.id
+}
+
 const isReactFragment = (child: unknown): child is ReactElement<{ children?: ReactNode }> =>
   React.isValidElement(child) && child.type === React.Fragment
 
@@ -71,19 +83,12 @@ export const collectMentionElements = <Extra extends Record<string, unknown>>(
   })
 
 const readConfigFromChildren = <Extra extends Record<string, unknown> = Record<string, unknown>>(
-  children: ReactNode
+  mentionChildren: ReadonlyArray<ReactElement<MentionComponentProps<Extra>>>
 ): PreparedMentionChildConfig<Extra>[] => {
-  const mentionChildren = collectMentionElements<Extra>(children)
   const serializerIdCounts = new Map<string, number>()
 
   for (const child of mentionChildren) {
-    const serializerId =
-      child.props.markup === undefined
-        ? generateMarkupForTrigger(child.props.trigger)
-        : typeof child.props.markup === 'string'
-          ? child.props.markup
-          : child.props.markup.id
-
+    const serializerId = resolveSerializerKey(child)
     serializerIdCounts.set(serializerId, (serializerIdCounts.get(serializerId) ?? 0) + 1)
   }
 


### PR DESCRIPTION
Narrowed readConfigFromChildren to consume pre-collected mention elements. Reworked selector/key and plain-text mapping array chains into single-pass local arrays plus .sort(). Removed the SuggestionsOverlay style useMemo; kept a narrow lint suppression because the local rule otherwise requires memoizing a non-memoized div style prop. Hoisted caret measurement and computed-style accessor work. Cached suggestion highlights and removed the non-null assertion disables.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code quality through extraction of reusable helper functions, refactored imperative patterns for better maintainability, and enhanced type annotations.
  * Optimized computation logic in suggestion state management and style rendering for improved performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Clean up duplicate traversal logic and hot-path code across mentions input
> - Extracts `measureCaretOffset` helper in [Highlighter.tsx](https://github.com/hbmartin/react-mentions-ts/pull/220/files#diff-2d8fdc86aaeb8d7adcdd60631f48110e3e6cce38d17b7e31828f5c0088eadcc2) to replace inline caret measurement logic
> - Rewrites `getSuggestionQueryStateEntries` and `getSuggestionsLayoutKey` in [MentionsInputSelectors.ts](https://github.com/hbmartin/react-mentions-ts/pull/220/files#diff-c90f618868bcc692e4549e3767f3a52a01f42df6a8d6d2767a705efbb5cf574b) using explicit `Object.keys` iteration with integer filtering and sorting
> - Refactors `readConfigFromChildren` in [readConfigFromChildren.ts](https://github.com/hbmartin/react-mentions-ts/pull/220/files#diff-f75f92f372c7d5742998a841b92a5a13383de129b6bd846b49f9f0b9f097b1bd) to accept a pre-collected array of Mention elements and adds `resolveSerializerKey` helper
> - Replaces `useMemo`-based style merging in [SuggestionsOverlay.tsx](https://github.com/hbmartin/react-mentions-ts/pull/220/files#diff-8d2b85b42eafe864e1f94902263195848ee9436d546b75c7baae1384f02e7f8a) with an inline spread object and memoizes `suppressStationaryMouseEnter` via `useEventCallback`
> - Rewrites `mapPlainTextIndices` in [mapPlainTextIndex.ts](https://github.com/hbmartin/react-mentions-ts/pull/220/files#diff-3af8ffce4fe988d5d00b526008f9ce1aa00c8ace525c33859b7e8f954f924275) using `flatMap` for pending mappings creation with sorting
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0f2ca19.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->