### PR TITLE
Added ./styles/tailwind.css to the package exports map

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
         "default": "./dist/index.cjs"
       }
     },
+    "./styles/tailwind.css": "./styles/tailwind.css",
     "./package.json": "./package.json"
   },
   "files": [


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add `./styles/tailwind.css` to package exports map
Adds `"./styles/tailwind.css": "./styles/tailwind.css"` to the exports field in [package.json](https://github.com/hbmartin/react-mentions-ts/pull/230/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519), making the Tailwind CSS file importable as a named package export.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized c770464.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tailwind stylesheet is now available for direct import through the package entrypoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->