### PR TITLE
Remove extra call coming from duplicate layout scheduling in src/useC…

### DIFF
--- a/src/useCaretLayout.ts
+++ b/src/useCaretLayout.ts
@@ -423,10 +423,6 @@ export const useCaretLayout = <Extra extends Record<string, unknown>>(
   const handleCaretPositionChange = useEventCallback(
     (position: MentionsInputState<Extra>['caretPosition']): void => {
       argsRef.current.setState({ caretPosition: position })
-      requestViewSync({
-        measureSuggestions: true,
-        measureInline: true,
-      })
     }
   )
 

--- a/tests/MentionsInput.performance.spec.tsx
+++ b/tests/MentionsInput.performance.spec.tsx
@@ -165,7 +165,7 @@ describe('MentionsInput performance', () => {
     emitPerformanceMetric('inline-layout', metrics)
 
     expect(metrics.calculateSuggestionsPositionCalls).toBe(0)
-    expect(metrics.calculateInlineSuggestionPositionCalls).toBeLessThanOrEqual(3)
+    expect(metrics.calculateInlineSuggestionPositionCalls).toBe(1)
   })
 
   it('reports layout measurement counts for overlay interactions', async () => {


### PR DESCRIPTION
…aretLayout.ts

handleCaretPositionChange updated caretPosition and also requested inline/suggestions measurement, while the commit-time layout effect already requests the same measurement when caretPosition changes. Depending on rAF ordering, those could coalesce to 1 call or split into 2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Caret position updates now generate fewer layout measurement requests
  * Inline autocomplete rendering performance improved

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove duplicate `requestViewSync` call from `handleCaretPositionChange` in `useCaretLayout`
> - `handleCaretPositionChange` in [useCaretLayout.ts](https://github.com/hbmartin/react-mentions-ts/pull/234/files#diff-fbc5d5b9cdf51e43d4fcf59fb092303fadb9b6f458b15745ac16f5e1e66cf739) previously called `requestViewSync` (with `measureSuggestions` and `measureInline` set to `true`) after updating caret position state, duplicating a sync that was already scheduled elsewhere.
> - The call is removed so only state is updated, eliminating the redundant layout measurement.
> - The performance test in [MentionsInput.performance.spec.tsx](https://github.com/hbmartin/react-mentions-ts/pull/234/files#diff-a684ec6d039d752da2b7594f88c0a3ab2520383b53f93f0ecdb53d2202bab016) tightens the inline layout assertion from `<= 3` to `=== 1` to reflect the corrected call count.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b823e2e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->